### PR TITLE
ScalaDoc pass on core public API

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -1,25 +1,53 @@
 package termflow.tui
 
-/** X coordinate wrapper (1-based column). */
+/**
+ * 1-based column coordinate.
+ *
+ * Opaque over `Int` to prevent accidental mixing with row coordinates. The
+ * `TuiPrelude` package provides `2.x` syntax sugar for constructing these
+ * at call sites.
+ */
 opaque type XCoord = Int
 object XCoord:
+
+  /** Construct an `XCoord` from a raw 1-based column. */
   def apply(value: Int): XCoord = value
 
   extension (x: XCoord)
-    def value: Int         = x
+
+    /** Unwrap to the raw 1-based column. */
+    def value: Int = x
+
+    /** Shift right by `dx` columns. */
     def +(dx: Int): XCoord = x + dx
+
+    /** Shift left by `dx` columns. */
     def -(dx: Int): XCoord = x - dx
 
-/** Y coordinate wrapper (1-based row). */
+/**
+ * 1-based row coordinate.
+ *
+ * Opaque over `Int`; see [[XCoord]] for rationale. Construct at call sites
+ * with `3.y` via the `TuiPrelude` extension.
+ */
 opaque type YCoord = Int
 object YCoord:
+
+  /** Construct a `YCoord` from a raw 1-based row. */
   def apply(value: Int): YCoord = value
 
   extension (y: YCoord)
-    def value: Int         = y
+
+    /** Unwrap to the raw 1-based row. */
+    def value: Int = y
+
+    /** Shift down by `dy` rows. */
     def +(dy: Int): YCoord = y + dy
+
+    /** Shift up by `dy` rows. */
     def -(dy: Int): YCoord = y - dy
 
+/** An `(x, y)` cell position on the terminal, 1-based. */
 final case class Coord(x: XCoord, y: YCoord)
 
 object ANSI:

--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -36,10 +36,22 @@ object Sub:
       case _ =>
         sub
 
+  /** A no-op subscription. Useful as a placeholder in model fields. */
   case object NoSub extends Sub[Nothing]:
     override def isActive: Boolean = false
     override def cancel(): Unit    = ()
 
+  /**
+   * Create a timer subscription that fires at a fixed interval.
+   *
+   * Each tick publishes `Cmd.GCmd(msg())` through `sink`. The thunk runs on
+   * a single background scheduler thread, so `msg()` must not block.
+   *
+   * @param millis Interval between ticks, in milliseconds.
+   * @param msg Thunk producing the next message on each tick.
+   * @param sink Where to publish ticks. When called with a [[RuntimeCtx]]
+   *             the subscription auto-registers for cleanup on exit.
+   */
   def Every[Msg](millis: Long, msg: () => Msg, sink: EventSink[Msg]): Sub[Msg] =
     val sub = new Sub[Msg]:
       @volatile private var active = true
@@ -65,7 +77,16 @@ object Sub:
         }
     autoRegisterIfRuntimeCtx(sub, sink)
 
-  /** Create an InputKey subscription from a TerminalKeySource. */
+  /**
+   * Create a keyboard-input subscription from an explicit
+   * [[TerminalKeySource]].
+   *
+   * Each decoded [[KeyDecoder.InputKey]] is wrapped with `msg` and published
+   * to `sink`. Read failures are surfaced via `onError`.
+   *
+   * Most apps should prefer [[InputKey]], which uses the runtime context's
+   * terminal reader.
+   */
   def InputKeyFromSource[Msg](
     source: TerminalKeySource,
     msg: InputKey => Msg,
@@ -110,7 +131,17 @@ object Sub:
         }
     autoRegisterIfRuntimeCtx(sub, sink)
 
-  /** Poll terminal dimensions and emit a message when they change. */
+  /**
+   * Poll terminal dimensions at a fixed interval and publish a message when
+   * they change.
+   *
+   * Useful for apps that need to re-flow their view when the window is
+   * resized. The subscription publishes through `ctx.publish` and
+   * auto-registers for cleanup on exit.
+   *
+   * @param millis Polling interval, in milliseconds.
+   * @param mkMsg Function producing the resize message from `(width, height)`.
+   */
   def TerminalResize[Msg](
     millis: Long,
     mkMsg: (Int, Int) => Msg,
@@ -150,7 +181,12 @@ object Sub:
         }
     ctx.registerSub(sub)
 
