### PR TITLE
Add minimal layout DSL (Row/Column/Spacer)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Layout.scala
@@ -1,0 +1,270 @@
+package termflow.tui
+
+/**
+ * Minimal layout DSL for composing TermFlow views without hand-rolling
+ * absolute coordinates.
+ *
+ * The renderer is still absolute-coordinate only — `Layout` is a build-time
+ * helper that walks a container tree and emits absolute-positioned [[VNode]]s
+ * that the existing `AnsiRenderer` consumes unchanged. No changes to
+ * `TuiApp`, `TuiRuntime`, or the render pipeline are required; apps opt in
+ * by building a `Layout` inside `view` and calling `.resolve` or
+ * `.toRootNode` to feed [[RootNode]].
+ *
+ * ## Quick example
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.TuiPrelude.*
+ *
+ * override def view(m: Model): RootNode =
+ *   Layout.column(gap = 1)(
+ *     TextNode(1.x, 1.y, List(Text("Status: ready", Style(fg = Color.Green)))),
+ *     Layout.row(gap = 2)(
+ *       TextNode(1.x, 1.y, List(Text("A", Style()))),
+ *       TextNode(1.x, 1.y, List(Text("B", Style()))),
+ *       TextNode(1.x, 1.y, List(Text("C", Style())))
+ *     ).asLayout
+ *   ).toRootNode(width = m.terminalWidth, height = m.terminalHeight)
+ * }}}
+ *
+ * ## Semantics
+ *
+ * Each `Layout` value has a natural size returned by [[Layout.measure]]:
+ *
+ *   - `Elem(v)` — size of the wrapped node (text width, box dimensions, etc.)
+ *   - `Row(gap, cs)` — `sum(childWidths) + gap * (n - 1)` wide, `max(childHeights)` tall
+ *   - `Column(gap, cs)` — `max(childWidths)` wide, `sum(childHeights) + gap * (n - 1)` tall
+ *   - `Spacer(w, h)` — exactly `(w, h)`
+ *
+ * Empty `Row` / `Column` measure as `(0, 0)` and resolve to the empty list.
+ *
+ * [[Layout.resolve]] walks the tree, placing children left-to-right (Row)
+ * or top-to-bottom (Column) starting from the supplied origin. Each child
+ * is positioned at the next free slot using its own measured width/height.
+ * Alignment is always start-of-axis; see the "Out of scope" notes below.
+ *
+ * ## Elem translation rule
+ *
+ * `Layout.Elem(vnode)` wraps a `VNode` that was authored with its own
+ * absolute coordinates (e.g. `TextNode(1.x, 1.y, ...)`). When the layout
+ * resolver places the element at `at`, it shifts the wrapped node by
+ * `(at.x - vnode.x, at.y - vnode.y)` — effectively repositioning the node
+ * to the container's chosen slot while preserving internal relative layout
+ * (e.g. child offsets inside a [[BoxNode]]).
+ *
+ * Common convention: author the wrapped node at `(1.x, 1.y)` so the
+ * translation is just "move to `at`".
+ *
+ * ## Out of scope (v1)
+ *
+ *   - Alignment / justification (children always at the start of the axis)
+ *   - Flex weights / grow / shrink
+ *   - Padding wrappers (use [[Layout.Spacer]] between siblings)
+ *   - Clipping / overflow handling
+ *   - Z-ordering of overlapping children
+ */
+enum Layout:
+
+  /**
+   * Wrap a concrete [[VNode]] as a layout leaf.
+   *
+   * The wrapped node's absolute coordinates are overridden by the container:
+   * when the layout resolver places the element at `at`, the node is
+   * translated so its own `(x, y)` becomes `(at.x, at.y)`. See the
+   * "Elem translation rule" section on [[Layout]].
+   */
+  case Elem(vnode: VNode)
+
+  /**
+   * Horizontal flow: children are placed left-to-right, top-aligned, with
+   * `gap` empty cells between siblings.
+   *
+   * @param gap Number of cells between adjacent children. Negative values
+   *            are treated as `0`.
+   * @param children Layout items in render order (first = leftmost).
+   */
+  case Row(gap: Int, children: List[Layout])
+
+  /**
+   * Vertical flow: children are placed top-to-bottom, left-aligned, with
+   * `gap` empty rows between siblings.
+   *
+   * @param gap Number of rows between adjacent children. Negative values
+   *            are treated as `0`.
+   * @param children Layout items in render order (first = topmost).
+   */
+  case Column(gap: Int, children: List[Layout])
+
+  /**
+   * Empty rectangle used to reserve space without drawing anything.
+   *
+   * Useful for pushing siblings apart inside a `Row` / `Column` — for
+   * example `Row(0, List(Elem(a), Spacer(4, 1), Elem(b)))` places `b`
+   * four cells to the right of `a`.
+   */
+  case Spacer(width: Int, height: Int)
+
+  /** Natural `(width, height)` of this layout, in cells. */
+  def measure: (Int, Int) = Layout.measure(this)
+
+  /**
+   * Resolve this layout into a flat list of absolute-positioned [[VNode]]s
+   * starting at `at`.
+   *
+   * The returned list is in render order. Callers typically pass it as the
+   * `children` argument of a [[RootNode]]; use [[toRootNode]] for a slightly
+   * more concise variant.
+   */
+  def resolve(at: Coord = Coord(XCoord(1), YCoord(1))): List[VNode] =
+    Layout.resolve(this, at)
+
+  /**
+   * Resolve this layout at `(1, 1)` and wrap the result in a [[RootNode]].
+   *
+   * @param width Terminal width to advertise on the root.
+   * @param height Terminal height to advertise on the root.
+   * @param input Optional focused input to attach to the root.
+   * @param at Origin for the layout resolver. Defaults to `(1, 1)`.
+   */
+  def toRootNode(
+    width: Int,
+    height: Int,
+    input: Option[InputNode] = None,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  ): RootNode =
+    RootNode(width, height, resolve(at), input)
+
+object Layout:
+
+  /**
+   * Fluent constructor for a [[Row]] over bare [[VNode]]s. Each vnode is
+   * auto-wrapped in an [[Elem]].
+   *
+   * {{{
+   * Layout.row(gap = 1)(
+   *   TextNode(1.x, 1.y, List(Text("A", Style()))),
+   *   TextNode(1.x, 1.y, List(Text("B", Style())))
+   * )
+   * }}}
+   */
+  def row(gap: Int)(children: VNode*): Layout =
+    Row(math.max(0, gap), children.toList.map(Elem.apply))
+
+  /**
+   * Fluent constructor for a [[Column]] over bare [[VNode]]s. Each vnode is
+   * auto-wrapped in an [[Elem]].
+   */
+  def column(gap: Int)(children: VNode*): Layout =
+    Column(math.max(0, gap), children.toList.map(Elem.apply))
+
+  /** Extension lifting a [[VNode]] into a [[Layout.Elem]]. */
+  extension (v: VNode) def asLayout: Layout = Elem(v)
+
+  /**
+   * Natural size of a layout, ignoring any container it will be placed in.
+   *
+   * Public for tests and for callers who want to size a surrounding box
+   * from measured layout dimensions.
+   */
+  def measure(layout: Layout): (Int, Int) = layout match
+    case Elem(v)      => measureVNode(v)
+    case Spacer(w, h) => (math.max(0, w), math.max(0, h))
+
+    case Row(gap, cs) =>
+      if cs.isEmpty then (0, 0)
+      else
+        val g      = math.max(0, gap)
+        val sizes  = cs.map(measure)
+        val width  = sizes.map(_._1).sum + g * (cs.size - 1)
+        val height = sizes.map(_._2).max
+        (width, height)
+
+    case Column(gap, cs) =>
+      if cs.isEmpty then (0, 0)
+      else
+        val g      = math.max(0, gap)
+        val sizes  = cs.map(measure)
+        val width  = sizes.map(_._1).max
+        val height = sizes.map(_._2).sum + g * (cs.size - 1)
+        (width, height)
+
+  /** Natural `(width, height)` of a concrete [[VNode]]. */
+  def measureVNode(v: VNode): (Int, Int) = v match
+    case TextNode(_, _, segments) =>
+      val width = segments.foldLeft(0)((acc, seg) => acc + seg.txt.length)
+      (width, 1)
+
+    case BoxNode(_, _, w, h, _, _) =>
+      (math.max(0, w), math.max(0, h))
+
+    case InputNode(_, _, prompt, _, _, lineWidth, _) =>
+      val width = if lineWidth > 0 then lineWidth else prompt.length
+      (width, 1)
+
+  /**
+   * Resolve a layout into absolute-positioned [[VNode]]s starting at `at`.
+   *
+   * The instance method [[Layout.resolve]] delegates here — prefer calling
+   * the method form for readability.
+   */
+  def resolve(layout: Layout, at: Coord): List[VNode] = layout match
+    case Elem(v) =>
+      val dx = at.x.value - v.x.value
+      val dy = at.y.value - v.y.value
+      if dx == 0 && dy == 0 then List(v)
+      else List(translate(v, dx, dy))
+
+    case Spacer(_, _) => Nil
+
+    case Row(gap, cs) =>
+      val g       = math.max(0, gap)
+      var xCursor = at.x.value
+      val out     = List.newBuilder[VNode]
+      var i       = 0
+      val n       = cs.size
+      while i < n do
+        val child   = cs(i)
+        val (cw, _) = measure(child)
+        val placed  = resolve(child, Coord(XCoord(xCursor), at.y))
+        out ++= placed
+        xCursor += cw
+        if i < n - 1 then xCursor += g
+        i += 1
+      out.result()
+
+    case Column(gap, cs) =>
+      val g       = math.max(0, gap)
+      var yCursor = at.y.value
+      val out     = List.newBuilder[VNode]
+      var i       = 0
+      val n       = cs.size
+      while i < n do
+        val child   = cs(i)
+        val (_, ch) = measure(child)
+        val placed  = resolve(child, Coord(at.x, YCoord(yCursor)))
+        out ++= placed
+        yCursor += ch
+        if i < n - 1 then yCursor += g
+        i += 1
+      out.result()
+
+  /**
+   * Translate a [[VNode]] by `(dx, dy)`, including any nested [[BoxNode]]
+   * children so that relative offsets are preserved.
+   *
+   * Exposed for tests; the resolver uses it internally for [[Elem]] nodes.
+   */
+  def translate(v: VNode, dx: Int, dy: Int): VNode = v match
+    case tn: TextNode =>
+      tn.copy(x = tn.x + dx, y = tn.y + dy)
+
+    case bn: BoxNode =>
+      bn.copy(
+        x = bn.x + dx,
+        y = bn.y + dy,
+        children = bn.children.map(translate(_, dx, dy))
+      )
+
+    case in: InputNode =>
+      in.copy(x = in.x + dx, y = in.y + dy)

