### PR TITLE
Add package object scaladoc landing page for termflow.tui

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/package.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/package.scala
@@ -1,0 +1,95 @@
+package termflow
+
+/**
+ * # TermFlow
+ *
+ * An Elm-style TUI framework for Scala 3.
+ *
+ * Apps describe their state as a `Model`, react to inputs via a pure
+ * `update`, render a virtual DOM via `view`, and let
+ * [[termflow.tui.TuiRuntime]] handle the loop, terminal I/O, and frame
+ * coalescing.
+ *
+ * ## Five core types
+ *
+ *   - [[termflow.tui.TuiApp]] — the application contract: `init` /
+ *     `update` / `view` / `toMsg`. Most apps are an `object` extending
+ *     this trait.
+ *   - [[termflow.tui.Tui]] — a `(Model, Cmd[Msg])` pair returned by
+ *     `init` and `update`.
+ *   - [[termflow.tui.Cmd]] — effects: `NoCmd`, `Exit`, `GCmd(msg)`,
+ *     `FCmd(future)`, `TermFlowErrorCmd(err)`.
+ *   - [[termflow.tui.Sub]] — subscriptions for keyboard input, timers,
+ *     and resize polling. Use `Sub.InputKey`, `Sub.Every`,
+ *     `Sub.TerminalResize`.
+ *   - [[termflow.tui.VNode]] — the virtual DOM: `TextNode`, `BoxNode`,
+ *     `InputNode`, wrapped in a [[termflow.tui.RootNode]] returned by
+ *     `view`.
+ *
+ * ## Composition stack
+ *
+ *   - [[termflow.tui.Layout]] composes children into a flat list of
+ *     positioned `VNode`s without hand-rolled coordinates.
+ *   - [[termflow.tui.widgets.Button]] /
+ *     [[termflow.tui.widgets.ProgressBar]] /
+ *     [[termflow.tui.widgets.Spinner]] /
+ *     [[termflow.tui.widgets.StatusBar]] in `termflow.tui.widgets`
+ *     provide ready-to-render building blocks; each takes a `given`
+ *     [[termflow.tui.Theme]].
+ *   - [[termflow.tui.Theme]] supplies semantic colour slots (`primary`,
+ *     `success`, `error`, …) so apps don't bake in palettes. Built-ins:
+ *     `Theme.dark`, `Theme.light`, `Theme.mono`.
+ *   - [[termflow.tui.FocusManager]] tracks ordered focusable elements
+ *     for forms and button rows; [[termflow.tui.Keymap]] turns key
+ *     events into messages declaratively.
+ *
+ * ## A minimal runnable example
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.TuiPrelude.*
+ *
+ * object Counter:
+ *   final case class Model(count: Int)
+ *
+ *   enum Msg:
+ *     case Inc, Dec, Quit
+ *
+ *   object App extends TuiApp[Model, Msg]:
+ *     def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] = Model(0).tui
+ *
+ *     def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+ *       msg match
+ *         case Msg.Inc  => m.copy(count = m.count + 1).tui
+ *         case Msg.Dec  => m.copy(count = m.count - 1).tui
+ *         case Msg.Quit => Tui(m, Cmd.Exit)
+ *
+ *     def view(m: Model): RootNode =
+ *       RootNode(
+ *         width    = 40,
+ *         height   = 1,
+ *         children = List(TextNode(1.x, 1.y, List(s"count = \${m.count}".text))),
+ *         input    = None
+ *       )
+ *
+ *     def toMsg(input: PromptLine): Result[Msg] = Right(Msg.Inc)
+ *
+ *   @main def run(): Unit = TuiRuntime.run(App)
+ * }}}
+ *
+ * ## Testing apps
+ *
+ * The `termflow.testkit` package (test classpath, available via
+ * `dependsOn(termflow % "test->test")`) provides `TuiTestDriver` — a
+ * synchronous driver that runs apps without `TuiRuntime` and captures
+ * frames as cell matrices for golden-file comparison via `GoldenSupport`.
+ *
+ * ## Further reading
+ *
+ *   - `docs/DESIGN.md` — architecture and motivation
+ *   - `docs/RENDER_PIPELINE.md` — coalescing, diff rendering, and
+ *     snapshot testing conventions
+ *   - `docs/RUN_EXAMPLES.md` — runnable sample apps and how to launch
+ *     them
+ */
+package object tui


### PR DESCRIPTION
Closes #93.

**Stacked on #95 → #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base branch is \`feature/92-lazy-sub-every\`.

## Summary

Adds \`modules/termflow/src/main/scala/termflow/tui/package.scala\` so the generated scaladoc has an orientation page at \`termflow/tui.html\` instead of dropping readers straight into an alphabetised member list.

The page covers:
- the **five core types** (\`TuiApp\`, \`Tui\`, \`Cmd\`, \`Sub\`, \`VNode\`) with one-liners and links
- the **composition stack** (\`Layout\` → widgets → \`Theme\` → \`FocusManager\` / \`Keymap\`) explaining how the new APIs from this stack fit together
- a complete **minimal runnable \`TuiApp\` example**
- the **testing entry-point** pointer to \`termflow.testkit\`
- **further reading** with links to \`docs/DESIGN.md\`, \`docs/RENDER_PIPELINE.md\`, \`docs/RUN_EXAMPLES.md\`

## Implementation notes

I tried a standalone \`/** doc */ package termflow.tui\` file first (no enclosed declarations). It compiles but Scala 3 scaladoc does **not** render the comment as package documentation — verified by inspecting \`target/scala-3.7.1/api/termflow/tui.html\` and seeing only the auto-generated member listing.

Switching to \`package object tui\` (Scala 2 syntax, still supported in Scala 3) makes scaladoc attach the doc to the package's actual landing page. \`TuiPrelude.scala\` carries a comment saying \"replace former package object\" — that was about avoiding type aliases / extensions in package objects, not about avoiding the syntax for documentation. This file contains only a doc comment, so it doesn't reintroduce any of the original problems.

I also tried wiki-style headings (\`== Heading ==\`) — they render as literal \`<p>== Heading ==</p>\` text. Markdown-style \`## Heading\` is what the rest of the codebase uses and what dottydoc actually processes into anchored \`<h2>\`s.

## Test plan

- [x] \`sbt termflow/clean termflow/doc\` regenerates cleanly with the new content
- [x] Manually inspected \`target/scala-3.7.1/api/termflow/tui.html\`:
  - All cross-references (\`[[termflow.tui.TuiApp]]\` etc.) resolve to working anchors
  - Section headings render as anchored \`<h2>\` elements
  - The minimal example renders inside a \`<pre><code>\` block with line numbers
- [x] \`sbt ciCheck\` green — **239 tests** still passing (this PR is purely additive docs, no runtime changes)

## Out of scope

- Generating a docs site / publishing the scaladoc anywhere
- Cross-linking sample apps from the package page (they're in the \`termflow-sample\` module; cross-module scaladoc links are awkward in dottydoc)
- A landing page for \`termflow.tui.widgets\` (could be a follow-up — same pattern, smaller scope)