-  /** Create an InputKey subscription from an explicit reader. */
+  /**
+   * Create a keyboard-input subscription from an explicit [[java.io.Reader]].
+   *
+   * Prefer [[InputKey]] for apps using the runtime's terminal backend. This
+   * form is mainly useful for tests and bespoke embeddings.
+   */
   def InputKeyWithReader[Msg](
     msg: InputKey => Msg,
     onError: Throwable => Msg,
@@ -159,25 +195,42 @@ object Sub:
   ): Sub[Msg] =
     InputKeyFromSource(ConsoleKeyPressSource(reader), msg, onError, sink)
 
-  /** Create an InputKey subscription using the shared terminal backend from the runtime context. */
+  /**
+   * Create a keyboard-input subscription using the terminal reader from the
+   * runtime context. The idiomatic form for `TuiApp.init`:
+   *
+   * {{{
+   * override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+   *   Model(
+   *     input = Sub.InputKey(Msg.KeyPress.apply, Msg.KeyError.apply, ctx),
+   *     ...
+   *   ).tui
+   * }}}
+   */
   def InputKey[Msg](msg: InputKey => Msg, onError: Throwable => Msg, ctx: RuntimeCtx[Msg]): Sub[Msg] =
     InputKeyFromSource(ConsoleKeyPressSource(ctx.terminal.reader), msg, onError, ctx)
 
 /**
- * Sink that receives commands from subscriptions and other sources.
- * Commands are queued and processed by the runtime loop.
+ * Sink that receives commands from subscriptions and other asynchronous
+ * sources. The runtime implements this via [[CmdBus]].
+ *
+ * @note SPI. Custom implementations are only needed when replacing the
+ *       default command bus.
  */
 trait EventSink[Msg]:
 
-  /** Publish a command to be processed by the runtime. */
+  /** Publish a command to be processed by the runtime loop. Thread-safe. */
   def publish(cmd: Cmd[Msg]): Unit
 
 /**
- * Source that produces events and sends them to a sink.
+ * Producer of events that can be started against a sink.
+ *
+ * @note SPI. Most applications construct subscriptions directly via the
+ *       factories on the [[Sub]] companion rather than implementing this.
  */
 trait EventSource[Msg]:
 
-  /** Start the source and return a subscription handle. */
+  /** Start the source, publishing to `sink`, and return a cancellation handle. */
   def start(sink: EventSink[Msg]): Sub[Msg]
 
 object RandomUtil:

--- a/modules/termflow/src/main/scala/termflow/tui/Tui.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Tui.scala
@@ -4,15 +4,56 @@ import termflow.tui.TuiPrelude.*
 
 import scala.concurrent.Future
 
-/** Error ADT used by TermFlow. */
+/**
+ * Recoverable error surface for TermFlow applications and the runtime.
+ *
+ * Errors are raised through [[Cmd.TermFlowErrorCmd]] and rendered by the
+ * runtime as a transient overlay above the next frame. They are informational
+ * rather than fatal — the runtime keeps looping unless an [[Cmd.Exit]] is
+ * also produced.
+ */
 enum TermFlowError:
+
+  /** Configuration load / parse failure. */
   case ConfigError(msg: String)
+
+  /** Raised when a command refers to a model that doesn't exist. */
   case ModelNotFound
+
+  /**
+   * Catch-all for unanticipated failures.
+   *
+   * @param msg A short human-readable description (shown in the UI).
+   * @param cause The originating throwable, if any. Included for logs.
+   */
   case Unexpected(msg: String, cause: Option[Throwable] = None)
+
+  /** A user-supplied value failed domain validation. */
   case Validation(msg: String)
+
+  /**
+   * Raised by `TuiApp.toMsg` when the prompt line cannot be parsed into a
+   * meaningful message.
+   *
+   * @param input The original prompt line as typed by the user.
+   */
   case CommandError(input: String)
+
+  /** The runtime received a request for an app whose name isn't registered. */
   case UnknownApp(name: String)
 