--- a/modules/termflow/src/test/scala/termflow/tui/LayoutSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/LayoutSpec.scala
@@ -1,0 +1,239 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.Layout.asLayout
+import termflow.tui.TuiPrelude.*
+
+class LayoutSpec extends AnyFunSuite:
+
+  private def tn(text: String): TextNode =
+    TextNode(1.x, 1.y, List(Text(text, Style())))
+
+  // --- measure -----------------------------------------------------------
+
+  test("measureVNode on TextNode returns (textWidth, 1)"):
+    assert(Layout.measureVNode(tn("abc")) == (3, 1))
+    assert(Layout.measureVNode(tn("")) == (0, 1))
+    // Multi-segment text sums the widths.
+    val multi = TextNode(1.x, 1.y, List(Text("ab", Style()), Text("cde", Style())))
+    assert(Layout.measureVNode(multi) == (5, 1))
+
+  test("measureVNode on BoxNode returns declared dimensions"):
+    assert(Layout.measureVNode(BoxNode(1.x, 1.y, 10, 4, children = Nil)) == (10, 4))
+
+  test("measureVNode on InputNode uses lineWidth when set, prompt length otherwise"):
+    val boxed = InputNode(1.x, 1.y, "hello", Style(), lineWidth = 20)
+    assert(Layout.measureVNode(boxed) == (20, 1))
+    val unboxed = InputNode(1.x, 1.y, "hello", Style(), lineWidth = 0)
+    assert(Layout.measureVNode(unboxed) == (5, 1))
+
+  test("Elem measures to its wrapped VNode"):
+    assert(Layout.Elem(tn("hi")).measure == (2, 1))
+
+  test("Spacer measures to its declared dimensions"):
+    assert(Layout.Spacer(3, 2).measure == (3, 2))
+    // Negative sizes clamp to zero.
+    assert(Layout.Spacer(-5, -1).measure == (0, 0))
+
+  test("empty Row and Column measure to (0, 0)"):
+    assert(Layout.Row(gap = 2, children = Nil).measure == (0, 0))
+    assert(Layout.Column(gap = 2, children = Nil).measure == (0, 0))
+
+  test("Row measure sums widths and picks max height, with gap between siblings"):
+    val r = Layout.Row(
+      gap = 1,
+      children = List(
+        Layout.Elem(tn("ab")),                               // 2x1
+        Layout.Elem(tn("cdef")),                             // 4x1
+        Layout.Elem(BoxNode(1.x, 1.y, 3, 2, children = Nil)) // 3x2
+      )
+    )
+    // width = 2 + 4 + 3 + 1*(3-1) = 11, height = max(1,1,2) = 2
+    assert(r.measure == (11, 2))
+
+  test("Column measure sums heights and picks max width, with gap between siblings"):
+    val c = Layout.Column(
+      gap = 2,
+      children = List(
+        Layout.Elem(tn("ab")),                                // 2x1
+        Layout.Elem(BoxNode(1.x, 1.y, 5, 3, children = Nil)), // 5x3
+        Layout.Elem(tn("xy"))                                 // 2x1
+      )
+    )
+    // width = max(2,5,2) = 5, height = 1 + 3 + 1 + 2*(3-1) = 9
+    assert(c.measure == (5, 9))
+
+  test("single-child container emits no gap"):
+    assert(Layout.Row(gap = 10, children = List(tn("abc").asLayout)).measure == (3, 1))
+    assert(Layout.Column(gap = 10, children = List(tn("abc").asLayout)).measure == (3, 1))
+
+  test("negative gap is clamped to zero"):
+    val r = Layout.Row(gap = -5, children = List(tn("ab").asLayout, tn("cd").asLayout))
+    assert(r.measure == (4, 1))
+
+  // --- resolve -----------------------------------------------------------
+
+  test("Elem.resolve shifts an authored-at-(1,1) node to the requested origin"):
+    val placed = Layout.Elem(tn("AB")).resolve(Coord(5.x, 3.y))
+    assert(placed.size == 1)
+    assert(placed.head.x.value == 5)
+    assert(placed.head.y.value == 3)
+
+  test("Elem.resolve at (1,1) is an identity for nodes authored at (1,1)"):
+    val node   = tn("hi")
+    val placed = Layout.Elem(node).resolve(Coord(1.x, 1.y))
+    assert(placed == List(node))
+
+  test("Elem.resolve translates a node authored at non-(1,1) to the container slot"):
+    val node   = TextNode(3.x, 2.y, List(Text("X", Style())))
+    val placed = Layout.Elem(node).resolve(Coord(7.x, 5.y))
+    // dx = 7-3 = 4, dy = 5-2 = 3 => landed at (7, 5)
+    assert(placed.head.x.value == 7)
+    assert(placed.head.y.value == 5)
+
+  test("Elem.resolve preserves BoxNode child offsets when translating"):
+    val inner  = TextNode(11.x, 6.y, List(Text("i", Style())))
+    val box    = BoxNode(10.x, 5.y, 4, 2, children = List(inner))
+    val placed = Layout.Elem(box).resolve(Coord(1.x, 1.y))
+    assert(placed.size == 1)
+    val p = placed.head.asInstanceOf[BoxNode]
+    assert(p.x.value == 1 && p.y.value == 1)
+    // Inner was at (11, 6), offset (+1, +1) from box. After translation it
+    // should still be (+1, +1) from the new box origin => (2, 2).
+    val pi = p.children.head
+    assert(pi.x.value == 2 && pi.y.value == 2)
+
+  test("Row.resolve places children left-to-right with gap"):
+    val r = Layout.Row(
+      gap = 1,
+      children = List(
+        tn("AB").asLayout,
+        tn("CD").asLayout,
+        tn("E").asLayout
+      )
+    )
+    val placed = r.resolve(Coord(1.x, 1.y))
+    assert(placed.size == 3)
+    // AB at 1..2, gap at 3, CD at 4..5, gap at 6, E at 7
+    assert(placed(0).x.value == 1)
+    assert(placed(1).x.value == 4)
+    assert(placed(2).x.value == 7)
+    assert(placed.forall(_.y.value == 1))
+
+  test("Column.resolve places children top-to-bottom with gap"):
+    val c = Layout.Column(
+      gap = 2,
+      children = List(
+        tn("first").asLayout,
+        tn("second").asLayout,
+        tn("third").asLayout
+      )
+    )
+    val placed = c.resolve(Coord(4.x, 2.y))
+    // rows are 1 tall each, gap of 2 between them
+    assert(placed(0).y.value == 2)
+    assert(placed(1).y.value == 5)
+    assert(placed(2).y.value == 8)
+    assert(placed.forall(_.x.value == 4))
+
+  test("Spacer.resolve produces no VNodes but Row/Column still account for its width"):
+    val r = Layout.Row(
+      gap = 0,
+      children = List(
+        tn("A").asLayout,
+        Layout.Spacer(3, 1),
+        tn("B").asLayout
+      )
+    )
+    val placed = r.resolve(Coord(1.x, 1.y))
+    assert(placed.size == 2)
+    // A at 1, spacer at 2..4 (not rendered), B at 5
+    assert(placed(0).x.value == 1)
+    assert(placed(1).x.value == 5)
+
+  test("nested Row inside Column resolves each container at its slot"):
+    val layout = Layout.Column(
+      gap = 0,
+      children = List(
+        tn("top").asLayout,
+        Layout.Row(
+          gap = 1,
+          children = List(
+            tn("L").asLayout,
+            tn("R").asLayout
+          )
+        )
+      )
+    )
+    val placed = layout.resolve(Coord(1.x, 1.y))
+    assert(placed.size == 3)
+    // top at (1,1)
+    assert(placed(0).x.value == 1 && placed(0).y.value == 1)
+    // L at (1,2) — row starts at y=2, x=1
+    assert(placed(1).x.value == 1 && placed(1).y.value == 2)
+    // R at (3,2) — L is 1 wide + 1 gap
+    assert(placed(2).x.value == 3 && placed(2).y.value == 2)
+
+  test("empty Row/Column resolve to the empty list"):
+    assert(Layout.Row(gap = 3, children = Nil).resolve(Coord(1.x, 1.y)).isEmpty)
+    assert(Layout.Column(gap = 3, children = Nil).resolve(Coord(1.x, 1.y)).isEmpty)
+
+  // --- fluent constructors ----------------------------------------------
+
+  test("Layout.row and Layout.column auto-wrap VNodes"):
+    val r = Layout.row(gap = 1)(tn("A"), tn("B"))
+    assert(r.measure == (3, 1))
+
+    val c = Layout.column(gap = 0)(tn("A"), tn("B"))
+    assert(c.measure == (1, 2))
+
+  test("Layout.row clamps negative gap to zero"):
+    val r = Layout.row(gap = -1)(tn("A"), tn("B"))
+    assert(r.measure == (2, 1))
+
+  // --- toRootNode -------------------------------------------------------
+
+  test("toRootNode wraps resolve output in a RootNode with the given dimensions"):
+    val layout = Layout.row(gap = 1)(tn("A"), tn("B"))
+    val root   = layout.toRootNode(width = 40, height = 3)
+    assert(root.width == 40 && root.height == 3)
+    assert(root.children.size == 2)
+    assert(root.input.isEmpty)
+
+  // --- end-to-end integration -------------------------------------------
+
+  test("a resolved layout renders as expected through AnsiRenderer.buildFrame"):
+    // Build a Row("AB", "CD") at (1,1), render, assert cell contents.
+    val root                   = Layout.row(gap = 1)(tn("AB"), tn("CD")).toRootNode(width = 10, height = 1)
+    val frame                  = AnsiRenderer.buildFrame(root)
+    def charAt(x: Int, y: Int) = frame.cells(y - 1)(x - 1).ch
+    assert(charAt(1, 1) == 'A')
+    assert(charAt(2, 1) == 'B')
+    assert(charAt(3, 1) == ' ') // gap
+    assert(charAt(4, 1) == 'C')
+    assert(charAt(5, 1) == 'D')
+
+  test("a nested Column containing a Row renders at the right coordinates"):
+    val root = Layout.column(gap = 0)(
+      tn("top")
+    ) match
+      case Layout.Column(g, cs) =>
+        // Compose via ADT to include a Row child.
+        val full = Layout.Column(
+          g,
+          cs ++ List(
+            Layout.Row(gap = 1, children = List(tn("L").asLayout, tn("R").asLayout))
+          )
+        )
+        full.toRootNode(width = 10, height = 2)
+      case _ => fail("expected a Column")
+
+    val frame = AnsiRenderer.buildFrame(root)
+    // top: row 1, cols 1..3
+    assert(frame.cells(0)(0).ch == 't')
+    assert(frame.cells(0)(1).ch == 'o')
+    assert(frame.cells(0)(2).ch == 'p')
+    // row 2: L at col 1, gap at col 2, R at col 3
+    assert(frame.cells(1)(0).ch == 'L')
+    assert(frame.cells(1)(1).ch == ' ')
+    assert(frame.cells(1)(2).ch == 'R')


