### PR TITLE
Defer Sub.Every scheduler to start() for deterministic testkit

### DIFF
--- a/modules/termflow-sample/src/test/resources/termflow/golden/WidgetsDemoAppSnapshotSpec/initial-dark.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/WidgetsDemoAppSnapshotSpec/initial-dark.golden
@@ -1,0 +1,15 @@
+# width=80 height=14
+|                                                                                |
+| TermFlow Widget Demo                                                           |
+|                                                                                |
+| ⠋  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   0%                               |
+|                                                                                |
+| [ Save ]  [ Cancel ]                                                           |
+|                                                                                |
+| Tab: focus   Enter/Space: activate   t: theme   +/-: nudge   q: quit           |
+|                                                                                |
+| last action: —                                                                 |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| demo                          theme=dark  tick=0                 progress=  0% |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/WidgetsDemoAppSnapshotSpec/light-cancel-clicked.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/WidgetsDemoAppSnapshotSpec/light-cancel-clicked.golden
@@ -1,0 +1,15 @@
+# width=80 height=14
+|                                                                                |
+| TermFlow Widget Demo                                                           |
+|                                                                                |
+| ⠋  ████████████████░░░░░░░░░░░░░░░░░░░░░░░░  40%                               |
+|                                                                                |
+| [ Save ]  [ Cancel ]                                                           |
+|                                                                                |
+| Tab: focus   Enter/Space: activate   t: theme   +/-: nudge   q: quit           |
+|                                                                                |
+| last action: clicked Cancel                                                    |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| demo                         theme=light  tick=0                 progress= 40% |

--- a/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
@@ -4,21 +4,20 @@ import org.scalatest.funsuite.AnyFunSuite
 import termflow.apps.widgets.WidgetsDemoApp.CancelFocus
 import termflow.apps.widgets.WidgetsDemoApp.Msg
 import termflow.apps.widgets.WidgetsDemoApp.SaveFocus
+import termflow.testkit.GoldenSupport
 import termflow.testkit.TuiTestDriver
 import termflow.tui.*
 
 /**
  * Integration coverage for the widgets demo.
  *
- * Instead of full-frame golden snapshots — which would be flaky against the
- * `Sub.Every` timer race in `init` (the scheduler fires its initial tick on a
- * background thread before `TuiTestDriver` can cancel it; tracked in
- * `llm4s/termflow#92`) — this spec drives the demo synchronously and asserts
- * on cell-level properties that are invariant to the tick count: which
- * button is focused, what style the status row is painted in, and whether
- * `Cmd.Exit` is observed on quit.
+ * Combines structural assertions (which button is focused, what style the
+ * status row is painted in) with proper golden-frame snapshots. The latter
+ * are only safe because PR #92 made `Sub.Every` defer its scheduler to
+ * `start()` — the testkit doesn't call `start()`, so the demo's animation
+ * timer stays dormant during snapshot tests.
  */
-class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
+class WidgetsDemoAppSnapshotSpec extends AnyFunSuite with GoldenSupport:
 
   private val Width  = 80
   private val Height = 14
@@ -117,3 +116,20 @@ class WidgetsDemoAppSnapshotSpec extends AnyFunSuite:
     assert(k.lookup(CharKey('q')).contains(Msg.Quit))
     assert(k.lookup(Ctrl('C')).contains(Msg.Quit))
     assert(k.lookup(Escape).contains(Msg.Quit))
+
+  // --- Golden-frame snapshots (timer-deterministic thanks to #92) ----------
+
+  test("initial frame matches the dark-theme golden"):
+    val d = driver()
+    // Confirm the timer never fired.
+    assert(d.model.tick == 0)
+    assert(d.model.progress == 0.0)
+    assertGoldenFrame(d.frame, "initial-dark")
+
+  test("light theme + focused Cancel after a few input keys"):
+    val d = driver()
+    d.send(Msg.ToggleTheme)
+    d.send(Msg.NextFocus)
+    d.send(Msg.BumpProgress(0.4))
+    d.send(Msg.Activate)
+    assertGoldenFrame(d.frame, "light-cancel-clicked")