+/**
+ * The fundamental state-transition unit of a TermFlow application.
+ *
+ * A `Tui` bundles the new model with an optional follow-up [[Cmd]] to be
+ * executed by the runtime. Both `init` and `update` return a `Tui`.
+ *
+ * @param model The application model after the transition.
+ * @param cmd An effect to run next — often [[Cmd.NoCmd]] for pure updates.
+ *
+ * @tparam Model The application's model type.
+ * @tparam Msg The application's message type.
+ */
 final case class Tui[Model, Msg](
   model: Model,
   cmd: Cmd[Msg] = Cmd.NoCmd
@@ -20,47 +61,160 @@ final case class Tui[Model, Msg](
 
 object Tui:
 
-  /** Syntax helpers for lifting a model into a `Tui`. */
+  /**
+   * Ergonomic lifting syntax for producing `Tui` values from a bare model.
+   *
+   * {{{
+   * // Pure update: no follow-up command.
+   * model.copy(counter = counter + 1).tui
+   *
+   * // Update plus a follow-up message dispatch.
+   * model.copy(flash = "done").gCmd(Msg.Dismiss)
+   * }}}
+   */
   extension [Model](m: Model)
-    def tui[Msg]: Tui[Model, Msg]            = Tui(m)
+
+    /** Lift `m` into a `Tui` with no follow-up command. */
+    def tui[Msg]: Tui[Model, Msg] = Tui(m)
+
+    /**
+     * Lift `m` into a `Tui` and immediately dispatch `msg` as the next
+     * message. Equivalent to `Tui(m, Cmd.GCmd(msg))`.
+     */
     def gCmd[Msg](msg: Msg): Tui[Model, Msg] = Tui(m, Cmd.GCmd(msg))
 
+/**
+ * Effects that an application can return from `init` / `update` to instruct
+ * the runtime to do something beyond updating the model.
+ *
+ * Commands are processed in order by the runtime loop. `GCmd` dispatches a
+ * follow-up message through `update`, `FCmd` bridges an async `Future` into
+ * the runtime, `Exit` ends the loop, and `TermFlowErrorCmd` surfaces a
+ * recoverable error to the renderer.
+ *
+ * @tparam Msg The application's message type.
+ */
 enum Cmd[+Msg]:
-  case NoCmd extends Cmd[Nothing]
-  case Exit  extends Cmd[Nothing]
 
+  /** No effect — the most common case for pure state transitions. */
+  case NoCmd extends Cmd[Nothing]
+
+  /**
+   * Cleanly terminate the runtime loop.
+   *
+   * The runtime restores terminal state (cursor, alt buffer) before
+   * returning from `TuiRuntime.run`.
+   */
+  case Exit extends Cmd[Nothing]
+
+  /**
+   * Dispatch a follow-up message through `update`.
+   *
+   * Useful for chaining state transitions from a single `update` call, or
+   * for self-dispatching initialisation work from `init`.
+   */
   case GCmd(msg: Msg) extends Cmd[Msg]
 
+  /**
+   * Run an asynchronous task and feed its result back into the runtime as a
+   * command when it completes.
+   *
+   * When the future succeeds, `toCmd(result)` is published to the command
+   * bus. When it fails, the runtime publishes a [[TermFlowErrorCmd]] with an
+   * [[TermFlowError.Unexpected]] describing the exception.
+   *
+   * @param task The asynchronous task to run.
+   * @param toCmd Function producing the follow-up command from the task's result.
+   * @param onEnqueue An optional message dispatched immediately when the
+   *                  command is enqueued — useful for updating a "loading"
+   *                  indicator before the future resolves.
+   */
   case FCmd[A, M](
     task: Future[A],
     toCmd: A => Cmd[M],
     onEnqueue: Option[M] = None
   ) extends Cmd[M]
 
+  /**
+   * Surface a recoverable error to the renderer.
+   *
+   * The error is displayed on the next frame (typically as an overlay) and
+   * cleared after one render cycle. The application continues running.
+   */
   case TermFlowErrorCmd(msg: TermFlowError) extends Cmd[Msg]
 
 /**
- * Main trait for TermFlow applications following the Elm architecture.
+ * The Elm-style application contract: a model, an update function, a view,
+ * and a way to turn prompt input into messages.
  *
- * Applications define four core functions:
- *  - `init`: Create initial model and optional startup command
- *  - `update`: Handle messages and produce new model state
- *  - `view`: Render model to a virtual DOM tree
- *  - `toMsg`: Parse user input into messages
+ * A typical application is an `object` that extends `TuiApp` and lives next
+ * to its `Model` case class and `Msg` enum:
  *
- * @tparam Model The application state type
- * @tparam Msg The message/event type handled by the application
+ * {{{
+ * object Counter:
+ *   final case class Model(count: Int)
+ *   enum Msg:
+ *     case Increment, Decrement, Quit
+ *
+ *   object App extends TuiApp[Model, Msg]:
+ *     def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] = Model(0).tui
+ *
+ *     def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+ *       msg match
+ *         case Msg.Increment => m.copy(count = m.count + 1).tui
+ *         case Msg.Decrement => m.copy(count = m.count - 1).tui
+ *         case Msg.Quit      => Tui(m, Cmd.Exit)
+ *
+ *     def view(m: Model): RootNode = /* … build the virtual DOM … */ ???
+ *
+ *     def toMsg(input: PromptLine): Result[Msg] = /* parse commands */ ???
+ * }}}
+ *
+ * Run the app with `TuiRuntime.run(Counter.App)`. For testing without a real
+ * terminal, drive it through `termflow.testkit.TuiTestDriver` instead.
+ *
+ * The architectural shape and rationale are documented in more depth in
+ * `docs/DESIGN.md` and `docs/RENDER_PIPELINE.md`.
+ *
+ * @tparam Model The application state type.
+ * @tparam Msg The message / event type handled by the application.
  */
 trait TuiApp[Model, Msg]:
 
