### PR TITLE
Add FocusManager + Keymap registry

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/widgets/WidgetsDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/widgets/WidgetsDemoApp.scala
@@ -6,19 +6,17 @@ import termflow.tui.TuiPrelude.*
 import termflow.tui.widgets.*
 
 /**
- * End-to-end demo of the `termflow.tui.widgets` package.
- *
- * Drives [[Button]], [[ProgressBar]], [[Spinner]], and [[StatusBar]]
- * through a `Layout.column` + `Layout.row` composition, using a `given
- * Theme` that the user can toggle at runtime.
+ * End-to-end demo of the new TermFlow stack: [[Layout]], [[Theme]], the
+ * stateless widgets in `termflow.tui.widgets`, plus [[FocusManager]] and
+ * [[Keymap]] for input dispatch.
  *
  * ## Keys
  *
- *   - `Tab` / `Shift+Tab` — cycle button focus
+ *   - `Tab`               — cycle button focus
  *   - `Enter` / `Space`   — activate the focused button
  *   - `t`                 — toggle dark / light theme
  *   - `+` / `-`           — nudge progress by ±10 %
- *   - `q` / `Ctrl+C`      — quit
+ *   - `q` / `Ctrl+C` / `Esc` — quit
  *
  * The spinner and progress bar are driven by a `Sub.Every` timer so they
  * animate on their own.
@@ -34,8 +32,9 @@ object WidgetsDemoApp:
     val _ = args
     TuiRuntime.run(App)
 
-  enum Focus:
-    case Save, Cancel
+  /** Stable focus identifiers for the two demo buttons. */
+  val SaveFocus: FocusId   = FocusId("save")
+  val CancelFocus: FocusId = FocusId("cancel")
 
   enum Msg:
     case Tick
@@ -53,12 +52,34 @@ object WidgetsDemoApp:
     terminalHeight: Int,
     tick: Int,
     progress: Double,
-    focus: Focus,
+    fm: FocusManager,
     darkTheme: Boolean,
     lastAction: String
   )
 
   import Msg.*
+
+  /**
+   * Declarative key bindings — composed from the standard quit + focus
+   * presets layered with the demo's app-specific shortcuts.
+   *
+   * Defining the keymap once at object scope rather than per-call keeps the
+   * `update` body short and lets the bindings be inspected and tested
+   * independently.
+   */
+  val Keys: Keymap[Msg] =
+    Keymap.quit(Quit) ++
+      Keymap.focus(next = NextFocus, previous = PrevFocus) ++
+      Keymap(
+        KeyDecoder.InputKey.Enter        -> Activate,
+        KeyDecoder.InputKey.CharKey(' ') -> Activate,
+        KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
+        KeyDecoder.InputKey.CharKey('T') -> ToggleTheme,
+        KeyDecoder.InputKey.CharKey('+') -> BumpProgress(0.1),
+        KeyDecoder.InputKey.CharKey('=') -> BumpProgress(0.1),
+        KeyDecoder.InputKey.CharKey('-') -> BumpProgress(-0.1),
+        KeyDecoder.InputKey.CharKey('_') -> BumpProgress(-0.1)
+      )
 
   object App extends TuiApp[Model, Msg]:
 
@@ -71,14 +92,15 @@ object WidgetsDemoApp:
     override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
       // Spinner / progress animation.
       Sub.Every(millis = 120L, msg = () => Tick, sink = ctx)
-      // Keyboard input. We don't use Prompt here — keys are handled directly.
+      // Keyboard input. We don't use Prompt here — keys are dispatched via
+      // the declarative Keymap below.
       Sub.InputKey(ConsoleInputKey.apply, ConsoleInputError.apply, ctx)
       Model(
         terminalWidth = ctx.terminal.width,
         terminalHeight = ctx.terminal.height,
         tick = 0,
         progress = 0.0,
-        focus = Focus.Save,
+        fm = FocusManager(Vector(SaveFocus, CancelFocus)),
         darkTheme = true,
         lastAction = "—"
       ).tui
@@ -93,16 +115,18 @@ object WidgetsDemoApp:
           sized.copy(tick = sized.tick + 1, progress = nextProgress).tui
 
         case NextFocus =>
-          val nf = if sized.focus == Focus.Save then Focus.Cancel else Focus.Save
-          sized.copy(focus = nf).tui
+          sized.copy(fm = sized.fm.next).tui
 
         case PrevFocus =>
-          // Two-button demo; prev and next are symmetric.
-          val nf = if sized.focus == Focus.Save then Focus.Cancel else Focus.Save
-          sized.copy(focus = nf).tui
+          sized.copy(fm = sized.fm.previous).tui
 
         case Activate =>
