### PR TITLE
Add semantic Theme with dark/light/mono presets

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Theme.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Theme.scala
@@ -1,0 +1,195 @@
+package termflow.tui
+
+/**
+ * Named colour slots for building terminal UIs that don't bake in a
+ * specific palette.
+ *
+ * A `Theme` maps short semantic names (`primary`, `success`, `error`, …) to
+ * concrete [[Color]] values. Apps reference slots by meaning, and can swap
+ * palettes (e.g. dark/light) without touching any view code.
+ *
+ * ## Direct usage
+ *
+ * The simplest approach is to hold a theme value somewhere in the model (or
+ * as a `val`) and read slots from it:
+ *
+ * {{{
+ * val theme = Theme.dark
+ *
+ * override def view(m: Model): RootNode =
+ *   RootNode(... children = List(
+ *     TextNode(2.x, 2.y, List("Status: ".text, "OK".text(fg = theme.success)))
+ *   ), ...)
+ * }}}
+ *
+ * ## Using `given` for call-site ergonomics
+ *
+ * For apps that want to stay theme-agnostic at call sites, bring a `Theme`
+ * into implicit scope and use the `themed` extensions defined on [[Theme]]:
+ *
+ * {{{
+ * given Theme = Theme.dark
+ *
+ * override def view(m: Model): RootNode =
+ *   RootNode(... children = List(
+ *     TextNode(2.x, 2.y, List(
+ *       "Status: ".text,
+ *       "OK".themed(_.success)                              // string -> Text
+ *     )),
+ *     BoxNode(1.x, 1.y, 40, 6, Nil,
+ *             style = Style(border = true).themed(_.border)) // style copy
+ *   ), ...)
+ * }}}
+ *
+ * ## Customising
+ *
+ * Themes are plain case classes, so ad-hoc overrides are just `copy`:
+ *
+ * {{{
+ * val highContrast = Theme.dark.copy(success = Color.White)
+ * }}}
+ *
+ * @param primary    Dominant accent colour (headers, active tabs, primary actions).
+ * @param secondary  Secondary accent for less prominent controls.
+ * @param error      Errors and destructive actions. Usually red.
+ * @param warning    Non-fatal warnings. Usually yellow.
+ * @param success    Confirmations and success states. Usually green.
+ * @param info       Informational highlights. Usually cyan.
+ * @param border     Default colour for [[BoxNode]] borders.
+ * @param background Background for large surfaces. `Color.Default` means
+ *                   "use the terminal's configured background".
+ * @param foreground Default body-text colour. `Color.Default` inherits the
+ *                   terminal's foreground, which is usually what you want
+ *                   unless the theme is explicitly opinionated.
+ *
+ * @note `muted` / `dim` is intentionally omitted from v1. TermFlow's [[Style]]
+ *       has no dim attribute, so a muted slot would have to alias an existing
+ *       colour, which is misleading. Add when `Style` grows a dim/faint flag.
+ */
+final case class Theme(
+  primary: Color,
+  secondary: Color,
+  error: Color,
+  warning: Color,
+  success: Color,
+  info: Color,
+  border: Color,
+  background: Color,
+  foreground: Color
+):
+
+  /** All slots as an ordered list. Convenient for tests and debugging. */
+  def slots: List[(String, Color)] =
+    List(
+      "primary"    -> primary,
+      "secondary"  -> secondary,
+      "error"      -> error,
+      "warning"    -> warning,
+      "success"    -> success,
+      "info"       -> info,
+      "border"     -> border,
+      "background" -> background,
+      "foreground" -> foreground
+    )
+
+object Theme:
+
+  /**
+   * Opinionated dark-mode palette.
+   *
+   * Background pinned to [[Color.Black]], foreground to [[Color.White]], with
+   * the standard ANSI accent colours for each semantic slot. Suitable as a
+   * sensible default for terminals that are already rendering on a dark
+   * background.
+   */
+  val dark: Theme = Theme(
+    primary = Color.Blue,
+    secondary = Color.Cyan,
+    error = Color.Red,
+    warning = Color.Yellow,
+    success = Color.Green,
+    info = Color.Cyan,
+    border = Color.Blue,
+    background = Color.Black,
+    foreground = Color.White
+  )
+
+  /**
+   * Opinionated light-mode palette.
+   *
+   * Same accent colours as [[dark]], but background is [[Color.White]] and
+   * foreground is [[Color.Black]]. Accent colours are unchanged because the
+   * ANSI basic-16 palette renders acceptably on either background.
+   */
+  val light: Theme = Theme(
+    primary = Color.Blue,
+    secondary = Color.Cyan,
+    error = Color.Red,
+    warning = Color.Yellow,
+    success = Color.Green,
+    info = Color.Cyan,
+    border = Color.Blue,
+    background = Color.White,
+    foreground = Color.Black
+  )
+
+  /**
+   * Theme with every slot set to [[Color.Default]].
+   *
+   * Useful as a starting point for apps that want to stay entirely at the
+   * terminal's configured palette, or as a null object in tests. Rendering
+   * a `mono` theme emits no SGR escapes at all.
+   */
+  val mono: Theme = Theme(
+    primary = Color.Default,
+    secondary = Color.Default,
+    error = Color.Default,
+    warning = Color.Default,
+    success = Color.Default,
+    info = Color.Default,
+    border = Color.Default,
+    background = Color.Default,
+    foreground = Color.Default
+  )
+
+  /**
+   * Return the `Theme` from implicit scope.
+   *
+   * Shorthand for `summon[Theme]`, useful when you want to pass the ambient
+   * theme explicitly to something that takes a regular `Theme` parameter.
+   */
+  def current(using t: Theme): Theme = t
+
+  /**
+   * Select a single slot from the ambient theme.
+   *
+   * {{{
+   * given Theme = Theme.dark
+   * val accent: Color = Theme.slot(_.primary)
+   * }}}
+   */
+  def slot(select: Theme => Color)(using t: Theme): Color = select(t)
+
+  /**
+   * Extension adding `style.themed(_.primary)` syntax for setting a theme
+   * slot as the style's foreground colour.
+   *
+   * Requires a `given Theme` in scope. Preserves every other field on the
+   * receiver, so `Style(bold = true).themed(_.success)` yields a bold green
+   * style.
+   */
+  extension (s: Style)
+    def themed(select: Theme => Color)(using t: Theme): Style =
+      s.copy(fg = select(t))
+
+  /**
+   * Extension adding `"label".themed(_.success)` syntax for producing a
+   * themed [[Text]] segment directly from a string.
+   *
+   * Requires a `given Theme` in scope. Equivalent to
+   * `"label".text(fg = Theme.slot(_.success))` but reads more naturally
+   * inside a `TextNode` child list.
+   */
+  extension (txt: String)
+    def themed(select: Theme => Color)(using t: Theme): Text =
+      Text(txt, Style(fg = select(t)))