-  /** Create the initial model and optional startup command. */
+  /**
+   * Produce the initial model and an optional startup command.
+   *
+   * Typical uses of the startup command are registering subscriptions
+   * (`Sub.InputKey`, `Sub.Every`) and kicking off async work with
+   * [[Cmd.FCmd]].
+   */
   def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg]
 
-  /** Handle a message and produce a new model state with optional command. */
+  /**
+   * Apply a message to the current model and return the next state plus an
+   * optional follow-up command.
+   *
+   * Must be pure with respect to `model` and `msg` — the runtime may re-run
+   * or coalesce updates during render pacing, and the test driver relies on
+   * determinism.
+   */
   def update(model: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg]
 
-  /** Render the model to a virtual DOM tree for display. */
+  /**
+   * Render the current model to a virtual-DOM tree.
+   *
+   * The returned [[RootNode]] is diffed against the previous frame by
+   * `AnsiRenderer` to produce a minimal ANSI patch. See
+   * `docs/RENDER_PIPELINE.md` for the full pipeline.
+   */
   def view(model: Model): RootNode
 
-  /** Parse user input into a message. */
+  /**
+   * Parse a submitted prompt line into a message, or a [[TermFlowError]] if
+   * the line isn't recognised.
+   *
+   * Validation errors are surfaced to the user via the error overlay;
+   * returning `Left(TermFlowError.Validation(...))` is the idiomatic way to
+   * reject a bad command without aborting the app.
+   */
   def toMsg(input: PromptLine): Result[Msg]

--- a/modules/termflow/src/main/scala/termflow/tui/TuiPrelude.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TuiPrelude.scala
@@ -1,24 +1,62 @@
 package termflow.tui
 
-/** Shared aliases and lightweight syntax; replace former package object. */
+/**
+ * Shared type aliases and lightweight syntax sugar used across TermFlow
+ * applications.
+ *
+ * Import the contents of `TuiPrelude.*` at the top of an app file to
+ * unlock:
+ *   - `Result[A]` as a shorthand for `Either[TermFlowError, A]`
+ *   - `2.x` / `3.y` coordinate syntax
+ *   - `"hello".text` / `"hi".text(fg = Color.Green, bold = true)` styled
+ *     text constructors
+ *   - `PromptLine`, the opaque type wrapping a submitted prompt line
+ */
 object TuiPrelude:
 
-  /** Fully edited line accepted from the prompt. */
+  /**
+   * Opaque wrapper for a completed line submitted from a prompt.
+   *
+   * `PromptLine` exists to keep `String`-typed raw input separate from
+   * domain strings in `update` / `view` call sites. Construct with
+   * `PromptLine(value)` and extract with `line.value`.
+   */
   opaque type PromptLine = String
   object PromptLine:
+
+    /** Wrap a raw string as a `PromptLine`. */
     def apply(value: String): PromptLine = value
 
+    /** Extension exposing the underlying string value. */
     extension (line: PromptLine) def value: String = line
 
-  /** Result type used by TUI parsing and commands. */
+  /**
+   * Convenience alias for the fallible result of parsing user input or
+   * running a validation step.
+   *
+   * Left-valued results surface through the runtime as
+   * [[Cmd.TermFlowErrorCmd]] without terminating the app.
+   */
   type Result[A] = Either[TermFlowError, A]
 
-  /** Syntax helpers: `2.x`, `3.y`. */
+  /**
+   * 1-based coordinate syntax: write `2.x` / `10.y` instead of
+   * `XCoord(2)` / `YCoord(10)` when building nodes in `view`.
+   */
   extension (i: Int)
     def x: XCoord = XCoord(i)
     def y: YCoord = YCoord(i)
 