--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -28,12 +28,34 @@ trait Sub[+Msg]:
   /** Cancel the subscription and release associated resources. */
   def cancel(): Unit
 
+  /**
+   * Begin any background activity (timers, reader threads, …).
+   *
+   * The default is a no-op for back-compat with existing `Sub` implementations
+   * that start their work eagerly in their constructor. New deferred-start
+   * factories — currently only [[Sub.Every]] — override this so the cost of
+   * "starting a sub" can be controlled by the registering context:
+   *
+   *   - `LocalCmdBus.registerSub` calls `start()` immediately after recording
+   *     the sub, preserving existing production behaviour.
+   *   - `TestRuntimeCtx.registerSub` deliberately does **not** call `start()`,
+   *     so timer-driven subs stay dormant inside the testkit.
+   *
+   * Calling `start()` more than once must be safe — the contract is "start if
+   * not already started".
+   */
+  def start(): Unit = ()
+
 object Sub:
   private def autoRegisterIfRuntimeCtx[Msg](sub: Sub[Msg], sink: EventSink[Msg]): Sub[Msg] =
     sink match
       case ctx: RuntimeCtx[?] =>
         ctx.asInstanceOf[RuntimeCtx[Msg]].registerSub(sub)
       case _ =>
+        // Non-RuntimeCtx sinks don't get the registerSub hook, so honour the
+        // start contract here to preserve eager-start semantics for existing
+        // call sites that pass a bare EventSink.
+        sub.start()
         sub
 
   /** A no-op subscription. Useful as a placeholder in model fields. */
@@ -47,6 +69,13 @@ object Sub:
    * Each tick publishes `Cmd.GCmd(msg())` through `sink`. The thunk runs on
    * a single background scheduler thread, so `msg()` must not block.
    *
+   * The scheduler is constructed lazily by [[Sub.start]] rather than in this
+   * factory, so `TestRuntimeCtx` can keep timers dormant during snapshot
+   * tests (it does not call `start()` on registered subs). For all
+   * production paths (`LocalCmdBus.registerSub`, bare `EventSink` sinks)
+   * `start()` runs synchronously immediately after construction, preserving
+   * the original eager-start behaviour.
+   *
    * @param millis Interval between ticks, in milliseconds.
    * @param msg Thunk producing the next message on each tick.
    * @param sink Where to publish ticks. When called with a [[RuntimeCtx]]
@@ -54,26 +83,37 @@ object Sub:
    */
   def Every[Msg](millis: Long, msg: () => Msg, sink: EventSink[Msg]): Sub[Msg] =
     val sub = new Sub[Msg]:
-      @volatile private var active = true
-      private val scheduler        = Executors.newSingleThreadScheduledExecutor(ThreadUtils.newThreadFactory())
-      private val handle =
-        scheduler.scheduleAtFixedRate(
-          () => sink.publish(Cmd.GCmd[Msg](msg())),
-          0L,
-          millis,
-          TimeUnit.MILLISECONDS
-        )
+      private val lock                                                               = new Object
+      @volatile private var active                                                   = true
+      @volatile private var scheduler: java.util.concurrent.ScheduledExecutorService = null
+      @volatile private var handle: java.util.concurrent.ScheduledFuture[?]          = null
+
+      override def start(): Unit =
+        lock.synchronized {
+          if scheduler == null && active then
+            val s = Executors.newSingleThreadScheduledExecutor(ThreadUtils.newThreadFactory())
+            scheduler = s
+            handle = s.scheduleAtFixedRate(
+              () => sink.publish(Cmd.GCmd[Msg](msg())),
+              0L,
+              millis,
+              TimeUnit.MILLISECONDS
+            )
+        }
 
       override def isActive: Boolean = active
 
       override def cancel(): Unit =
