### PR TITLE
Add widget library first cut: Button, ProgressBar, Spinner, StatusBar

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Button.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Button.scala
@@ -1,0 +1,50 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Inline-styled button rendered as `[ Label ]`.
+ *
+ * Focus is communicated through colour and boldness: an unfocused button uses
+ * the theme's `foreground` slot, a focused button uses `primary` and bolds
+ * the label. The shape of the widget doesn't change on focus, so siblings
+ * don't have to reflow when focus moves.
+ *
+ * Natural width is `label.length + 4`. Height is always `1`.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Layout.row(gap = 2)(
+ *   Button(label = "Save",   focused = true),
+ *   Button(label = "Cancel", focused = false)
+ * )
+ * }}}
+ *
+ * The returned node is authored at `(1.x, 1.y)` so it composes cleanly with
+ * [[Layout]]. To place it directly inside a `RootNode`, pass an explicit
+ * `at` coordinate or translate the result with `Layout.translate`.
+ *
+ * @param label Button label. Rendered as-is (no truncation).
+ * @param focused Whether the button currently owns focus.
+ * @param at Top-left cell. Defaults to `(1, 1)` for use inside a layout.
+ */
+object Button:
+  def apply(
+    label: String,
+    focused: Boolean = false,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  )(using theme: Theme): VNode =
+    val fg = if focused then theme.primary else theme.foreground
+    TextNode(
+      at.x,
+      at.y,
+      List(
+        "[ ".text(fg = fg),
+        Text(label, Style(fg = fg, bold = focused)),
+        " ]".text(fg = fg)
+      )
+    )
+
+  /** Natural width of a button rendering `label`. */
+  def width(label: String): Int = label.length + 4

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/ProgressBar.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/ProgressBar.scala
@@ -1,0 +1,53 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Horizontal determinate progress bar.
+ *
+ * Renders as a filled portion (`█`) in the theme's `primary` slot followed
+ * by an empty tail (`░`) in `foreground`, optionally suffixed with a
+ * right-aligned percentage.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * ProgressBar(value = 0.75, width = 20)
+ * // ████████████████░░░░  75%
+ * }}}
+ *
+ * @param value       Progress in `[0.0, 1.0]`. Values outside the range are clamped.
+ * @param width       Number of cells used by the bar itself (before the optional percentage).
+ * @param showPercent If `true`, append `"  NN%"`. Default `true`.
+ * @param at          Top-left cell. Defaults to `(1, 1)` for layout composition.
+ *
+ * Height is always `1`. Natural width is `width + 5` when `showPercent`, else
+ * `width`. Use [[ProgressBar.renderedWidth]] to size sibling layouts.
+ */
+object ProgressBar:
+
+  private val FilledChar = '█'
+  private val EmptyChar  = '░'
+
+  def apply(
+    value: Double,
+    width: Int,
+    showPercent: Boolean = true,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  )(using theme: Theme): VNode =
+    val clamped    = math.max(0.0, math.min(1.0, value))
+    val safeW      = math.max(0, width)
+    val filled     = math.round(clamped * safeW).toInt
+    val empty      = math.max(0, safeW - filled)
+    val filledText = if filled > 0 then FilledChar.toString * filled else ""
+    val emptyText  = if empty > 0 then EmptyChar.toString * empty else ""
+    val percent    = f" ${clamped * 100}%3.0f%%"
+    val segments = List(
+      filledText.text(fg = theme.primary),
+      emptyText.text(fg = theme.foreground)
+    ) ++ (if showPercent then List(percent.text(fg = theme.foreground)) else Nil)
+    TextNode(at.x, at.y, segments)
+
+  /** Natural width of a progress bar with the given settings. */
+  def renderedWidth(width: Int, showPercent: Boolean = true): Int =
+    math.max(0, width) + (if showPercent then 5 else 0)

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Spinner.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Spinner.scala
@@ -1,0 +1,46 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Indeterminate progress indicator.
+ *
+ * The app drives the animation by incrementing an integer frame counter and
+ * passing it to the widget — typically from a `Sub.Every` tick. The widget
+ * is purely presentational.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Spinner(Spinner.Braille, frame = model.tick)
+ * }}}
+ *
+ * Several frame sets are provided as constants on the companion:
+ *
+ *   - [[Spinner.Braille]] — smooth rotating braille dots
+ *   - [[Spinner.Line]]    — classic ASCII `|/-\`
+ *   - [[Spinner.Dots]]    — three-dot ellipsis walk
+ *
+ * @param frames Ordered frame strings. Must be non-empty; the widget cycles through them via `frame % frames.size`.
+ * @param frame  Current animation tick. Any non-negative integer; taken modulo `frames.size`.
+ * @param at     Top-left cell. Defaults to `(1, 1)` for layout composition.
+ */
+object Spinner:
+
+  val Braille: Vector[String] = Vector("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+  val Line: Vector[String]    = Vector("|", "/", "-", "\\")
+  val Dots: Vector[String]    = Vector(".  ", ".. ", "...", " ..", "  .", "   ")
+
+  def apply(
+    frames: Vector[String],
+    frame: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  )(using theme: Theme): VNode =
+    require(frames.nonEmpty, "Spinner.frames must be non-empty")
+    val idx = ((frame % frames.size) + frames.size) % frames.size
+    val ch  = frames(idx)
+    TextNode(at.x, at.y, List(ch.text(fg = theme.primary)))
+
+  /** Width of the current frame in a spinner set. Frames may be multi-cell (e.g. [[Dots]]). */
+  def width(frames: Vector[String]): Int =
+    if frames.isEmpty then 0 else frames.map(_.length).max

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/StatusBar.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/StatusBar.scala
@@ -1,0 +1,91 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Bottom-of-screen status bar with left / center / right sections.
+ *
+ * Produces a single-row `TextNode` exactly `width` cells wide. The three
+ * sections are placed independently:
+ *
+ *   - left  — flush to the left edge
+ *   - center — centered within the row
+ *   - right — flush to the right edge
+ *
+ * If sections overlap because the row is too narrow, the renderer drops
+ * sections in priority order `right → center → left`. An oversized `left`
+ * is truncated to fit.
+ *
+ * The bar uses the theme's `primary` colour as its background and
+ * `background` as the foreground by default — the classic "inverse-video
+ * status line" look. Override the styling by constructing the `TextNode`
+ * directly if you need something bespoke.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * StatusBar(
+ *   left   = " ready",
+ *   center = "editor.scala",
+ *   right  = "L:42 ",
+ *   width  = model.terminalWidth,
+ *   at     = Coord(1.x, (model.terminalHeight).y)
+ * )
+ * }}}
+ */
+object StatusBar:
+
+  def apply(
+    left: String,
+    center: String,
+    right: String,
+    width: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  )(using theme: Theme): VNode =
+    val row   = renderString(left, center, right, math.max(0, width))
+    val style = Style(fg = theme.background, bg = theme.primary)
+    TextNode(at.x, at.y, List(Text(row, style)))
+
+  /**
+   * Compose the three sections into a single padded string of length `width`.
+   *
+   * Exposed for tests and for callers that want to apply custom styling
+   * rather than going through [[apply]].
+   */
+  def renderString(left: String, center: String, right: String, width: Int): String =
+    if width <= 0 then ""
+    else
+      val buf = Array.fill(width)(' ')
+
+      // Left section truncated to total width.
+      val leftFit = if left.length > width then left.take(width) else left
+      var i       = 0
+      while i < leftFit.length do
+        buf(i) = leftFit.charAt(i)
+        i += 1
+
+      // Right section only if it doesn't overlap with left.
+      val rightFit =
+        if right.length > math.max(0, width - leftFit.length) then ""
+        else right
+      if rightFit.nonEmpty then
+        val start = width - rightFit.length
+        var j     = 0
+        while j < rightFit.length do
+          buf(start + j) = rightFit.charAt(j)
+          j += 1
+
+      // Center section only if it fits in the gap.
+      val used      = leftFit.length + rightFit.length
+      val available = math.max(0, width - used)
+      val centerFit = if center.length > available then "" else center
+      if centerFit.nonEmpty then
+        val start = math.max(leftFit.length, (width - centerFit.length) / 2)
+        val clampedStart =
+          math.min(start, width - rightFit.length - centerFit.length)
+        var k = 0
+        while k < centerFit.length do
+          buf(clampedStart + k) = centerFit.charAt(k)
+          k += 1
+
+      new String(buf)

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/ButtonSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/ButtonSpec.scala
@@ -1,0 +1,43 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class ButtonSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  test("Button.width reports label length plus padding"):
+    assert(Button.width("OK") == 6)
+    assert(Button.width("") == 4)
+
+  test("unfocused Button renders [ label ] in the theme foreground"):
+    val v     = Button("OK", focused = false)
+    val cells = AnsiRenderer.buildFrame(RootNode(Button.width("OK"), 1, List(v), None)).cells
+    val row   = (0 until 6).map(c => cells(0)(c).ch).mkString
+    assert(row == "[ OK ]")
+    // Label cell uses theme.foreground, not primary, when unfocused.
+    assert(cells(0)(2).style.fg == Theme.dark.foreground)
+    assert(!cells(0)(2).style.bold)
+
+  test("focused Button paints the label bold and in theme.primary"):
+    val v     = Button("Save", focused = true)
+    val cells = AnsiRenderer.buildFrame(RootNode(Button.width("Save"), 1, List(v), None)).cells
+    // Cell at column 3 (1-based) holds the 'S' of "Save"
+    val labelCell = cells(0)(2)
+    assert(labelCell.ch == 'S')
+    assert(labelCell.style.fg == Theme.dark.primary)
+    assert(labelCell.style.bold)
+
+  test("Button composes inside Layout.row with the natural width"):
+    val buttons = Layout.row(gap = 1)(
+      Button("A", focused = true),
+      Button("BB", focused = false)
+    )
+    // widths: 5 + 1 + 6 = 12
+    assert(buttons.measure == (12, 1))
+    val placed = buttons.resolve(Coord(1.x, 1.y))
+    assert(placed.size == 2)
+    assert(placed(0).x.value == 1)
+    assert(placed(1).x.value == 7) // "[ A ]" is 5 wide, + 1 gap, so next at 7

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/ProgressBarSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/ProgressBarSpec.scala
@@ -1,0 +1,59 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class ProgressBarSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private def rowChars(vnode: VNode, totalWidth: Int): String =
+    val root  = RootNode(totalWidth, 1, List(vnode), None)
+    val frame = AnsiRenderer.buildFrame(root)
+    (0 until frame.width).map(c => frame.cells(0)(c).ch).mkString
+
+  test("ProgressBar.renderedWidth accounts for the percent suffix"):
+    assert(ProgressBar.renderedWidth(10, showPercent = true) == 15)
+    assert(ProgressBar.renderedWidth(10, showPercent = false) == 10)
+
+  test("zero progress produces all empty cells"):
+    val v   = ProgressBar(value = 0.0, width = 5, showPercent = false)
+    val row = rowChars(v, 5)
+    assert(row == "░░░░░")
+
+  test("full progress produces all filled cells"):
+    val v   = ProgressBar(value = 1.0, width = 5, showPercent = false)
+    val row = rowChars(v, 5)
+    assert(row == "█████")
+
+  test("mid progress splits the bar proportionally"):
+    val v   = ProgressBar(value = 0.5, width = 4, showPercent = false)
+    val row = rowChars(v, 4)
+    assert(row.count(_ == '█') == 2)
+    assert(row.count(_ == '░') == 2)
+
+  test("values outside [0, 1] are clamped"):
+    val neg = ProgressBar(value = -0.2, width = 4, showPercent = false)
+    assert(rowChars(neg, 4) == "░░░░")
+    val big = ProgressBar(value = 2.0, width = 4, showPercent = false)
+    assert(rowChars(big, 4) == "████")
+
+  test("filled cells use theme.primary and empty cells use theme.foreground"):
+    val v     = ProgressBar(value = 0.5, width = 4, showPercent = false)
+    val cells = AnsiRenderer.buildFrame(RootNode(4, 1, List(v), None)).cells
+    assert(cells(0)(0).style.fg == Theme.dark.primary)
+    assert(cells(0)(1).style.fg == Theme.dark.primary)
+    assert(cells(0)(2).style.fg == Theme.dark.foreground)
+    assert(cells(0)(3).style.fg == Theme.dark.foreground)
+
+  test("percent suffix is rendered when showPercent=true"):
+    val v   = ProgressBar(value = 0.25, width = 4, showPercent = true)
+    val row = rowChars(v, ProgressBar.renderedWidth(4))
+    // 25% → 1 filled, 3 empty, plus " 25%"
+    assert(row == "█░░░  25%")
+
+  test("ProgressBar composes inside Layout.row with measured width"):
+    val bar = ProgressBar(value = 0.5, width = 10, showPercent = true)
+    val lay = Layout.row(gap = 0)(bar)
+    assert(lay.measure == (15, 1))

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/SpinnerSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/SpinnerSpec.scala
@@ -1,0 +1,49 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+
+class SpinnerSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private def firstChar(v: VNode): Char =
+    AnsiRenderer.buildFrame(RootNode(1, 1, List(v), None)).cells(0)(0).ch
+
+  test("frame index cycles modulo the frame count"):
+    val v0 = Spinner(Spinner.Line, frame = 0)
+    val v4 = Spinner(Spinner.Line, frame = 4)
+    val v8 = Spinner(Spinner.Line, frame = 8)
+    assert(firstChar(v0) == firstChar(v4)) // 0 mod 4 = 4 mod 4 = 0
+    assert(firstChar(v4) == firstChar(v8))
+
+  test("frame advances between consecutive ticks"):
+    val a = firstChar(Spinner(Spinner.Line, frame = 0))
+    val b = firstChar(Spinner(Spinner.Line, frame = 1))
+    assert(a != b)
+
+  test("negative frames are handled by wrapping into range"):
+    val v = Spinner(Spinner.Line, frame = -1)
+    // -1 maps to index 3 (the last frame)
+    assert(firstChar(v) == Spinner.Line(3).charAt(0))
+
+  test("empty frames set is rejected with a clear error"):
+    val ex = intercept[IllegalArgumentException] {
+      Spinner(Vector.empty, frame = 0)
+    }
+    assert(ex.getMessage.contains("must be non-empty"))
+
+  test("Spinner uses theme.primary for the frame character"):
+    val v     = Spinner(Spinner.Line, frame = 0)
+    val cells = AnsiRenderer.buildFrame(RootNode(1, 1, List(v), None)).cells
+    assert(cells(0)(0).style.fg == Theme.dark.primary)
+
+  test("Spinner.width reports the widest frame in a set"):
+    assert(Spinner.width(Spinner.Line) == 1)
+    assert(Spinner.width(Spinner.Dots) == 3)
+    assert(Spinner.width(Vector.empty) == 0)
+
+  test("braille spinner renders the expected character for a known frame"):
+    val v     = Spinner(Spinner.Braille, frame = 3)
+    val cells = AnsiRenderer.buildFrame(RootNode(1, 1, List(v), None)).cells
+    assert(cells(0)(0).ch == Spinner.Braille(3).charAt(0))

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/StatusBarSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/StatusBarSpec.scala
@@ -1,0 +1,54 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+
+class StatusBarSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  test("renderString places left, center, and right sections"):
+    val row = StatusBar.renderString(left = "LEFT", center = "MID", right = "RIGHT", width = 20)
+    assert(row.length == 20)
+    assert(row.startsWith("LEFT"))
+    assert(row.endsWith("RIGHT"))
+    // Center 'M' lands near the middle.
+    val midIdx = row.indexOf('M')
+    assert(midIdx >= 6 && midIdx <= 10)
+
+  test("center section is dropped when it won't fit"):
+    // left(4) + right(5) = 9, leaves 1 cell for center — "MID"(3) doesn't fit.
+    val row = StatusBar.renderString("LEFT", "MID", "RIGHT", width = 10)
+    assert(row.length == 10)
+    assert(row.startsWith("LEFT"))
+    assert(row.endsWith("RIGHT"))
+    assert(!row.contains("MID"))
+
+  test("right section is dropped when it overlaps with left"):
+    val row = StatusBar.renderString("LEFTTOOLONG", "", "RIGHT", width = 12)
+    assert(row.length == 12)
+    // "RIGHT" needs 5, but only 1 cell remains → dropped
+    assert(!row.contains("RIGHT"))
+
+  test("left section is truncated when wider than the total row"):
+    val row = StatusBar.renderString("VERYLONGLEFT", "", "", width = 5)
+    assert(row == "VERYL")
+
+  test("zero or negative width returns an empty string"):
+    assert(StatusBar.renderString("a", "b", "c", width = 0) == "")
+    assert(StatusBar.renderString("a", "b", "c", width = -1) == "")
+
+  test("StatusBar colours the row with theme.primary background"):
+    val v     = StatusBar("ready", "editor", "12:34", width = 30)
+    val cells = AnsiRenderer.buildFrame(RootNode(30, 1, List(v), None)).cells
+    // Spot-check a cell that should be painted (the 'r' of "ready").
+    val first = cells(0)(0)
+    assert(first.ch == 'r')
+    assert(first.style.bg == Theme.dark.primary)
+    assert(first.style.fg == Theme.dark.background)
+
+  test("StatusBar composes into a RootNode for full-frame tests"):
+    val v     = StatusBar("a", "", "b", width = 5)
+    val frame = AnsiRenderer.buildFrame(RootNode(5, 1, List(v), None))
+    val row   = (0 until 5).map(c => frame.cells(0)(c).ch).mkString
+    assert(row == "a   b")


### PR DESCRIPTION
Partially closes #81 (first cut; see \"Deferred\" below).

**Stacked on #87 → #86 → #85 → #84.** Base branch is \`feature/77-layout-primitives\`; the GitHub diff shows only the 8 new widget files.

## Summary

New \`termflow.tui.widgets\` package with four theme-aware, stateless widgets that return \`VNode\`s authored at \`(1, 1)\` so they compose directly with the layout DSL from #87:

- **Button** — inline \`[ label ]\` form. Focus switches between \`theme.foreground\` and bolded \`theme.primary\` without changing the widget's shape, so siblings don't reflow on focus moves.
- **ProgressBar** — horizontal bar with filled (\`theme.primary\`) and empty (\`theme.foreground\`) cells, optional \`\"  NN%\"\` suffix. Clamps out-of-range values.
- **Spinner** — single-glyph animated indicator cycling through user-supplied frames. Built-in sets: \`Spinner.Braille\`, \`Spinner.Line\`, \`Spinner.Dots\`.
- **StatusBar** — inverse-video row (\`theme.primary\` bg, \`theme.background\` fg) with left / center / right sections and graceful overflow priority.

Every widget takes a \`given Theme\`, so swapping palettes is a single binding change. \`Theme.mono\` produces uncoloured output which is handy for tests.

## Composition example

\`\`\`scala
import termflow.tui.*
import termflow.tui.TuiPrelude.*
import termflow.tui.widgets.*

given Theme = Theme.dark

override def view(m: Model): RootNode =
  Layout.column(gap = 1)(
    StatusBar(\" ready\", m.filename, f\"L:\${m.line}\", width = m.terminalWidth),
    Layout.row(gap = 2)(
      Spinner(Spinner.Braille, frame = m.tick),
      ProgressBar(m.progress, width = 20)
    ).asLayout,
    Layout.row(gap = 2)(
      Button(\"Save\",   focused = m.focus == Focus.Save),
      Button(\"Cancel\", focused = m.focus == Focus.Cancel)
    ).asLayout
  ).toRootNode(width = m.terminalWidth, height = m.terminalHeight)
\`\`\`

## Design choices

- **Stateless, VNode-returning.** No widget owns state. Apps pass in the relevant slice of their model (focus flag, progress value, spinner tick) and the widget renders. This keeps widgets composable inside \`Layout\` and avoids duplicating the Elm architecture inside the widget library.
- **Authored at \`(1, 1)\`.** Matches the convention established by \`Layout.Elem\` in #87 — so a widget can be dropped straight into \`Layout.row\` / \`column\` without positional arithmetic.
- **Helpers for natural width.** \`Button.width(label)\`, \`ProgressBar.renderedWidth(width, showPercent)\`, and \`Spinner.width(frames)\` expose the measured dimensions that the \`Layout\` DSL will read, so callers can size surrounding boxes if needed.

## Test plan

- [x] 26 new tests across \`ButtonSpec\`, \`ProgressBarSpec\`, \`SpinnerSpec\`, \`StatusBarSpec\` — each exercises both the widget API (widths, clamping, error cases) and the rendered cell-grid output through \`AnsiRenderer.buildFrame\`.
- [x] Layout composition verified for \`Button\` (in a \`Layout.row\`) and \`ProgressBar\` (measured width matches the layout's natural width).
- [x] \`sbt ciCheck\` green — scalafmt + scalafix + **195 tests total** (169 termflow + 26 sample).
- [x] \`sbt termflow/doc\` regenerates cleanly (only the pre-existing \`-classpath\` warning remains).

## Deferred (follow-up PRs)

The issue proposes 6–8 widgets; this PR ships the four purely stateless ones. The stateful widgets are deferred because they need more design work:

- **TextField** — wants to integrate with the existing \`Prompt\` / \`Sub.InputKey\` infrastructure. Needs a decision on how widgets surface their own \`Msg\`s back to the app's update function.
- **List / Select** — require scrolling state and a focus index. Composes with a future focus-management PR (#82).
- **Table** — wants column definitions with alignment and width strategies; worth its own focused PR.

These follow-ups will build on this PR's pattern (theme-aware, \`given\`-based, authored at \`(1, 1)\`) for consistency. The issue can be treated as partially closed — I'll re-file the deferred widgets as follow-ups if that suits you, or leave the issue open as a tracker.