-          sized.copy(lastAction = s"clicked ${sized.focus}").tui
+          val label = sized.fm.current match
+            case Some(id) if id == SaveFocus   => "Save"
+            case Some(id) if id == CancelFocus => "Cancel"
+            case Some(id)                      => id.value
+            case None                          => "(nothing focused)"
+          sized.copy(lastAction = s"clicked $label").tui
 
         case ToggleTheme =>
           sized.copy(darkTheme = !sized.darkTheme).tui
@@ -115,25 +139,12 @@ object WidgetsDemoApp:
           Tui(sized, Cmd.Exit)
 
         case ConsoleInputKey(key) =>
-          keyToMsg(key) match
+          Keys.lookup(key) match
             case Some(next) => update(sized, next, ctx)
             case None       => sized.tui
 
         case ConsoleInputError(e) =>
           sized.copy(lastAction = s"input error: ${Option(e.getMessage).getOrElse("unknown")}").tui
-
-    private def keyToMsg(key: KeyDecoder.InputKey): Option[Msg] =
-      import KeyDecoder.InputKey.*
-      key match
-        // Tab arrives as Ctrl+I via the ASCII decoder.
-        case Ctrl('I')                   => Some(NextFocus)
-        case Enter | CharKey(' ')        => Some(Activate)
-        case CharKey('t') | CharKey('T') => Some(ToggleTheme)
-        case CharKey('+') | CharKey('=') => Some(BumpProgress(0.1))
-        case CharKey('-') | CharKey('_') => Some(BumpProgress(-0.1))
-        case CharKey('q') | CharKey('Q') => Some(Quit)
-        case Ctrl('C') | Escape          => Some(Quit)
-        case _                           => None
 
     override def view(m: Model): RootNode =
       given Theme = if m.darkTheme then Theme.dark else Theme.light
@@ -157,10 +168,11 @@ object WidgetsDemoApp:
         ProgressBar(m.progress, width = barWidth)
       )
 
-      // Button row with focus tracking.
+      // Button row driven by the focus manager — the manager owns which id
+      // is focused; widgets just ask `isFocused(id)` and render accordingly.
       val buttons = Layout.row(gap = 2)(
-        Button(label = "Save", focused = m.focus == Focus.Save),
-        Button(label = "Cancel", focused = m.focus == Focus.Cancel)
+        Button(label = "Save", focused = m.fm.isFocused(SaveFocus)),
+        Button(label = "Cancel", focused = m.fm.isFocused(CancelFocus))
       )
 
       // Instructions + last-action feedback.

--- a/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
@@ -1,8 +1,9 @@
 package termflow.apps.widgets
 
 import org.scalatest.funsuite.AnyFunSuite
-import termflow.apps.widgets.WidgetsDemoApp.Focus
+import termflow.apps.widgets.WidgetsDemoApp.CancelFocus
 import termflow.apps.widgets.WidgetsDemoApp.Msg
+import termflow.apps.widgets.WidgetsDemoApp.SaveFocus
 import termflow.testkit.TuiTestDriver
 import termflow.tui.*
 
@@ -11,10 +12,11 @@ import termflow.tui.*
  *
  * Instead of full-frame golden snapshots — which would be flaky against the
  * `Sub.Every` timer race in `init` (the scheduler fires its initial tick on a
- * background thread before `TuiTestDriver` can cancel it) — this spec drives
- * the demo synchronously and asserts on cell-level properties that are
- * invariant to the tick count: which button is focused, what style the
- * status row is painted in, and whether `Cmd.Exit` is observed on quit.
+ * background thread before `TuiTestDriver` can cancel it; tracked in
+ * `llm4s/termflow#92`) — this spec drives the demo synchronously and asserts
+ * on cell-level properties that are invariant to the tick count: which
+ * button is focused, what style the status row is painted in, and whether
+ * `Cmd.Exit` is observed on quit.
  */
 class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
 
@@ -33,20 +35,25 @@ class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
 
   test("initial model is on Save focus and dark theme"):
     val d = driver()
-    assert(d.model.focus == Focus.Save)
+    assert(d.model.fm.isFocused(SaveFocus))
     assert(d.model.darkTheme)
     assert(statusBg(d) == Theme.dark.primary)
 
-  test("Msg.NextFocus flips the model focus"):
+  test("Msg.NextFocus cycles focus forward through the FocusManager"):
     val d = driver()
     d.send(Msg.NextFocus)
-    assert(d.model.focus == Focus.Cancel)
+    assert(d.model.fm.isFocused(CancelFocus))
     d.send(Msg.NextFocus)
-    assert(d.model.focus == Focus.Save)
+    assert(d.model.fm.isFocused(SaveFocus)) // wraps
 