-  /** String syntax helpers for creating styled text nodes. */
+  /**
+   * Fluent helpers for constructing [[Text]] segments from plain strings.
+   *
+   * {{{
+   * TextNode(2.x, 3.y, List(
+   *   "Status: ".text,
+   *   "ready".text(fg = Color.Green, bold = true)
+   * ))
+   * }}}
+   */
   extension (txt: String)
     def text: Text                                      = Text(txt, Style())
     def text(style: Style): Text                        = Text(txt, style)

--- a/modules/termflow/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -8,11 +8,28 @@ import scala.util.Failure
 import scala.util.Success
 
 /**
- * Renderer responsible for converting virtual DOM to terminal output.
+ * Pluggable renderer invoked by the runtime loop once per frame.
+ *
+ * The default implementation is `SimpleANSIRenderer` which delegates to
+ * `AnsiRenderer.buildFrame` + `AnsiRenderer.diff`. Custom renderers can be
+ * supplied to `TuiRuntime.run` for backends that emit something other than
+ * raw ANSI (e.g. test capture, alternate terminals).
+ *
+ * @note This is an SPI. Source-compatible changes are not guaranteed;
+ *       downstream implementers should expect the trait to evolve.
  */
 trait TuiRenderer:
 
-  /** Render the root node and optionally display an error. */
+  /**
+   * Render `textNode` onto `terminal`, optionally overlaying `err` as an
+   * error banner. Called at most once per frame by the runtime loop after
+   * coalescing queued commands.
+   *
+   * @param textNode The virtual DOM root produced by `TuiApp.view`.
+   * @param err A pending error to surface (cleared by the runtime after this call).
+   * @param terminal The backend to write ANSI output to.
+   * @param renderMetrics Metrics sink for diff size / coalescing counters.
+   */
   def render(
     textNode: RootNode,
     err: Option[TermFlowError],
@@ -45,16 +62,40 @@ trait RuntimeCtx[Msg] extends EventSink[Msg]:
    */
   def registerSub(sub: Sub[Msg]): Sub[Msg]
 
-/** Read side of the command bus used by the runtime loop. */
+/**
+ * Read side of the command bus consumed by the runtime loop.
+ *
+ * @note SPI. Applications should interact with commands through [[Cmd]] and
+ *       [[RuntimeCtx]], not this trait.
+ */
 trait CmdConsumer[Msg]:
+
+  /** Block until a command is available and return it. */
   def take(): Cmd[Msg]
+
+  /**
+   * Wait up to `timeoutMillis` for a command. Returns `None` on timeout.
+   * Used by the runtime to coalesce queued commands within a frame budget.
+   */
   def poll(timeoutMillis: Long): Option[Cmd[Msg]]
 
-/** Bidirectional command bus: producers publish, the runtime consumes. */
+/**
+ * Bidirectional command bus: producers publish, the runtime consumes.
+ *
+ * @note SPI. Custom implementations are only useful when replacing
+ *       `TuiRuntime.run` wholesale (e.g. for a bespoke test harness).
+ */
 trait CmdBus[Msg] extends RuntimeCtx[Msg] with CmdConsumer[Msg]:
+
+  /** Cancel every registered subscription, swallowing individual errors. */
   def cancelAllSubscriptions(): Unit
 
-/** Default in-memory command bus backed by a LinkedBlockingQueue. */
+/**
+ * Default in-memory [[CmdBus]] backed by a `LinkedBlockingQueue`.
+ *
+ * Thread-safe: multiple subscription threads can call `publish` concurrently
+ * while the runtime loop drains via `take` / `poll`.
+ */
 final class LocalCmdBus[Msg](val terminal: TerminalBackend, val config: TermFlowConfig) extends CmdBus[Msg]:
   private val queue                                   = new LinkedBlockingQueue[Cmd[Msg]]()
   private val subscriptions: java.util.List[Sub[Msg]] = new java.util.concurrent.CopyOnWriteArrayList[Sub[Msg]]()
@@ -82,10 +123,26 @@ object TuiRuntime:
     Option(e.getMessage).filter(_.trim.nonEmpty).getOrElse(e.getClass.getSimpleName)
 
   /**
-   * Run a TUI application with the given renderer and terminal backend.
+   * Run a TUI application, loading configuration from the environment.
    *
-   * This method enters alternate buffer mode, runs the application loop,
-   * and ensures terminal state is restored on exit (whether normal or due to error).
+   * This is the entry point most applications use: it loads
+   * [[TermFlowConfig]], delegates to the lower-level
+   * [[TuiRuntime.run[Model,Msg](app,renderer,terminalBackend,config)* overload]],
+   * and writes a diagnostic message if config loading fails.
+   *
+   * The runtime:
+   *   1. enters the terminal alternate buffer,
+   *   2. installs a JVM shutdown hook that restores cursor/alt-buffer state,
+   *   3. drives an event loop that coalesces queued commands at 60 FPS,
+   *   4. renders at most one frame per command burst,
+   *   5. tears down subscriptions and restores terminal state on exit.
+   *
+   * The loop runs on the caller's thread and only returns when the app
+   * publishes [[Cmd.Exit]] or throws.
+   *
+   * @param app The application to run.
+   * @param renderer The renderer to use. Defaults to `SimpleANSIRenderer`.
+   * @param terminalBackend The terminal backend. Defaults to `JLineTerminalBackend`.
    */
   def run[Model, Msg](
     app: TuiApp[Model, Msg],
@@ -105,6 +162,17 @@ object TuiRuntime:
         terminalBackend.flush()
         terminalBackend.close()
 
+  /**
+   * Run a TUI application with an explicitly supplied [[TermFlowConfig]].
+   *
+   * Use this overload when you need to override the default config (e.g.
+   * from tests or custom embedding). Otherwise prefer the
+   * [[TuiRuntime.run[Model,Msg](app,renderer,terminalBackend)* three-argument overload]]
+   * which loads config from the environment.
+   *
+   * See the three-argument overload for the loop semantics — this method
+   * only differs in that it skips the `TermFlowConfig.load()` step.
+   */
   def run[Model, Msg](
     app: TuiApp[Model, Msg],
     renderer: TuiRenderer,

--- a/modules/termflow/src/main/scala/termflow/tui/vdom.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/vdom.scala
@@ -1,9 +1,28 @@
 package termflow.tui
 
-/** Basic colour palette for text and borders. */
+/**
+ * Basic colour palette for text and borders.
+ *
+ * `Default` leaves the terminal's current foreground/background untouched
+ * and is the idiomatic way to say "no explicit colour" — it is not emitted
+ * as an ANSI escape at render time.
+ */
 enum Color:
   case Default, Black, Red, Green, Yellow, Blue, Magenta, Cyan, White
 
+/**
+ * Styling applied to a cell or run of cells.
+ *
+ * Styles are combined with the character content at render time by
+ * `AnsiRenderer` and emitted as SGR escape sequences. A default-constructed
+ * `Style` produces no escape sequences at all, so "plain text" stays plain.
+ *
+ * @param fg Foreground colour. [[Color.Default]] leaves it unset.
+ * @param bg Background colour. [[Color.Default]] leaves it unset.
+ * @param bold Enable the bold attribute.
+ * @param underline Enable the underline attribute.
+ * @param border Only meaningful on a [[BoxNode]]: draw a border around the box.
+ */
 final case class Style(
   fg: Color = Color.Default,
   bg: Color = Color.Default,
@@ -12,14 +31,63 @@ final case class Style(
   border: Boolean = false
 )
 
+/**
+ * A run of text with an associated [[Style]].
+ *
+ * Multiple `Text` segments can be concatenated inside a single [[TextNode]]
+ * to mix styles on one row without having to lay out multiple nodes:
+ *
+ * {{{
+ * TextNode(2.x, 3.y, List(
+ *   "Status: ".text,
+ *   "OK".text(fg = Color.Green, bold = true)
+ * ))
+ * }}}
+ */
 final case class Text(txt: String, style: Style)
 
+/**
+ * Virtual-DOM node type.
+ *
+ * All coordinates are 1-based (mirroring the underlying ANSI protocol) and
+ * absolute — there is no layout pass at the moment, so parents do not affect
+ * child positions. See issue #77 for the planned flex/stack layout engine.
+ *
+ * The three variants cover everything the current renderer supports:
+ *   - [[VNode.TextNode]] — styled text at a fixed coordinate
+ *   - [[VNode.BoxNode]]  — container with an optional border
+ *   - [[VNode.InputNode]] — single-line editable prompt with a cursor
+ */
 enum VNode:
+
+  /**
+   * A run of styled text anchored at `(x, y)`.
+   *
+   * @param x The 1-based column of the first character.
+   * @param y The 1-based row.
+   * @param txt One or more [[Text]] segments, concatenated left-to-right.
+   */
   case TextNode(
     override val x: XCoord,
     override val y: YCoord,
     txt: List[Text]
   )
+
+  /**
+   * A rectangular container anchored at `(x, y)`.
+   *
+   * `BoxNode` is currently visual-only: if `style.border` is set, the
+   * renderer draws a border from `(x, y)` to `(x + width - 1, y + height - 1)`.
+   * Children are drawn in document order on top of the box; they are not
+   * automatically clipped or repositioned relative to the box.
+   *
+   * @param x The 1-based column of the top-left corner.
+   * @param y The 1-based row of the top-left corner.
+   * @param width The box width including both border columns.
+   * @param height The box height including both border rows.
+   * @param children Child nodes drawn inside / over the box.
+   * @param style The box style. `Style(border = true)` is the usual setting.
+   */
   case BoxNode(
     override val x: XCoord,
     override val y: YCoord,
@@ -28,50 +96,100 @@ enum VNode:
     children: List[VNode],
     override val style: Style = Style()
   )
+
+  /**
+   * A single-line editable prompt with a cursor.
+   *
+   * `InputNode` is the only node type that the renderer treats as "live":
+   * after drawing the static content it moves the hardware cursor into the
+   * input at `cursor`, so editing is reflected at the terminal level.
+   *
+   * @param x 1-based column of the first character of the prompt.
+   * @param y 1-based row of the prompt.
+   * @param prompt The buffer to display (already rendered from `Prompt.State`).
+   * @param style The style applied to the prompt text.
+   * @param cursor Cursor index within `prompt`. `-1` means "at end".
+   * @param lineWidth Fixed viewport width. `0` means "use the prompt length".
+   * @param prefixLength Number of leading characters that belong to a fixed
+   *                     prefix (e.g. `">>> "`) and should be pinned to the
+   *                     left edge even when the viewport scrolls.
+   */
   case InputNode(
     override val x: XCoord,
     override val y: YCoord,
     prompt: String,
     override val style: Style,
-    cursor: Int = -1,   // -1 means at end
-    lineWidth: Int = 0, // 0 means use prompt length
+    cursor: Int = -1,
+    lineWidth: Int = 0,
     prefixLength: Int = 0
   )
 
+  /** Top-left column of this node (1-based). */
   def x: XCoord = this match
     case TextNode(x, _, _)              => x
     case BoxNode(x, _, _, _, _, _)      => x
     case InputNode(x, _, _, _, _, _, _) => x
 
+  /** Top-left row of this node (1-based). */
   def y: YCoord = this match
     case TextNode(_, y, _)              => y
     case BoxNode(_, y, _, _, _, _)      => y
     case InputNode(_, y, _, _, _, _, _) => y
 
+  /**
+   * Width of this node in cells.
+   *
+   * `TextNode` always reports `1` — it does not know its own visible width
+   * because that depends on the underlying `Text` segments. Use
+   * `AnsiRenderer.buildFrame` for authoritative layout.
+   */
   def width: Int = this match
     case TextNode(_, _, _)             => 1
     case BoxNode(_, _, width, _, _, _) => width
     case InputNode(_, _, prompt, _, _, lineWidth, _) =>
       if lineWidth > 0 then lineWidth else prompt.length + 1
 
+  /** Height of this node in cells. Always `1` for text and input nodes. */
   def height: Int = this match
     case TextNode(_, _, _)              => 1
     case BoxNode(_, _, _, height, _, _) => height
     case InputNode(_, _, _, _, _, _, _) => 1
 
+  /** The style applied to this node. [[TextNode]] styles live on its segments. */
   def style: Style = this match
     case TextNode(_, _, _)                  => Style()
     case BoxNode(_, _, _, _, _, style)      => style
     case InputNode(_, _, _, style, _, _, _) => style
 
-// Compatibility aliases so call sites can keep using TextNode/BoxNode/InputNode directly.
+/**
+ * Compatibility alias so call sites can reference `TextNode` unqualified
+ * instead of `VNode.TextNode`. Matches the spelling used by the sample apps.
+ */
 type TextNode = VNode.TextNode
 val TextNode = VNode.TextNode
+
+/** Compatibility alias; see [[TextNode]]. */
 type BoxNode = VNode.BoxNode
 val BoxNode = VNode.BoxNode
+
+/** Compatibility alias; see [[TextNode]]. */
 type InputNode = VNode.InputNode
 val InputNode = VNode.InputNode
 
+/**
+ * The top-level virtual-DOM container produced by `TuiApp.view`.
+ *
+ * `RootNode` declares the logical frame size and a list of children plus an
+ * optional focused input. The actual terminal width/height is read from the
+ * backend by the renderer; the `width`/`height` here are the app's own idea
+ * of the drawing surface and are used by `AnsiRenderer.buildFrame` to size
+ * the cell matrix.
+ *
+ * @param width Frame width in cells.
+ * @param height Frame height in cells.
+ * @param children Static nodes to draw, in document order.
+ * @param input Optional focused [[InputNode]] rendered last, with cursor placement.
+ */
 final case class RootNode(
   width: Int,
   height: Int,


### PR DESCRIPTION
Closes #79.

**Stacked on top of #84** — review that one first. The base branch of this PR is \`feature/78-renderer-harness\`, not \`main\`, so the diff shows only the doc changes.

## Summary

- Adds comprehensive ScalaDoc to the public API every \`TuiApp\` author touches: \`Tui\` / \`Cmd\` / \`TermFlowError\` / \`TuiApp\`, all \`VNode\` variants + \`RootNode\` + \`Style\` / \`Color\` / \`Text\`, the \`Sub\` factories, the \`TuiRuntime.run\` overloads, \`TuiPrelude\`, and the \`XCoord\` / \`YCoord\` coordinate types
- Marks internal-facing SPI (\`TuiRenderer\`, \`CmdConsumer\`, \`CmdBus\`, \`EventSink\`, \`EventSource\`) with \`@note\` comments so users know what's safe to extend
- Adds a runnable \`TuiApp\` example to the trait's ScalaDoc as a landing page
- No visibility changes, no runtime behaviour changes — purely additive

## What's here

### Fully documented

- **\`Tui.scala\`** — \`TuiApp\` trait has an example-driven overview pointing at \`docs/DESIGN.md\` and \`RENDER_PIPELINE.md\`. \`Tui\`, \`Cmd\` (every variant with \`@param\` where useful), \`TermFlowError\` (every variant), plus the \`tui\` / \`gCmd\` extension sugar.
- **\`vdom.scala\`** — \`Color\`, \`Style\`, \`Text\`, \`VNode.{TextNode, BoxNode, InputNode}\`, the width/height/x/y/style accessors, the \`TextNode\` / \`BoxNode\` / \`InputNode\` compatibility aliases, and \`RootNode\`. Calls out that coordinates are 1-based absolute and links forward to #77 for the layout engine.
- **\`AnsiRenderer.scala\`** (coordinate types only) — \`XCoord\`, \`YCoord\`, \`Coord\` now carry per-method ScalaDoc.

### Polished / extended

- **\`TuiRuntime.scala\`** — both \`run\` overloads now describe the loop semantics (alt buffer, shutdown hook, 60 FPS coalescing, teardown order, exit semantics). \`TuiRenderer\`, \`CmdConsumer\`, \`CmdBus\`, and \`LocalCmdBus\` gain full docs. \`TuiRenderer\` / \`CmdConsumer\` / \`CmdBus\` are marked as SPI via \`@note\`.
- **\`Sub.scala\`** — \`Sub\`, \`NoSub\`, \`Every\`, \`InputKey\`, \`InputKeyFromSource\`, \`InputKeyWithReader\`, and \`TerminalResize\` all have usage-oriented docs. \`EventSink\` and \`EventSource\` marked as SPI.
- **\`TuiPrelude.scala\`** — \`PromptLine\`, \`Result[A]\`, the \`2.x\` / \`3.y\` coordinate extensions, and the \`text(...)\` fluent builders explained with an example.

### Deferred

Not in this PR (scope kept tight to the core public API):
- Internal implementation types: \`TerminalBackend\`, \`JLineTerminalBackend\`, \`KeyDecoder\`, \`Prompt\`, \`History\`, \`RenderMetrics\`, \`FrameworkLog\`, \`ConsoleKeyPressSource\`, \`AnsiRenderer\` (render/diff internals), \`TermFlowConfig\`, \`ThreadUtils\`
- Actual \`private[termflow]\` tightening — left for a follow-up because visibility changes need more care than this doc-only pass
- A top-level \`package.scala\` / framework landing page — the \`TuiApp\` trait ScalaDoc serves that purpose for now

## Test plan
- [x] \`sbt ciCheck\` — scalafmt + scalafix + 135 tests passing
- [x] \`sbt termflow/doc\` — ScalaDoc generates cleanly (one pre-existing \`-classpath\` warning unrelated to these changes)
- [x] No runtime behaviour modified; the only test coverage needed is the existing regression suite, which passes unchanged