### PR DESCRIPTION
Closes #77.

**Stacked on #86 → #85 → #84.** Base branch is \`feature/80-semantic-theming\`, so the GitHub diff shows only the two new layout files.

## Summary

- New \`Layout\` ADT with \`Elem\`, \`Row\`, \`Column\`, \`Spacer\` variants
- Fluent constructors (\`Layout.row(gap)(vnodes*)\`, \`Layout.column(gap)(vnodes*)\`) plus a \`VNode.asLayout\` extension
- \`layout.toRootNode(width, height, input)\` sugar for the common \"resolve at (1,1) and wrap\" case
- 24 unit tests including an end-to-end integration test that builds a layout, renders through \`AnsiRenderer.buildFrame\`, and asserts on cell-grid contents
- **Zero changes to \`VNode\`, \`TuiApp\`, \`TuiRuntime\`, or the renderer** — purely additive; apps opt in

This is the biggest-visible-impact issue in the recent batch, and exactly the kind of change the testkit in #84 was built to keep safe. The full regression suite (145 tests pre-PR, 169 post-PR) stays green.

## Design

### Approach: view-time resolution

The issue allowed the layout pass to live either in \`TuiRuntime\` or in a dedicated \`Layout.scala\`. I chose view-time resolution:

\`\`\`scala
override def view(m: Model): RootNode =
  Layout.column(gap = 1)(
    TextNode(1.x, 1.y, List(Text(\"Status: ready\", Style(fg = Color.Green)))),
    Layout.row(gap = 2)(
      TextNode(1.x, 1.y, List(Text(\"A\", Style()))),
      TextNode(1.x, 1.y, List(Text(\"B\", Style()))),
      TextNode(1.x, 1.y, List(Text(\"C\", Style())))
    ).asLayout
  ).toRootNode(width = m.terminalWidth, height = m.terminalHeight)
\`\`\`

- The renderer still consumes absolute-positioned \`VNode\`s. Apps that don't use \`Layout\` are completely unaffected.
- No need to change \`TuiApp.view\`'s return type, \`TuiRuntime\`'s loop, or \`AnsiRenderer\`.
- Swapping \`TuiRuntime\` to do layout before \`render\` is a future, backward-compatible migration if we ever want that.

### Elem translation rule

\`Layout.Elem(vnode)\` wraps a \`VNode\` authored with its own absolute coords (typically \`(1.x, 1.y)\`). The resolver translates the wrapped node — and any \`BoxNode\` descendants — so its origin aligns with the container's chosen slot. Relative offsets inside a box are preserved. A dedicated test (\"Elem.resolve preserves BoxNode child offsets when translating\") pins this behaviour.

### Measure semantics

| Case | width | height |
|---|---|---|
| \`Elem(v)\` | \`measureVNode(v)\` | \`measureVNode(v)\` |
| \`Row(gap, cs)\` | \`sum(childWidths) + gap*(n-1)\` | \`max(childHeights)\` |
| \`Column(gap, cs)\` | \`max(childWidths)\` | \`sum(childHeights) + gap*(n-1)\` |
| \`Spacer(w, h)\` | \`max(0, w)\` | \`max(0, h)\` |
| empty \`Row\`/\`Column\` | \`0\` | \`0\` |

Single-child containers emit no gap. Negative gaps clamp to zero.

### Why \`Spacer\`

Handy for padding-like effects without a full \`Padded\` wrapper: \`Row(0, [Elem(a), Spacer(4, 1), Elem(b)])\` puts \`b\` four cells to the right of \`a\`. No render output — it's purely positional. Could also be used to right-align a sibling inside a \`Row\` by sizing the spacer to \`containerWidth - otherChildrenWidth\`.

## Test plan

- [x] 24 new tests in \`LayoutSpec\`:
  - \`measureVNode\` for each \`VNode\` variant
  - \`Elem\` / \`Spacer\` measure, including clamped negatives
  - Empty, single-child, and multi-child \`Row\` / \`Column\` measure
  - Negative-gap clamping
  - \`Elem.resolve\` identity, translation, and \`BoxNode\`-child preservation
  - \`Row.resolve\` / \`Column.resolve\` placement with gap
  - \`Spacer.resolve\` produces no nodes but still accounts for width
  - Nested \`Row\` inside \`Column\` coordinate verification
  - Fluent \`Layout.row\` / \`Layout.column\` with auto-wrapping
  - \`toRootNode\` wrapping behaviour
  - **End-to-end**: layout → \`AnsiRenderer.buildFrame\` → cell-grid assertions for both a flat \`Row\` and a nested \`Column(top, Row(L, R))\`
- [x] \`sbt ciCheck\` green — scalafmt + scalafix + 169 tests passing
- [x] \`sbt termflow/doc\` regenerates cleanly (only the pre-existing \`-classpath\` warning remains)

## Out of scope (per the issue)

- Alignment / justification
- \`Flex\` weights (grow / shrink / basis)
- Padding wrappers
- Clipping / overflow handling
- Z-ordering
- Sample-app refactor (e.g. \`TabsDemoApp\` → \`Layout\`) — deferred to a follow-up so this PR stays additive and easy to review. Those refactors will also serve as regression tests once the sample snapshot suites are updated.