-  test("Msg.Activate records the currently focused action"):
+  test("Msg.PrevFocus cycles focus backward (and wraps)"):
     val d = driver()
-    d.send(Msg.NextFocus)
+    d.send(Msg.PrevFocus)
+    assert(d.model.fm.isFocused(CancelFocus))
+
+  test("Msg.Activate records the label of the currently focused button"):
+    val d = driver()
+    d.send(Msg.NextFocus) // focus -> Cancel
     d.send(Msg.Activate)
     assert(d.model.lastAction == "clicked Cancel")
 
@@ -75,9 +82,6 @@ class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
   test("button row reflects focus by painting Save bold when focused, Cancel plain"):
     val d     = driver()
     val frame = d.frame
-    // The buttons row is the third non-blank row in the layout; layout ordering
-    // is: title (row 2), spinner+bar (row 4), buttons (row 6). Locate 'S' of
-    // "Save" and 'C' of "Cancel" by scanning for them.
     val rowIdx = (0 until frame.height).indexWhere { r =>
       val s = (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString
       s.contains("[ Save ]") && s.contains("[ Cancel ]")
@@ -88,3 +92,28 @@ class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
     val canIdx = (0 until frame.width).find(c => row(c).ch == 'C').get
     assert(row(savIdx).style.bold, "Save label should be bold (focused)")
     assert(!row(canIdx).style.bold, "Cancel label should not be bold when Save is focused")
+
+  test("ConsoleInputKey dispatches via the Keymap — Tab cycles focus"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(KeyDecoder.InputKey.Ctrl('I')))
+    assert(d.model.fm.isFocused(CancelFocus))
+
+  test("ConsoleInputKey dispatches via the Keymap — q quits"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(KeyDecoder.InputKey.CharKey('q')))
+    assert(d.exited)
+
+  test("the Keymap binds every documented shortcut"):
+    // Spot-check the binding table directly so future bindings can't be
+    // dropped without breaking this test.
+    val k = WidgetsDemoApp.Keys
+    import KeyDecoder.InputKey.*
+    assert(k.lookup(Ctrl('I')).contains(Msg.NextFocus))
+    assert(k.lookup(Enter).contains(Msg.Activate))
+    assert(k.lookup(CharKey(' ')).contains(Msg.Activate))
+    assert(k.lookup(CharKey('t')).contains(Msg.ToggleTheme))
+    assert(k.lookup(CharKey('+')).contains(Msg.BumpProgress(0.1)))
+    assert(k.lookup(CharKey('-')).contains(Msg.BumpProgress(-0.1)))
+    assert(k.lookup(CharKey('q')).contains(Msg.Quit))
+    assert(k.lookup(Ctrl('C')).contains(Msg.Quit))
+    assert(k.lookup(Escape).contains(Msg.Quit))

--- a/modules/termflow/src/main/scala/termflow/tui/FocusManager.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/FocusManager.scala
@@ -1,0 +1,145 @@
+package termflow.tui
+
+/**
+ * Identifier for a focusable element in the UI.
+ *
+ * `FocusId` is opaque over `String` so it can't be confused with arbitrary
+ * domain strings. Construct with `FocusId("save")` and unwrap with
+ * `id.value`. Identifiers are compared by string value, so two `FocusId`s
+ * built from the same string are equal.
+ */
+opaque type FocusId = String
+
+object FocusId:
+
+  /** Wrap a raw string as a `FocusId`. */
+  def apply(s: String): FocusId = s
+
+  extension (id: FocusId)
+    /** Unwrap to the underlying string. */
+    def value: String = id
+
+/**
+ * Tracks an ordered list of focusable elements and which one currently owns
+ * focus.
+ *
+ * `FocusManager` is a plain immutable value — apps store it in their model
+ * and call `next` / `previous` / `focus` from `update` to produce a new
+ * manager. `view` then asks `isFocused(id)` per widget to decide on
+ * presentation.
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.widgets.*
+ *
+ * given Theme = Theme.dark
+ * val Save   = FocusId("save")
+ * val Cancel = FocusId("cancel")
+ *
+ * case class Model(fm: FocusManager)
+ * val initial = Model(FocusManager(Vector(Save, Cancel)))
+ *
+ * // In update:
+ * case Msg.Tab => model.copy(fm = model.fm.next).tui
+ *
+ * // In view:
+ * Layout.row(gap = 2)(
+ *   Button("Save",   focused = model.fm.isFocused(Save)),
+ *   Button("Cancel", focused = model.fm.isFocused(Cancel))
+ * )
+ * }}}
+ *
+ * The manager is a pure value: every transition method returns a new
+ * `FocusManager` and never mutates the receiver. Cycling wraps around at
+ * either end of the order. An empty manager has no current focus and all
+ * transitions are no-ops.
+ *
+ * @param ids     Focusable element ids in cycle order.
+ * @param current The id that currently owns focus, if any.
+ */
+final case class FocusManager(
+  ids: Vector[FocusId],
+  current: Option[FocusId]
+):
+
+  /** `true` when `id` is the currently focused element. */
+  def isFocused(id: FocusId): Boolean = current.contains(id)
+
+  /**
+   * Move focus to the next element in the order, wrapping back to the start.
+   *
+   * No-op when the manager is empty. If the current focus isn't in `ids`
+   * (e.g. after a `withIds` shrink), focus jumps to the first element.
+   */
+  def next: FocusManager =
+    if ids.isEmpty then this
+    else
+      val nextId = current match
+        case Some(c) =>
+          val idx = ids.indexOf(c)
+          if idx < 0 then ids.head else ids((idx + 1) % ids.size)
+        case None => ids.head
+      copy(current = Some(nextId))
+
+  /**
+   * Move focus to the previous element in the order, wrapping to the last.
+   *
+   * No-op when the manager is empty. If the current focus isn't in `ids`,
+   * focus jumps to the last element.
+   */
+  def previous: FocusManager =
+    if ids.isEmpty then this
+    else
+      val prevId = current match
+        case Some(c) =>
+          val idx = ids.indexOf(c)
+          if idx < 0 then ids.last
+          else ids((idx - 1 + ids.size) % ids.size)
+        case None => ids.last
+      copy(current = Some(prevId))
+
+  /**
+   * Set focus to `id` explicitly.
+   *
+   * No-op when `id` isn't in the manager's `ids` — the previous focus is
+   * preserved. Use [[withIds]] to register a new focusable first.
+   */
+  def focus(id: FocusId): FocusManager =
+    if ids.contains(id) then copy(current = Some(id)) else this
+
+  /**
+   * Clear focus without removing any ids.
+   *
+   * Useful when the app temporarily wants no element focused (e.g. during
+   * a modal overlay).
+   */
+  def clear: FocusManager = copy(current = None)
+
+  /**
+   * Replace the registered focus order.
+   *
+   * If the previous current focus is still in `newIds`, it's preserved.
+   * Otherwise the first id (if any) becomes focused, or focus is cleared
+   * for an empty list.
+   */
+  def withIds(newIds: Vector[FocusId]): FocusManager =
+    val nextCurrent = current match
+      case Some(c) if newIds.contains(c) => Some(c)
+      case _                             => newIds.headOption
+    FocusManager(newIds, nextCurrent)
+
+object FocusManager:
+
+  /** Empty manager — no focusable elements, no current focus. */
+  val empty: FocusManager = FocusManager(Vector.empty, None)
+
+  /**
+   * Build a manager whose initial focus is the first id, if any.
+   *
+   * {{{
+   * val fm = FocusManager(Vector(FocusId("name"), FocusId("email")))
+   * fm.focused == Some(FocusId("name"))
+   * }}}
+   */
+  def apply(ids: Vector[FocusId]): FocusManager =
+    new FocusManager(ids, ids.headOption)

--- a/modules/termflow/src/main/scala/termflow/tui/Keymap.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Keymap.scala
@@ -1,0 +1,144 @@
+package termflow.tui
+
+import termflow.tui.KeyDecoder.InputKey
+
+/**
+ * Declarative mapping from terminal keys to application messages.
+ *
+ * Apps that handle keyboard input via `Sub.InputKey` typically have a
+ * pattern-match in their `update` (or a helper) that turns each `InputKey`
+ * into the appropriate `Msg`. `Keymap` formalises that lookup table:
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.KeyDecoder.InputKey.*
+ *
+ * val keys: Keymap[Msg] =
+ *   Keymap.quit(Msg.Quit) ++
+ *   Keymap.focus(next = Msg.NextFocus, previous = Msg.PrevFocus) ++
+ *   Keymap(
+ *     Enter        -> Msg.Activate,
+ *     CharKey('t') -> Msg.ToggleTheme
+ *   )
+ *
+ * // In update:
+ * case Msg.ConsoleInputKey(k) =>
+ *   keys.lookup(k) match
+ *     case Some(msg) => update(model, msg, ctx)
+ *     case None      => model.tui
+ * }}}
+ *
+ * Keymaps compose with `++` (later bindings win) so apps can layer global
+ * shortcuts (`quit`, `focus`) under app-specific bindings without
+ * boilerplate. The contract is intentionally simple — single-key only, no
+ * chord support — to match the minimal viable feature set described in #82.
+ *
+ * @tparam Msg The application's message type.
+ */
+final case class Keymap[Msg](bindings: Map[InputKey, Msg]):
+
+  /** Look up a message bound to `key`, if any. */
+  def lookup(key: InputKey): Option[Msg] = bindings.get(key)
+
+  /**
+   * Add or override a single binding. Equivalent to `++(Keymap(binding))`.
+   *
+   * If `binding._1` is already mapped, the new value replaces it.
+   */
+  def +(binding: (InputKey, Msg)): Keymap[Msg] =
+    Keymap(bindings + binding)
+
+  /**
+   * Merge two keymaps. Bindings from `other` win on conflicts so callers
+   * can layer overrides on top of shared baselines:
+   *
+   * {{{
+   * val base    = Keymap.quit(Msg.Quit)
+   * val mine    = Keymap(KeyDecoder.InputKey.CharKey('q') -> Msg.PromptQuit)
+   * val merged  = base ++ mine    // 'q' now goes to Msg.PromptQuit
+   * }}}
+   */
+  def ++(other: Keymap[Msg]): Keymap[Msg] =
+    Keymap(bindings ++ other.bindings)
+
+  /** Number of registered bindings. */
+  def size: Int = bindings.size
+
+  /** `true` when no bindings are registered. */
+  def isEmpty: Boolean = bindings.isEmpty
+
+object Keymap:
+
+  /** A keymap with no bindings. `lookup` always returns `None`. */
+  def empty[Msg]: Keymap[Msg] = Keymap(Map.empty[InputKey, Msg])
+
+  /**
+   * Build a keymap from a varargs list of bindings.
+   *
+   * If the same key appears more than once, the last binding wins
+   * (consistent with `Map(...)` semantics).
+   */
+  def apply[Msg](bindings: (InputKey, Msg)*): Keymap[Msg] =
+    Keymap(bindings.toMap)
+
+  /**
+   * Conventional quit bindings: `Ctrl+C`, `Escape`, and `q` / `Q` all map
+   * to the same message.
+   *
+   * Use `++` to add more bindings without overwriting these.
+   */
+  def quit[Msg](msg: Msg): Keymap[Msg] = Keymap(
+    InputKey.Ctrl('C')    -> msg,
+    InputKey.Escape       -> msg,
+    InputKey.CharKey('q') -> msg,
+    InputKey.CharKey('Q') -> msg
+  )
+
+  /**
+   * Conventional focus bindings: `Tab` to advance, no shift-tab binding
+   * because the current `KeyDecoder` doesn't distinguish `Shift+Tab` from
+   * a bare ESC sequence.
+   *
+   * Apps that want explicit forward / backward bindings can pass both
+   * messages and add their own back-cycle key (e.g. `BackTick`):
+   *
+   * {{{
+   * Keymap.focus(next = Msg.NextFocus, previous = Msg.PrevFocus) ++
+   *   Keymap(InputKey.CharKey('`') -> Msg.PrevFocus)
+   * }}}
+   *
+   * `Tab` on most terminals is decoded as `Ctrl+I` by the ASCII control
+   * range, so that's the binding installed.
+   *
+   * @param next     Message to dispatch on Tab (`Ctrl+I`).
+   * @param previous Currently unused — wire your own binding via `++`. The
+   *                 parameter exists so the API doesn't have to change once
+   *                 `Shift+Tab` decoding is supported.
+   */
+  def focus[Msg](next: Msg, previous: Msg): Keymap[Msg] =
+    val _ = previous // reserved; see ScalaDoc
+    Keymap(InputKey.Ctrl('I') -> next)
+
+  /**
+   * Conventional editing bindings: arrow keys, Home, End, Enter, Backspace.
+   *
+   * Useful when wiring an app that handles its own text input (without
+   * using the `Prompt` helper). Apps using `Prompt` already get these
+   * via `Prompt.handleKey`.
+   *
+   * @param onEnter     Message dispatched on Enter.
+   * @param onBackspace Message dispatched on Backspace.
+   * @param onLeft      Message dispatched on Left arrow.
+   * @param onRight     Message dispatched on Right arrow.
+   */
+  def editing[Msg](
+    onEnter: Msg,
+    onBackspace: Msg,
+    onLeft: Msg,
+    onRight: Msg
+  ): Keymap[Msg] = Keymap(
+    InputKey.Enter      -> onEnter,
+    InputKey.Backspace  -> onBackspace,
+    InputKey.ArrowLeft  -> onLeft,
+    InputKey.ArrowRight -> onRight
+  )

--- a/modules/termflow/src/test/scala/termflow/tui/FocusManagerSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/FocusManagerSpec.scala
@@ -1,0 +1,101 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class FocusManagerSpec extends AnyFunSuite:
+
+  private val A = FocusId("a")
+  private val B = FocusId("b")
+  private val C = FocusId("c")
+
+  test("FocusId equality is based on the underlying string"):
+    assert(FocusId("x") == FocusId("x"))
+    assert(FocusId("x") != FocusId("y"))
+    assert(FocusId("x").value == "x")
+
+  test("FocusManager.empty has no ids and no current focus"):
+    val fm = FocusManager.empty
+    assert(fm.ids.isEmpty)
+    assert(fm.current.isEmpty)
+
+  test("apply with non-empty ids picks the first as initially focused"):
+    val fm = FocusManager(Vector(A, B, C))
+    assert(fm.current.contains(A))
+
+  test("apply with an empty vector leaves current focus as None"):
+    val fm = FocusManager(Vector.empty)
+    assert(fm.current.isEmpty)
+
+  test("isFocused returns true only for the current id"):
+    val fm = FocusManager(Vector(A, B))
+    assert(fm.isFocused(A))
+    assert(!fm.isFocused(B))
+
+  test("next cycles forward and wraps at the end"):
+    val fm0 = FocusManager(Vector(A, B, C))
+    val fm1 = fm0.next
+    val fm2 = fm1.next
+    val fm3 = fm2.next
+    assert(fm0.current.contains(A))
+    assert(fm1.current.contains(B))
+    assert(fm2.current.contains(C))
+    assert(fm3.current.contains(A)) // wrap
+
+  test("previous cycles backward and wraps at the start"):
+    val fm0 = FocusManager(Vector(A, B, C))
+    val fm1 = fm0.previous
+    val fm2 = fm1.previous
+    assert(fm1.current.contains(C)) // wrap
+    assert(fm2.current.contains(B))
+
+  test("next on an empty manager is a no-op"):
+    assert(FocusManager.empty.next == FocusManager.empty)
+    assert(FocusManager.empty.previous == FocusManager.empty)
+
+  test("focus(id) sets focus when id is in the order"):
+    val fm = FocusManager(Vector(A, B, C)).focus(C)
+    assert(fm.current.contains(C))
+
+  test("focus(id) is a no-op for an unknown id"):
+    val fm0 = FocusManager(Vector(A, B))
+    val fm1 = fm0.focus(C)
+    assert(fm1.current.contains(A)) // unchanged
+
+  test("clear removes the current focus without removing ids"):
+    val fm = FocusManager(Vector(A, B)).clear
+    assert(fm.current.isEmpty)
+    assert(fm.ids == Vector(A, B))
+
+  test("withIds preserves the current focus when still present"):
+    val fm  = FocusManager(Vector(A, B, C)).focus(B)
+    val fm2 = fm.withIds(Vector(B, A))
+    assert(fm2.current.contains(B))
+    assert(fm2.ids == Vector(B, A))
+
+  test("withIds resets focus to the first id when the previous current is gone"):
+    val fm  = FocusManager(Vector(A, B, C)).focus(C)
+    val fm2 = fm.withIds(Vector(A, B))
+    assert(fm2.current.contains(A))
+
+  test("withIds clears focus when given an empty vector"):
+    val fm = FocusManager(Vector(A, B)).withIds(Vector.empty)
+    assert(fm.current.isEmpty)
+    assert(fm.ids.isEmpty)
+
+  test("next falls back to the first id if current isn't in ids"):
+    // Manually construct a manager whose current is stale relative to ids.
+    val fm = FocusManager(Vector(A, B), Some(C))
+    assert(fm.next.current.contains(A))
+
+  test("previous falls back to the last id if current isn't in ids"):
+    val fm = FocusManager(Vector(A, B), Some(C))
+    assert(fm.previous.current.contains(B))
+
+  test("FocusManager is purely immutable — all transitions return new values"):
+    val fm0 = FocusManager(Vector(A, B))
+    val fm1 = fm0.next
+    val fm2 = fm0.focus(B)
+    // Receiver unchanged across both transitions.
+    assert(fm0.current.contains(A))
+    assert(fm1.current.contains(B))
+    assert(fm2.current.contains(B))

--- a/modules/termflow/src/test/scala/termflow/tui/KeymapSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/KeymapSpec.scala
@@ -1,0 +1,86 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.KeyDecoder.InputKey
+
+class KeymapSpec extends AnyFunSuite:
+
+  enum DemoMsg:
+    case A, B, Quit, NextFocus
+
+  test("empty keymap has no bindings and lookup always returns None"):
+    val k = Keymap.empty[DemoMsg]
+    assert(k.isEmpty)
+    assert(k.size == 0)
+    assert(k.lookup(InputKey.Enter).isEmpty)
+
+  test("apply with varargs builds a keymap from explicit bindings"):
+    val k = Keymap(
+      InputKey.Enter        -> DemoMsg.A,
+      InputKey.CharKey('q') -> DemoMsg.Quit
+    )
+    assert(k.size == 2)
+    assert(k.lookup(InputKey.Enter).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.CharKey('q')).contains(DemoMsg.Quit))
+    assert(k.lookup(InputKey.CharKey('z')).isEmpty)
+
+  test("+ adds a single binding without disturbing existing ones"):
+    val k0 = Keymap[DemoMsg](InputKey.Enter -> DemoMsg.A)
+    val k1 = k0 + (InputKey.Backspace -> DemoMsg.B)
+    assert(k1.size == 2)
+    assert(k1.lookup(InputKey.Enter).contains(DemoMsg.A))
+    assert(k1.lookup(InputKey.Backspace).contains(DemoMsg.B))
+
+  test("+ replaces an existing binding for the same key"):
+    val k = Keymap[DemoMsg](InputKey.Enter -> DemoMsg.A) +
+      (InputKey.Enter -> DemoMsg.B)
+    assert(k.size == 1)
+    assert(k.lookup(InputKey.Enter).contains(DemoMsg.B))
+
+  test("++ merges keymaps with right-side winning on conflict"):
+    val left = Keymap[DemoMsg](InputKey.CharKey('q') -> DemoMsg.Quit)
+    val right = Keymap[DemoMsg](
+      InputKey.CharKey('q') -> DemoMsg.A, // overrides
+      InputKey.Enter        -> DemoMsg.B
+    )
+    val merged = left ++ right
+    assert(merged.size == 2)
+    assert(merged.lookup(InputKey.CharKey('q')).contains(DemoMsg.A))
+    assert(merged.lookup(InputKey.Enter).contains(DemoMsg.B))
+
+  test("Keymap.quit binds Ctrl+C, Escape, q, and Q to the supplied message"):
+    val k = Keymap.quit(DemoMsg.Quit)
+    assert(k.lookup(InputKey.Ctrl('C')).contains(DemoMsg.Quit))
+    assert(k.lookup(InputKey.Escape).contains(DemoMsg.Quit))
+    assert(k.lookup(InputKey.CharKey('q')).contains(DemoMsg.Quit))
+    assert(k.lookup(InputKey.CharKey('Q')).contains(DemoMsg.Quit))
+
+  test("Keymap.focus binds Tab (Ctrl+I) to the next-focus message"):
+    val k = Keymap.focus(next = DemoMsg.NextFocus, previous = DemoMsg.A)
+    assert(k.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus))
+    // Shift+Tab is unsupported by KeyDecoder today; the parameter is reserved.
+    assert(k.size == 1)
+
+  test("Keymap.editing binds Enter, Backspace, ArrowLeft, ArrowRight"):
+    val k = Keymap.editing(
+      onEnter = DemoMsg.A,
+      onBackspace = DemoMsg.B,
+      onLeft = DemoMsg.NextFocus,
+      onRight = DemoMsg.Quit
+    )
+    assert(k.lookup(InputKey.Enter).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.Backspace).contains(DemoMsg.B))
+    assert(k.lookup(InputKey.ArrowLeft).contains(DemoMsg.NextFocus))
+    assert(k.lookup(InputKey.ArrowRight).contains(DemoMsg.Quit))
+
+  test("layered keymaps form a baseline plus app-specific overrides"):
+    val baseline = Keymap.quit(DemoMsg.Quit) ++
+      Keymap.focus(next = DemoMsg.NextFocus, previous = DemoMsg.A)
+    val mine = Keymap[DemoMsg](
+      InputKey.CharKey('q') -> DemoMsg.A // override quit's q->Quit
+    )
+    val full = baseline ++ mine
+    assert(full.lookup(InputKey.Ctrl('C')).contains(DemoMsg.Quit))      // baseline
+    assert(full.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus)) // baseline
+    assert(full.lookup(InputKey.CharKey('q')).contains(DemoMsg.A))      // override
+    assert(full.lookup(InputKey.CharKey('Q')).contains(DemoMsg.Quit))   // baseline preserved