-        active = false
-        handle.cancel(true)
-        scheduler.shutdownNow(): Unit
-        try scheduler.awaitTermination(200L, TimeUnit.MILLISECONDS): Unit
-        catch {
-          case _: InterruptedException =>
-            Thread.currentThread().interrupt()
+        lock.synchronized {
+          active = false
+          if handle != null then handle.cancel(true)
+          if scheduler != null then
+            scheduler.shutdownNow(): Unit
+            try scheduler.awaitTermination(200L, TimeUnit.MILLISECONDS): Unit
+            catch {
+              case _: InterruptedException =>
+                Thread.currentThread().interrupt()
+            }
         }
     autoRegisterIfRuntimeCtx(sub, sink)
 

--- a/modules/termflow/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -103,7 +103,14 @@ final class LocalCmdBus[Msg](val terminal: TerminalBackend, val config: TermFlow
   override def take(): Cmd[Msg]                       = queue.take()
   override def poll(timeoutMillis: Long): Option[Cmd[Msg]] =
     Option(queue.poll(timeoutMillis, TimeUnit.MILLISECONDS))
-  override def registerSub(sub: Sub[Msg]): Sub[Msg] = { subscriptions.add(sub); sub }
+  override def registerSub(sub: Sub[Msg]): Sub[Msg] = {
+    subscriptions.add(sub): Unit
+    // Start any deferred-start machinery (e.g. Sub.Every's scheduler).
+    // Eagerly-started subs override `start` as a no-op, so this is safe
+    // for every existing implementation.
+    sub.start()
+    sub
+  }
   override def cancelAllSubscriptions(): Unit =
     subscriptions.forEach { sub =>
       try sub.cancel()

--- a/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
+++ b/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
@@ -63,12 +63,15 @@ final class TuiTestDriver[Model, Msg](
   /**
    * Call `app.init(ctx)`, store the initial model, and apply the startup `Cmd`.
    *
-   * After init runs, every subscription the app registered (directly or via
-   * `Sub.*` factories) is cancelled and any commands they published in the
-   * meantime are dropped. This is necessary because some `Sub.*` factories —
-   * notably `Sub.Every` — start background schedulers inside their own
-   * constructors, before `registerSub` even runs; leaving them live would
-   * leak non-deterministic ticks into the test.
+   * Subscriptions the app registers via `Sub.*` factories pass through
+   * [[TestRuntimeCtx.registerSub]], which deliberately does not invoke
+   * `Sub.start()`. Combined with `Sub.Every`'s deferred-start design (see
+   * `llm4s/termflow#92`), this means timer-driven subscriptions stay
+   * dormant in tests — no race-prone ticks land in the model.
+   *
+   * Subscriptions that still start eagerly in their own constructor (e.g.
+   * `Sub.InputKey` with the testkit's empty `StringReader`) terminate
+   * harmlessly on the test backend.
    */
   def init(): Unit =
     if _initialized then throw new IllegalStateException("TuiTestDriver.init() called twice")
@@ -77,10 +80,6 @@ final class TuiTestDriver[Model, Msg](
     _initialized = true
     applyCmd(initial.cmd)
     drainCtxQueue()
-    // Shut down any background schedulers the app spun up in `init`, then
-    // discard anything those schedulers may have published in the race.
-    ctx.cancelSubs()
-    val _ = ctx.drainCmds()
 
   /**
    * Dispatch a message through `app.update` and apply the resulting `Cmd`.

--- a/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
@@ -179,3 +179,71 @@ class SubSpec extends AnyFunSuite:
     val msgs = sink.messages.collect { case Cmd.GCmd(v: String) => v }
     assert(msgs.count(_.startsWith("key:")) == 1)
     assert(!msgs.exists(_.startsWith("err:")))
+
+  // --- Sub.start() / deferred-start contract --------------------------------
+
+  /** Stub RuntimeCtx that records subs but never calls `start()`. */
+  private class CapturingCtx[Msg] extends RuntimeCtx[Msg]:
+    private val captured                              = new java.util.concurrent.ConcurrentLinkedQueue[Cmd[Msg]]()
+    private val subs                                  = new java.util.concurrent.ConcurrentLinkedQueue[Sub[Msg]]()
+    override def terminal: TerminalBackend            = throw new UnsupportedOperationException("not used in test")
+    override def config: TermFlowConfig               = throw new UnsupportedOperationException("not used in test")
+    override def publish(cmd: Cmd[Msg]): Unit         = captured.add(cmd): Unit
+    override def registerSub(sub: Sub[Msg]): Sub[Msg] = { subs.add(sub): Unit; sub }
+    def messages: List[Cmd[Msg]]                      = captured.iterator().asScala.toList
+    def registered: List[Sub[Msg]]                    = subs.iterator().asScala.toList
+
+  test("Sub.Every does not tick when registered into a RuntimeCtx that omits start()"):
+    val ctx = new CapturingCtx[String]
+    val sub = Sub.Every(20, () => "tick", ctx)
+    assert(ctx.registered == List(sub))
+    Thread.sleep(80) // enough wall-clock for several missed intervals
+    assert(ctx.messages.isEmpty, s"expected no ticks but saw ${ctx.messages}")
+    sub.cancel()
+
+  test("Sub.Every starts ticking once start() is invoked explicitly"):
+    val ctx = new CapturingCtx[String]
+    val sub = Sub.Every(20, () => "tick", ctx)
+    assert(ctx.messages.isEmpty)
+    sub.start()
+    try
+      // Wait for at least one tick.
+      val deadline = System.currentTimeMillis() + 500
+      while ctx.messages.isEmpty && System.currentTimeMillis() < deadline do Thread.sleep(10)
+      assert(ctx.messages.nonEmpty, "expected a tick after start()")
+      assert(ctx.messages.head == Cmd.GCmd("tick"))
+    finally sub.cancel()
+
+  test("Sub.Every.start() is idempotent — multiple calls do not spawn extra schedulers"):
+    val ctx = new CapturingCtx[String]
+    val sub = Sub.Every(50, () => "tick", ctx)
+    sub.start()
+    sub.start()
+    sub.start()
+    Thread.sleep(120)
+    sub.cancel()
+    // We only assert determinism via "did not blow up"; concretely, double-start
+    // would have leaked extra scheduler threads. The cancel above should still
+    // tear everything down cleanly; this test is primarily about not throwing.
+    assert(!sub.isActive)
+
+  test("Sub.Every with a bare EventSink (non-RuntimeCtx) still starts eagerly"):
+    // Back-compat: when caller passes a plain EventSink, the factory must
+    // start the sub itself so existing code keeps working.
+    val sink = new TestSink[String]
+    val sub  = Sub.Every(20, () => "tick", sink)
+    try
+      assert(sink.awaitFirst(500))
+      assert(sink.messages.nonEmpty)
+    finally sub.cancel()
+
+  test("Sub trait default start() is a no-op"):
+    val sub = new Sub[Nothing]:
+      override def isActive: Boolean = true
+      override def cancel(): Unit    = ()
+      // Inherit default start, which is a no-op.
+    // Should not throw and should leave isActive untouched.
+    sub.start()
+    assert(sub.isActive)
+    sub.start()
+    assert(sub.isActive)


### PR DESCRIPTION
Closes #92.

**Stacked on #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base branch is \`feature/82-focus-keymap\`.

## Summary

- Adds \`def start(): Unit = ()\` to the \`Sub\` trait — no-op default, opt-in override
- \`Sub.Every\` now constructs its scheduler in \`start()\` instead of in its anonymous-class body
- \`LocalCmdBus.registerSub\` calls \`sub.start()\` after recording, so production behaviour is unchanged
- \`autoRegisterIfRuntimeCtx\` also calls \`start()\` when given a bare \`EventSink\`, preserving back-compat for non-runtime callers
- \`TestRuntimeCtx.registerSub\` deliberately doesn't call \`start()\`, so timer-driven subs stay dormant in tests
- Reverts the PR #89 cancel-and-drain workaround in \`TuiTestDriver.init\` — no longer needed
- Adds two **proper golden-frame snapshots** for \`WidgetsDemoApp\` now that the timer is deterministic; both pin \`tick=0\` in the rendered \`StatusBar\`

## Why

PR #84's testkit promised \"subscriptions never start\" — but \`Sub.Every\` violated that contract by spawning a \`ScheduledExecutorService\` inside its anonymous-class body, before \`registerSub\` ran. This race forced PR #89 (the widgets demo) to use structural-only assertions instead of real golden-frame snapshots, and required PR #94 to keep the cancel-and-drain workaround. With \`Sub.Every\` deferred, the contract is now real and the testkit is fully deterministic for timer-driven apps.

## Code shape

### Before
\`\`\`scala
def Every[Msg](millis: Long, msg: () => Msg, sink: EventSink[Msg]): Sub[Msg] =
  val sub = new Sub[Msg]:
    @volatile private var active = true
    private val scheduler        = Executors.newSingleThreadScheduledExecutor(...)
    private val handle           = scheduler.scheduleAtFixedRate(... 0L ...) // fires immediately
    ...
  autoRegisterIfRuntimeCtx(sub, sink)
\`\`\`

### After
\`\`\`scala
def Every[Msg](millis: Long, msg: () => Msg, sink: EventSink[Msg]): Sub[Msg] =
  val sub = new Sub[Msg]:
    private val lock                           = new Object
    @volatile private var active               = true
    @volatile private var scheduler            = null
    @volatile private var handle               = null

    override def start(): Unit = lock.synchronized {
      if scheduler == null && active then
        scheduler = Executors.newSingleThreadScheduledExecutor(...)
        handle    = scheduler.scheduleAtFixedRate(...)
    }
    ...
  autoRegisterIfRuntimeCtx(sub, sink)  // calls registerSub which calls start
\`\`\`

The lock is needed because \`start()\` is called from whatever thread \`registerSub\` runs on; \`cancel()\` may run from another thread later. Both methods are \`synchronized\` to prevent the \"started after cancel\" race.

## Behavioural compatibility

| Caller | Before | After |
|---|---|---|
| \`LocalCmdBus.registerSub(sub.Every)\` | scheduler runs (eager) | scheduler runs (via \`start()\`) |
| Bare \`EventSink\` (non-RuntimeCtx) sink | scheduler runs (eager) | scheduler runs (via \`autoRegisterIfRuntimeCtx\`'s explicit \`start()\`) |
| \`TestRuntimeCtx.registerSub(sub.Every)\` | scheduler runs (was a bug) | scheduler dormant (now correct) |
| \`Sub.InputKey\` / \`Sub.TerminalResize\` | unchanged | unchanged (default \`start()\` is a no-op) |

## Test plan

- [x] **5 new SubSpec tests** pin the deferred-start contract: capturing-ctx receives no ticks; explicit \`start()\` begins ticking; double-start is safe; bare \`EventSink\` keeps ticking (back-compat); trait default is a no-op
- [x] **2 new golden-frame snapshots** for the widgets demo, both pinning \`tick=0\` in the StatusBar — would have failed before the fix
- [x] All existing SubSpec tests still pass — the eager-start path is preserved through \`autoRegisterIfRuntimeCtx\`
- [x] \`sbt ciCheck\` green: **239 tests total** (200 termflow + 39 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## Out of scope (per the issue)

- Refactoring \`Sub.InputKey\` / \`Sub.TerminalResize\` similarly. They don't have the same race because \`Sub.InputKey\`'s producer thread harmlessly exits on the testkit's empty \`StringReader\`, and \`Sub.TerminalResize\`'s polling never publishes when dimensions don't change.
- Broader subscription lifecycle redesign (e.g. lifecycle phases, started/cancelled state machine).