--- a/modules/termflow/src/test/scala/termflow/tui/ThemeSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/ThemeSpec.scala
@@ -1,0 +1,81 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.Theme.themed
+
+class ThemeSpec extends AnyFunSuite:
+
+  test("dark theme exposes every semantic slot with a non-default colour"):
+    val slots = Theme.dark.slots
+    assert(
+      slots.map(_._1).toSet == Set(
+        "primary",
+        "secondary",
+        "error",
+        "warning",
+        "success",
+        "info",
+        "border",
+        "background",
+        "foreground"
+      )
+    )
+    // Every slot in dark is concrete — no Color.Default leaks.
+    assert(slots.forall { case (_, c) => c != Color.Default })
+
+  test("light theme exposes every semantic slot with a non-default colour"):
+    val slots = Theme.light.slots
+    assert(slots.forall { case (_, c) => c != Color.Default })
+
+  test("dark and light differ on background / foreground but share accents"):
+    assert(Theme.dark.background != Theme.light.background)
+    assert(Theme.dark.foreground != Theme.light.foreground)
+    // Accents are identical — basic ANSI-16 renders fine on either bg.
+    assert(Theme.dark.primary == Theme.light.primary)
+    assert(Theme.dark.success == Theme.light.success)
+    assert(Theme.dark.error == Theme.light.error)
+
+  test("mono theme has every slot set to Color.Default"):
+    assert(Theme.mono.slots.forall { case (_, c) => c == Color.Default })
+
+  test("copy lets callers override individual slots"):
+    val high = Theme.dark.copy(success = Color.White)
+    assert(high.success == Color.White)
+    // Other slots untouched.
+    assert(high.primary == Theme.dark.primary)
+    assert(high.error == Theme.dark.error)
+
+  test("Theme.current returns the given in implicit scope"):
+    given Theme = Theme.light
+    assert(Theme.current eq Theme.light)
+
+  test("Theme.slot projects a slot from the ambient theme"):
+    given Theme = Theme.dark
+    assert(Theme.slot(_.primary) == Color.Blue)
+    assert(Theme.slot(_.success) == Color.Green)
+
+  test("Style.themed copies the receiver and sets fg from a slot"):
+    given Theme         = Theme.dark
+    val base            = Style(bold = true, underline = true)
+    val accented: Style = base.themed(_.primary)
+    assert(accented.fg == Color.Blue)
+    // Other fields preserved.
+    assert(accented.bold)
+    assert(accented.underline)
+    // Receiver is not mutated.
+    assert(base.fg == Color.Default)
+
+  test("String.themed produces a Text with the ambient theme's slot colour"):
+    given Theme = Theme.dark
+    val t: Text = "ready".themed(_.success)
+    assert(t.txt == "ready")
+    assert(t.style.fg == Color.Green)
+    assert(!t.style.bold)
+
+  test("theming against the mono theme is a no-op colour-wise"):
+    given Theme = Theme.mono
+    val t       = "hello".themed(_.primary)
+    assert(t.style.fg == Color.Default)
+    val s = Style(bold = true).themed(_.error)
+    assert(s.fg == Color.Default)
+    assert(s.bold)