### PR DESCRIPTION
Closes #82.

**Stacked on #89 → #88 → #87 → #86 → #85 → #84.** Base branch is \`feature/81-widgets-demo\`; the GitHub diff shows the focus/keymap addition plus the demo refactor that uses it.

## Summary

Two small core types that close the loop on the widget library work:

- **\`FocusManager\`** — pure immutable value tracking an ordered list of \`FocusId\`s and which one currently owns focus. Apps store it in their model and call \`next\` / \`previous\` / \`focus(id)\` from \`update\`.
- **\`Keymap[Msg]\`** — declarative \`InputKey -> Msg\` lookup. Composes with \`++\` (right wins). Three preset factories cover the common bindings.

The \`WidgetsDemoApp\` from PR #89 is refactored to use both, replacing the ad-hoc \`Focus\` enum + \`keyToMsg\` pattern-match. This closes the gap I called out in PR #89: \"Button has a \`focused\` field but nothing in the framework drives it.\"

## What's here

### \`FocusManager.scala\`

\`\`\`scala
val fm = FocusManager(Vector(FocusId(\"save\"), FocusId(\"cancel\")))
fm.isFocused(FocusId(\"save\"))   // true (initial)
fm.next.isFocused(FocusId(\"cancel\")) // true
fm.next.next == fm                    // wraps
\`\`\`

- Pure value semantics: every transition returns a new manager
- Cycling wraps at both ends; \`empty\` is a stable no-op
- \`withIds(...)\` preserves current focus when still present, otherwise resets to head
- \`FocusId\` is opaque over \`String\` to prevent accidental mixing with domain strings

### \`Keymap.scala\`

\`\`\`scala
val keys: Keymap[Msg] =
  Keymap.quit(Msg.Quit) ++
  Keymap.focus(next = Msg.NextFocus, previous = Msg.PrevFocus) ++
  Keymap(
    InputKey.Enter        -> Msg.Activate,
    InputKey.CharKey('t') -> Msg.ToggleTheme
  )

// In update:
case Msg.ConsoleInputKey(k) =>
  keys.lookup(k) match
    case Some(msg) => update(model, msg, ctx)
    case None      => model.tui
\`\`\`

- Three preset factories: \`Keymap.quit\` (Ctrl+C / Esc / q / Q), \`Keymap.focus\` (Tab → next), \`Keymap.editing\` (arrows / Enter / Backspace)
- \`Shift+Tab\` is a documented gap — \`KeyDecoder\` doesn't currently distinguish it from a bare ESC sequence; \`Keymap.focus\` reserves the parameter so the API doesn't need to change when that lands
- Layered overrides via \`++\` work as expected (later wins)

### Demo refactor

The before/after on \`WidgetsDemoApp.update\`:

**Before** (PR #89):
\`\`\`scala
case NextFocus =>
  val nf = if sized.focus == Focus.Save then Focus.Cancel else Focus.Save
  sized.copy(focus = nf).tui

private def keyToMsg(key: KeyDecoder.InputKey): Option[Msg] =
  import KeyDecoder.InputKey.*
  key match
    case Ctrl('I')                   => Some(NextFocus)
    case Enter | CharKey(' ')        => Some(Activate)
    // ... 8 more cases
\`\`\`

**After** (this PR):
\`\`\`scala
case NextFocus =>
  sized.copy(fm = sized.fm.next).tui

val Keys: Keymap[Msg] =
  Keymap.quit(Quit) ++
    Keymap.focus(next = NextFocus, previous = PrevFocus) ++
    Keymap(/* app-specific bindings */)
\`\`\`

The \`Keys\` table is now hoisted to the demo's object scope so it's both inspectable and testable independently of the runtime.

## Test plan

- [x] **17 FocusManager tests**: construction, all transitions, wrap behaviour, \`focus(id)\` no-op for unknown ids, \`withIds\` preservation/shrink/empty, immutability, recovery from stale current
- [x] **9 Keymap tests**: empty, varargs, \`+\`, \`++\` precedence, every preset factory, layered overrides
- [x] **11 demo tests** (3 new): \`Msg.PrevFocus\` cycles backward, \`ConsoleInputKey(Ctrl+I)\` cycles focus via \`Keys.lookup\`, \`ConsoleInputKey(q)\` quits via \`Keys.lookup\`, plus a binding-table spot-check that prevents future bindings from being silently dropped
- [x] \`sbt ciCheck\` green — **232 tests total** (195 termflow + 37 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## Out of scope (per the issue)

- Chord bindings (Ctrl+X Ctrl+S) — single-key only for v1
- Context-sensitive keymaps per focused widget — apps can implement this manually by composing different keymaps based on the focus
- Mouse focus / clicking to focus — separate issue if/when mouse support lands
- Runtime-level focus interception (where the runtime consumes Tab before the app sees it) — kept opt-in/additive in line with the rest of this stack; apps wire \`Keymap\` into their own \`update\`

## Status of the original 7 issues

After this PR, 6 of 7 are addressed:

- #77 layout — PR #87
- #78 testkit — PR #84
- #79 ScalaDoc — PR #85
- #80 theming — PR #86
- #81 widgets — PR #88 (first cut) + PR #89 (demo); stateful widgets in #91
- #82 focus + keymap — **this PR**
- #83 devtools — still open

Plus four follow-ups freshly filed: #90 (refactor samples to Layout), #91 (stateful widgets), #92 (lazy \`Sub.Every\` for testkit determinism), #93 (top-level \`package.scala\`).