### PR TITLE
Add widgets demo app exercising Layout + Theme + widgets

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/widgets/WidgetsDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/widgets/WidgetsDemoApp.scala
@@ -1,0 +1,215 @@
+package termflow.apps.widgets
+
+import termflow.tui.*
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+import termflow.tui.widgets.*
+
+/**
+ * End-to-end demo of the `termflow.tui.widgets` package.
+ *
+ * Drives [[Button]], [[ProgressBar]], [[Spinner]], and [[StatusBar]]
+ * through a `Layout.column` + `Layout.row` composition, using a `given
+ * Theme` that the user can toggle at runtime.
+ *
+ * ## Keys
+ *
+ *   - `Tab` / `Shift+Tab` — cycle button focus
+ *   - `Enter` / `Space`   — activate the focused button
+ *   - `t`                 — toggle dark / light theme
+ *   - `+` / `-`           — nudge progress by ±10 %
+ *   - `q` / `Ctrl+C`      — quit
+ *
+ * The spinner and progress bar are driven by a `Sub.Every` timer so they
+ * animate on their own.
+ *
+ * Run with:
+ * {{{
+ *   sbt "termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp"
+ * }}}
+ */
+object WidgetsDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  enum Focus:
+    case Save, Cancel
+
+  enum Msg:
+    case Tick
+    case NextFocus
+    case PrevFocus
+    case Activate
+    case ToggleTheme
+    case BumpProgress(delta: Double)
+    case ConsoleInputKey(key: KeyDecoder.InputKey)
+    case ConsoleInputError(error: Throwable)
+    case Quit
+
+  final case class Model(
+    terminalWidth: Int,
+    terminalHeight: Int,
+    tick: Int,
+    progress: Double,
+    focus: Focus,
+    darkTheme: Boolean,
+    lastAction: String
+  )
+
+  import Msg.*
+
+  object App extends TuiApp[Model, Msg]:
+
+    private def syncTerminalSize(m: Model, ctx: RuntimeCtx[Msg]): Model =
+      val w = ctx.terminal.width
+      val h = ctx.terminal.height
+      if w == m.terminalWidth && h == m.terminalHeight then m
+      else m.copy(terminalWidth = w, terminalHeight = h)
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      // Spinner / progress animation.
+      Sub.Every(millis = 120L, msg = () => Tick, sink = ctx)
+      // Keyboard input. We don't use Prompt here — keys are handled directly.
+      Sub.InputKey(ConsoleInputKey.apply, ConsoleInputError.apply, ctx)
+      Model(
+        terminalWidth = ctx.terminal.width,
+        terminalHeight = ctx.terminal.height,
+        tick = 0,
+        progress = 0.0,
+        focus = Focus.Save,
+        darkTheme = true,
+        lastAction = "—"
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val sized = syncTerminalSize(m, ctx)
+      msg match
+        case Tick =>
+          val nextProgress =
+            if sized.progress >= 1.0 then 0.0
+            else math.min(1.0, sized.progress + 0.02)
+          sized.copy(tick = sized.tick + 1, progress = nextProgress).tui
+
+        case NextFocus =>
+          val nf = if sized.focus == Focus.Save then Focus.Cancel else Focus.Save
+          sized.copy(focus = nf).tui
+
+        case PrevFocus =>
+          // Two-button demo; prev and next are symmetric.
+          val nf = if sized.focus == Focus.Save then Focus.Cancel else Focus.Save
+          sized.copy(focus = nf).tui
+
+        case Activate =>
+          sized.copy(lastAction = s"clicked ${sized.focus}").tui
+
+        case ToggleTheme =>
+          sized.copy(darkTheme = !sized.darkTheme).tui
+
+        case BumpProgress(delta) =>
+          val next = math.max(0.0, math.min(1.0, sized.progress + delta))
+          sized.copy(progress = next).tui
+
+        case Quit =>
+          Tui(sized, Cmd.Exit)
+
+        case ConsoleInputKey(key) =>
+          keyToMsg(key) match
+            case Some(next) => update(sized, next, ctx)
+            case None       => sized.tui
+
+        case ConsoleInputError(e) =>
+          sized.copy(lastAction = s"input error: ${Option(e.getMessage).getOrElse("unknown")}").tui
+
+    private def keyToMsg(key: KeyDecoder.InputKey): Option[Msg] =
+      import KeyDecoder.InputKey.*
+      key match
+        // Tab arrives as Ctrl+I via the ASCII decoder.
+        case Ctrl('I')                   => Some(NextFocus)
+        case Enter | CharKey(' ')        => Some(Activate)
+        case CharKey('t') | CharKey('T') => Some(ToggleTheme)
+        case CharKey('+') | CharKey('=') => Some(BumpProgress(0.1))
+        case CharKey('-') | CharKey('_') => Some(BumpProgress(-0.1))
+        case CharKey('q') | CharKey('Q') => Some(Quit)
+        case Ctrl('C') | Escape          => Some(Quit)
+        case _                           => None
+
+    override def view(m: Model): RootNode =
+      given Theme = if m.darkTheme then Theme.dark else Theme.light
+      val theme   = summon[Theme]
+
+      val themeName  = if m.darkTheme then "dark" else "light"
+      val termWidth  = math.max(40, m.terminalWidth)
+      val termHeight = math.max(14, m.terminalHeight)
+      val barWidth   = math.max(10, math.min(40, termWidth - 12))
+
+      // Static caption line.
+      val title = TextNode(
+        1.x,
+        1.y,
+        List(Text("TermFlow Widget Demo", Style(fg = theme.primary, bold = true, underline = true)))
+      )
+
+      // Spinner + progress bar.
+      val spinnerAndBar = Layout.row(gap = 2)(
+        Spinner(Spinner.Braille, frame = m.tick),
+        ProgressBar(m.progress, width = barWidth)
+      )
+
+      // Button row with focus tracking.
+      val buttons = Layout.row(gap = 2)(
+        Button(label = "Save", focused = m.focus == Focus.Save),
+        Button(label = "Cancel", focused = m.focus == Focus.Cancel)
+      )
+
+      // Instructions + last-action feedback.
+      val keyHelp = TextNode(
+        1.x,
+        1.y,
+        List(
+          "Tab: focus   Enter/Space: activate   t: theme   +/-: nudge   q: quit".text(fg = theme.foreground)
+        )
+      )
+      val lastAction = TextNode(
+        1.x,
+        1.y,
+        List(Text(s"last action: ${m.lastAction}", Style(fg = theme.info)))
+      )
+
+      // Body column stacking title, animated row, button row, help, and last
+      // action. Uses the ADT form of `Column` so we can mix `Elem(vnode)`
+      // leaves with nested `Row` layouts in the same children list.
+      val column = Layout.Column(
+        gap = 1,
+        children = List(
+          Layout.Elem(title),
+          spinnerAndBar,
+          buttons,
+          Layout.Elem(keyHelp),
+          Layout.Elem(lastAction)
+        )
+      )
+      val columnChildren = column.resolve(Coord(2.x, 2.y))
+
+      // Inverse-video status bar pinned to the bottom row.
+      val statusRow = termHeight
+      val status = StatusBar(
+        left = " demo ",
+        center = s"theme=$themeName  tick=${m.tick}",
+        right = f" progress=${m.progress * 100}%3.0f%% ",
+        width = termWidth,
+        at = Coord(1.x, statusRow.y)
+      )
+
+      RootNode(
+        width = termWidth,
+        height = termHeight,
+        children = columnChildren :+ status,
+        input = None
+      )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      // This app drives input directly through ConsoleInputKey; `toMsg` is
+      // only called when a Prompt is present, which it isn't here.
+      Left(TermFlowError.CommandError(input.value))

--- a/modules/termflow-sample/src/main/scala/termflow/run/SampleSmoke.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/run/SampleSmoke.scala
@@ -42,4 +42,5 @@ object SampleSmoke:
     smokeApp("stress", termflow.apps.stress.RenderStressApp.App)
     smokeApp("tabs", termflow.apps.tabs.TabsDemoApp.App)
     smokeApp("input-line", termflow.apps.input.InputLineReproApp.App)
+    smokeApp("widgets-demo", termflow.apps.widgets.WidgetsDemoApp.App)
     Console.out.println("Sample smoke checks passed.")

--- a/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
@@ -1,0 +1,90 @@
+package termflow.apps.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.apps.widgets.WidgetsDemoApp.Focus
+import termflow.apps.widgets.WidgetsDemoApp.Msg
+import termflow.testkit.TuiTestDriver
+import termflow.tui.*
+
+/**
+ * Integration coverage for the widgets demo.
+ *
+ * Instead of full-frame golden snapshots — which would be flaky against the
+ * `Sub.Every` timer race in `init` (the scheduler fires its initial tick on a
+ * background thread before `TuiTestDriver` can cancel it) — this spec drives
+ * the demo synchronously and asserts on cell-level properties that are
+ * invariant to the tick count: which button is focused, what style the
+ * status row is painted in, and whether `Cmd.Exit` is observed on quit.
+ */
+class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
+
+  private val Width  = 80
+  private val Height = 14
+
+  private def driver(): TuiTestDriver[WidgetsDemoApp.Model, WidgetsDemoApp.Msg] =
+    val d = TuiTestDriver(WidgetsDemoApp.App, width = Width, height = Height)
+    d.init()
+    d
+
+  private def statusBg(d: TuiTestDriver[WidgetsDemoApp.Model, WidgetsDemoApp.Msg]): Color =
+    val frame = d.frame
+    // Status bar is the last row; the first cell of the " demo " tag is enough.
+    frame.cells(Height - 1)(1).style.bg
+
+  test("initial model is on Save focus and dark theme"):
+    val d = driver()
+    assert(d.model.focus == Focus.Save)
+    assert(d.model.darkTheme)
+    assert(statusBg(d) == Theme.dark.primary)
+
+  test("Msg.NextFocus flips the model focus"):
+    val d = driver()
+    d.send(Msg.NextFocus)
+    assert(d.model.focus == Focus.Cancel)
+    d.send(Msg.NextFocus)
+    assert(d.model.focus == Focus.Save)
+
+  test("Msg.Activate records the currently focused action"):
+    val d = driver()
+    d.send(Msg.NextFocus)
+    d.send(Msg.Activate)
+    assert(d.model.lastAction == "clicked Cancel")
+
+  test("Msg.ToggleTheme repaints the status row in the light palette"):
+    val d = driver()
+    assert(statusBg(d) == Theme.dark.primary)
+    d.send(Msg.ToggleTheme)
+    assert(!d.model.darkTheme)
+    assert(statusBg(d) == Theme.light.primary)
+
+  test("Msg.BumpProgress clamps to [0, 1]"):
+    val d  = driver()
+    val p0 = d.model.progress
+    d.send(Msg.BumpProgress(-1.0))
+    assert(d.model.progress == 0.0)
+    d.send(Msg.BumpProgress(5.0))
+    assert(d.model.progress == 1.0)
+    // Ensure the starting progress didn't prevent the clamp round-trip.
+    assert(p0 >= 0.0 && p0 <= 1.0)
+
+  test("Msg.Quit publishes Cmd.Exit"):
+    val d = driver()
+    d.send(Msg.Quit)
+    assert(d.exited)
+
+  test("button row reflects focus by painting Save bold when focused, Cancel plain"):
+    val d     = driver()
+    val frame = d.frame
+    // The buttons row is the third non-blank row in the layout; layout ordering
+    // is: title (row 2), spinner+bar (row 4), buttons (row 6). Locate 'S' of
+    // "Save" and 'C' of "Cancel" by scanning for them.
+    val rowIdx = (0 until frame.height).indexWhere { r =>
+      val s = (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString
+      s.contains("[ Save ]") && s.contains("[ Cancel ]")
+    }
+    assert(rowIdx >= 0, "expected a row containing both button labels")
+    val row    = frame.cells(rowIdx)
+    val savIdx = (0 until frame.width).find(c => row(c).ch == 'S').get
+    val canIdx = (0 until frame.width).find(c => row(c).ch == 'C').get
+    assert(row(savIdx).style.bold, "Save label should be bold (focused)")
+    assert(!row(canIdx).style.bold, "Cancel label should not be bold when Save is focused")

--- a/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
+++ b/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
@@ -60,7 +60,16 @@ final class TuiTestDriver[Model, Msg](
   def frame: RenderFrame =
     AnsiRenderer.buildFrame(app.view(model))
 
-  /** Call `app.init(ctx)`, store the initial model, and apply the startup `Cmd`. */
+  /**
+   * Call `app.init(ctx)`, store the initial model, and apply the startup `Cmd`.
+   *
+   * After init runs, every subscription the app registered (directly or via
+   * `Sub.*` factories) is cancelled and any commands they published in the
+   * meantime are dropped. This is necessary because some `Sub.*` factories —
+   * notably `Sub.Every` — start background schedulers inside their own
+   * constructors, before `registerSub` even runs; leaving them live would
+   * leak non-deterministic ticks into the test.
+   */
   def init(): Unit =
     if _initialized then throw new IllegalStateException("TuiTestDriver.init() called twice")
     val initial = app.init(ctx)
@@ -68,6 +77,10 @@ final class TuiTestDriver[Model, Msg](
     _initialized = true
     applyCmd(initial.cmd)
     drainCtxQueue()
+    // Shut down any background schedulers the app spun up in `init`, then
+    // discard anything those schedulers may have published in the race.
+    ctx.cancelSubs()
+    val _ = ctx.drainCmds()
 
   /**
    * Dispatch a message through `app.update` and apply the resulting `Cmd`.


### PR DESCRIPTION
Follows on from #88 (widget library first cut).

**Stacked on #88 → #87 → #86 → #85 → #84.** Base branch is \`feature/81-widget-library\`.

## Summary

- New \`termflow.apps.widgets.WidgetsDemoApp\` — a runnable \`TuiApp\` that exercises the full new stack end-to-end in a real terminal
- Registered in \`SampleSmoke\` so the \`prePR\` pipeline verifies it boots without crashing
- 7 integration tests in \`WidgetsDemoAppSnapshotSpec\` using structural assertions (focus flags, style comparisons) rather than golden files, to avoid flakiness from \`Sub.Every\`
- Small hardening tweak to \`TuiTestDriver.init\` — now cancels subscriptions after init to neutralise eagerly-started schedulers

## Running it

\`\`\`bash
sbt \"termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp\"
\`\`\`

**Keys:**
- \`Tab\` — cycle button focus (Save ↔ Cancel)
- \`Enter\` / \`Space\` — activate the focused button
- \`t\` — toggle dark / light theme
- \`+\` / \`-\` — nudge progress ±10 %
- \`q\` / \`Ctrl+C\` — quit

## What it shows

\`\`\`
 TermFlow Widget Demo                                                           

 ⠹  ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░  42%                               

 [ Save ]  [ Cancel ]                                                           

 Tab: focus   Enter/Space: activate   t: theme   +/-: nudge   q: quit           

 last action: clicked Cancel                                                    

 demo                          theme=dark  tick=6                 progress= 42%
\`\`\`

- **Layout**: \`Layout.Column\` stacks title, spinner+progress row, buttons row, help, and last-action text. \`StatusBar\` is positioned independently at the bottom.
- **Theme**: \`given Theme = if darkTheme then Theme.dark else Theme.light\`. Every widget picks up slots via \`using Theme\`; toggling flips all colours in one step.
- **Widgets**:
  - \`Button\` — focus visibly switches between \`theme.foreground\` and bolded \`theme.primary\`
  - \`Spinner.Braille\` animated by a \`Sub.Every(120 ms)\` tick
  - \`ProgressBar\` auto-fills from 0 → 1 → 0 driven by the same tick
  - \`StatusBar\` inverse-video row with left / center / right sections

## Testkit hardening

\`Sub.Every\` starts a \`ScheduledExecutorService\` inside its own constructor, before \`registerSub\` even runs — so the \"subscriptions never start\" contract promised by \`TestRuntimeCtx\` was actually being violated, leaking ticks into tests.

\`TuiTestDriver.init\` now cancels every registered sub and drops any commands they may have published in the construction-to-cancellation race window. Documented in the \`init\` doc comment. The scheduler can still squeeze in one tick before cancellation arrives (initial-delay is \`0L\`), so tests that care about deterministic initial state should use structural assertions rather than tick-dependent goldens — as the demo spec does.

## Why no full-frame goldens for the demo

I tried golden snapshots first and they were flaky: the \`Sub.Every\` scheduler fires on a background thread between construction and cancellation, which races with test setup non-deterministically. Rather than baking flakiness into the CI signal, the spec uses:

- model-level assertions (\`d.model.focus\`, \`d.model.lastAction\`)
- specific cell-style checks (status row background == \`Theme.X.primary\`)
- targeted content scans (\"find the row containing both button labels, verify Save is bold\")

These give strong coverage without depending on any timer-affected content.

Completing #81 will need a full golden suite for the \`Sub.Every\`-style case — a good follow-up candidate is modifying \`Sub.Every\` itself to defer its scheduler start until \`registerSub\`, which would let \`TestRuntimeCtx\` neutralise it cleanly.

## Test plan

- [x] 7 integration tests pass
- [x] \`sbt ciCheck\` green — 202 tests total (169 termflow + 33 sample)
- [x] \`sbt prePR\` green — SampleSmoke now exercises the demo's init+view
- [x] \`sbt \"termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp\"\` boots without crashing (verified via non-interactive launch; JLine falls back to dumb terminal in that context)