### PR DESCRIPTION
Closes #80.

**Stacked on top of #85** (which is stacked on #84). The base branch of this PR is \`feature/79-scaladoc-pass\`, so the GitHub diff shows only the two new theme files.

## Summary

- New \`Theme\` case class with 9 semantic slots: \`primary\`, \`secondary\`, \`error\`, \`warning\`, \`success\`, \`info\`, \`border\`, \`background\`, \`foreground\`
- Three built-in presets: \`Theme.dark\`, \`Theme.light\`, \`Theme.mono\`
- \`given\`-based ergonomic extensions: \`Style.themed(_.primary)\` and \`\"label\".themed(_.success)\`
- 10 unit tests in \`ThemeSpec\`
- **Zero changes to \`Style\`, \`VNode\`, or the renderer** — theming is resolved at view time, so the render pipeline stays dumb and nothing else in the codebase has to know about themes

## Why

Theming is the explicit precursor for the widget library (#81). If widgets hard-code \`Color.Blue\` / \`Color.Green\` / etc., every app that uses them has to re-theme individually. Landing semantic slots first means widgets can reference \`Theme.primary\` / \`Theme.success\` and apps can swap palettes via a single \`given\` binding.

Picking this as the next stacked PR after the testkit (#84) and ScalaDoc pass (#85) matches the ordering I recommended earlier: **#80 → #81 → #82 → #83** with \"theming before widgets so nothing hard-codes colours\".

## Two consumption patterns

### Direct (no magic)

\`\`\`scala
val theme = Theme.dark

override def view(m: Model): RootNode =
  RootNode(... children = List(
    TextNode(2.x, 2.y, List(\"Status: \".text, \"OK\".text(fg = theme.success)))
  ), ...)
\`\`\`

### Given-based (theme-agnostic call sites)

\`\`\`scala
given Theme = Theme.dark

override def view(m: Model): RootNode =
  RootNode(... children = List(
    TextNode(2.x, 2.y, List(
      \"Status: \".text,
      \"OK\".themed(_.success)
    )),
    BoxNode(1.x, 1.y, 40, 6, Nil,
            style = Style(border = true).themed(_.border))
  ), ...)
\`\`\`

## Design notes

- **View-time resolution, not render-time.** The renderer never sees themes — apps produce concrete \`Color\` values before \`view\` returns. This is simpler than the issue's \"renderer resolves themed styles at render time\" wording but achieves the same end: apps stay theme-agnostic via \`given Theme\`. Render-time resolution would require plumbing \`Theme\` through \`TuiRenderer.render\`, which is more disruptive and only buys runtime theme hot-swapping — a feature we can add later if asked for.
- **No \`TermFlowConfig\` plumbing.** Apps bind the theme themselves (via \`val theme = ...\` or \`given Theme = ...\`). Config-driven theme selection can be a follow-up once there's demand.
- **\`muted\` slot deferred.** \`Style\` has no dim/faint attribute, so a muted slot would have to alias an existing colour, which is misleading. Add when \`Style\` grows a \`dim\` boolean.
- **\`Theme.mono\`** (all \`Color.Default\`) is included as a null-object baseline and for tests.

## Test plan
- [x] 10 new tests in \`ThemeSpec\`: slot coverage, dark/light differences, \`copy\` customisation, \`Theme.current\`, \`Theme.slot\`, and both \`themed\` extensions (including the no-op behaviour on \`Theme.mono\`)
- [x] \`sbt ciCheck\` green — 145 tests passing total, scalafmt + scalafix clean
- [x] \`sbt termflow/doc\` regenerates cleanly with no broken links (the only warning is the pre-existing \`-classpath\` one)

## Out of scope (per the issue)

- User-supplied theme files / hot reload
- 24-bit truecolor palette — basic-16 only for v1
- Per-widget style cascade
- \`muted\` slot (see note above)
- Porting existing sample apps to use themes — intentionally left as follow-ups to keep the PR scope tight