### PR TITLE
Refactor SyncCounter / EchoApp / TabsDemoApp views to use Layout

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/counter/SyncCounter.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/counter/SyncCounter.scala
@@ -69,24 +69,41 @@ object SyncCounter:
       val renderedPrompt = Prompt.renderWithPrefix(m.prompt, prefix)
       // Use terminal width with a small right margin.
       val boxWidth = math.max(2, m.terminalWidth - 4)
+
+      // Vertical stack of text rows starting at (2, 2). The Spacer slots a
+      // blank row between the count line and the command list to match the
+      // original hand-positioned layout.
+      val textColumn = Layout.Column(
+        gap = 0,
+        children = List(
+          Layout.Elem(
+            TextNode(
+              1.x,
+              1.y,
+              List(
+                "Current count: ".text,
+                Text(s"${m.counter.count}", renderCount(m.counter.count))
+              )
+            )
+          ),
+          Layout.Spacer(1, 1),
+          Layout.Elem(TextNode(1.x, 1.y, List("Commands:".text(fg = Yellow)))),
+          Layout.Elem(TextNode(1.x, 1.y, List("  increment | + -> increase counter".text))),
+          Layout.Elem(TextNode(1.x, 1.y, List("  decrement | - -> decrease counter".text))),
+          Layout.Elem(TextNode(1.x, 1.y, List("  exit          -> quit".text)))
+        )
+      )
+      val textChildren = textColumn.resolve(Coord(2.x, 2.y))
+
+      // Background border box drawn behind the text column. BoxNodes are
+      // visual-only today (they don't lay out children), so we keep the box
+      // as a sibling of the resolved column rather than wrapping it.
+      val border = BoxNode(1.x, 1.y, boxWidth, 6, children = Nil, style = Style(border = true, fg = Blue))
+
       RootNode(
         m.terminalWidth,
         13,
-        children = List(
-          BoxNode(1.x, 1.y, boxWidth, 6, children = List(), style = Style(border = true, fg = Blue)),
-          TextNode(
-            2.x,
-            2.y,
-            List(
-              "Current count: ".text,
-              Text(s"${m.counter.count}", renderCount(m.counter.count))
-            )
-          ),
-          TextNode(2.x, 4.y, List("Commands:".text(fg = Yellow))),
-          TextNode(2.x, 5.y, List("  increment | + -> increase counter".text)),
-          TextNode(2.x, 6.y, List("  decrement | - -> decrease counter".text)),
-          TextNode(2.x, 7.y, List("  exit          -> quit".text))
-        ),
+        children = border :: textChildren,
         input = Some(
           InputNode(
             2.x,

--- a/modules/termflow-sample/src/main/scala/termflow/apps/echo/EchoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/echo/EchoApp.scala
@@ -81,38 +81,48 @@ object EchoApp:
       val renderedPrompt = Prompt.renderWithPrefix(m.prompt, prefix)
       val innerHeight    = math.max(1, panelHeight - 2)
       val visible        = m.messages.takeRight(innerHeight)
-      val startY         = panelTop + 1 + (innerHeight - visible.length)
       val clearRowWidth  = math.max(1, contentWidth(m.terminalWidth))
 
-      // Explicitly clear message rows each frame so shorter content
-      // cannot leave stale characters behind.
-      val clearNodes =
-        (0 until innerHeight).toList.map { i =>
-          TextNode(2.x, (panelTop + 1 + i).y, List(Text(" " * clearRowWidth, Style())))
-        }
+      // The message panel is always exactly `innerHeight` rows. We pad with
+      // blank-text rows above the messages so they bottom-align inside the
+      // panel — the explicit blanks (rather than `Layout.Spacer`) double as
+      // erase rows so shorter content doesn't ghost previous frames.
+      def blankRow: Layout =
+        Layout.Elem(TextNode(1.x, 1.y, List(Text(" " * clearRowWidth, Style()))))
 
-      val messageNodes =
+      val panelRows: List[Layout] =
         if visible.nonEmpty then
-          visible.zipWithIndex.map { case (msg, i) =>
-            TextNode(2.x, (startY + i).y, List(msg.text))
-          }
+          val padding = innerHeight - visible.length
+          List.fill(padding)(blankRow) ++
+            visible.map(msg => Layout.Elem(TextNode(1.x, 1.y, List(msg.text))))
         else
-          List(
-            TextNode(2.x, (panelTop + 1 + (innerHeight / 2)).y, List("Type a message and press Enter".text(fg = Cyan)))
-          )
+          val before = innerHeight / 2
+          val after  = innerHeight - before - 1
+          List.fill(before)(blankRow) ++
+            List(Layout.Elem(TextNode(1.x, 1.y, List("Type a message and press Enter".text(fg = Cyan))))) ++
+            List.fill(after)(blankRow)
+
+      val column = Layout.Column(
+        gap = 0,
+        children = List(
+          Layout.Elem(TextNode(1.x, 1.y, List(Text("Messages", Style(fg = Blue, underline = true)))))
+        ) ++ panelRows ++ List(
+          // Original layout reserves one blank row between the panel
+          // (which is `innerHeight` tall) and the separator (which sits at
+          // `panelTop + panelHeight = panelTop + innerHeight + 2`).
+          Layout.Spacer(1, 1),
+          Layout.Elem(TextNode(1.x, 1.y, List("──────────────────────────────".text(fg = Cyan)))),
+          Layout.Elem(TextNode(1.x, 1.y, List("Commands:".text(fg = Yellow)))),
+          Layout.Elem(TextNode(1.x, 1.y, List("  clear | /clear -> clear chat".text))),
+          Layout.Elem(TextNode(1.x, 1.y, List("  exit           -> quit".text)))
+        )
+      )
+      val children = column.resolve(Coord(2.x, panelTop.y))
 
       RootNode(
         width = m.terminalWidth,
         height = panelHeight + 8,
-        children = List(
-          TextNode(2.x, panelTop.y, List(Text("Messages", Style(fg = Blue, underline = true))))
-        ) ++ clearNodes ++ messageNodes ++
-          List(
-            TextNode(2.x, (panelTop + panelHeight).y, List("──────────────────────────────".text(fg = Cyan))),
-            TextNode(2.x, (panelTop + panelHeight + 1).y, List("Commands:".text(fg = Yellow))),
-            TextNode(2.x, (panelTop + panelHeight + 2).y, List("  clear | /clear -> clear chat".text)),
-            TextNode(2.x, (panelTop + panelHeight + 3).y, List("  exit           -> quit".text))
-          ),
+        children = children,
         input = Some(
           InputNode(
             2.x,

--- a/modules/termflow-sample/src/main/scala/termflow/apps/tabs/TabsDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/tabs/TabsDemoApp.scala
@@ -137,31 +137,55 @@ object TabsDemoApp:
       val headerText = s"Active: ${active.name} | counter=${active.counter}"
       val headerFit  = if headerText.length <= innerWidth then headerText else headerText.take(innerWidth)
 
-      val children: List[VNode] = List(
-        BoxNode(1.x, 1.y, boxWidth, boxHeight, children = Nil, style = Style(border = true, fg = Blue)),
-        TextNode(2.x, 2.y, List(Text("Tabs Demo", Style(fg = Yellow, bold = true, underline = true)))),
-        TextNode(2.x, 3.y, List(Text(tabBarFit, Style(fg = Magenta, bold = true)))),
-        TextNode(2.x, 4.y, List(Text(headerFit, Style(fg = Cyan)))),
-        TextNode(2.x, 5.y, List(Text("-" * innerWidth, Style(fg = Blue)))),
-        TextNode(2.x, (notesStartY - 1).y, List(Text("Notes (per-tab persistent):", Style(fg = White))))
-      ) ++
-        (if notes.isEmpty then List(TextNode(2.x, notesStartY.y, List(Text("(none)", Style(fg = White)))))
-         else
-           notes.zipWithIndex.map { case (line, idx) =>
-             val text = if line.length <= innerWidth then line else line.take(innerWidth)
-             TextNode(2.x, (notesStartY + idx).y, List(Text(s"- $text", Style(fg = White))))
-           }
-        ) ++
-        List(
-          TextNode(2.x, (boxHeight - 4).y, List(Text("-" * innerWidth, Style(fg = Blue)))),
-          TextNode(
-            2.x,
-            (boxHeight - 3).y,
-            List(Text("Commands: next | prev | tab 1|2|3 | inc | dec", Style(fg = White)))
-          ),
-          TextNode(2.x, (boxHeight - 2).y, List(Text("          note <text> | clear | exit", Style(fg = White)))),
-          TextNode(2.x, (boxHeight - 1).y, List(Text(statusFit, Style(fg = Green))))
+      // Header section: title, tab bar, current-tab header line, separator.
+      val headerColumn = Layout.Column(
+        gap = 0,
+        children = List(
+          Layout.Elem(TextNode(1.x, 1.y, List(Text("Tabs Demo", Style(fg = Yellow, bold = true, underline = true))))),
+          Layout.Elem(TextNode(1.x, 1.y, List(Text(tabBarFit, Style(fg = Magenta, bold = true))))),
+          Layout.Elem(TextNode(1.x, 1.y, List(Text(headerFit, Style(fg = Cyan))))),
+          Layout.Elem(TextNode(1.x, 1.y, List(Text("-" * innerWidth, Style(fg = Blue)))))
         )
+      )
+
+      // Notes section: label sits ON TOP of the header separator (overlap is
+      // intentional in the original layout — text characters overwrite the
+      // dashes wherever the label has chars). Body lines flow below.
+      val notesBody: List[Layout] =
+        if notes.isEmpty then List(Layout.Elem(TextNode(1.x, 1.y, List(Text("(none)", Style(fg = White))))))
+        else
+          notes.map { line =>
+            val text = if line.length <= innerWidth then line else line.take(innerWidth)
+            Layout.Elem(TextNode(1.x, 1.y, List(Text(s"- $text", Style(fg = White)))))
+          }
+
+      // Footer section anchored to the bottom of the box: separator, two
+      // commands lines, status line. Resolved at boxHeight - 4 so it stays
+      // pinned regardless of how tall the notes panel grows.
+      val footerColumn = Layout.Column(
+        gap = 0,
+        children = List(
+          Layout.Elem(TextNode(1.x, 1.y, List(Text("-" * innerWidth, Style(fg = Blue))))),
+          Layout.Elem(
+            TextNode(
+              1.x,
+              1.y,
+              List(Text("Commands: next | prev | tab 1|2|3 | inc | dec", Style(fg = White)))
+            )
+          ),
+          Layout.Elem(TextNode(1.x, 1.y, List(Text("          note <text> | clear | exit", Style(fg = White))))),
+          Layout.Elem(TextNode(1.x, 1.y, List(Text(statusFit, Style(fg = Green)))))
+        )
+      )
+
+      val children: List[VNode] =
+        BoxNode(1.x, 1.y, boxWidth, boxHeight, children = Nil, style = Style(border = true, fg = Blue)) ::
+          headerColumn.resolve(Coord(2.x, 2.y)) :::
+          // Notes label OVERWRITES the header separator at row 5 (deliberate
+          // visual overlap from the original hand-positioned layout).
+          TextNode(2.x, (notesStartY - 1).y, List(Text("Notes (per-tab persistent):", Style(fg = White)))) ::
+          Layout.Column(gap = 0, children = notesBody).resolve(Coord(2.x, notesStartY.y)) :::
+          footerColumn.resolve(Coord(2.x, (boxHeight - 4).y))
 
       RootNode(
         width = m.terminalWidth,


### PR DESCRIPTION
Closes #90.

**Stacked on #96 → #95 → #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base is \`feature/93-package-doc\`.

## Summary

Migrates three headline sample apps to the [`Layout` DSL](../blob/main/modules/termflow/src/main/scala/termflow/tui/Layout.scala) from PR #87. Behavior is **byte-for-byte unchanged** — every existing snapshot golden still matches, no goldens needed re-recording.

| App | What changed |
|---|---|
| **\`SyncCounter\`** | Text rows flow through \`Layout.Column\`; \`Spacer\` slots a blank between the count and command list. The border \`BoxNode\` stays as a background sibling (BoxNodes are visual-only today). |
| **\`EchoApp\`** | The hand-rolled \`clearNodes\` + bottom-aligned \`messageNodes\` pattern collapses into a single \`Layout.Column\` where padding rows are blank-text \`Elem\`s (doubling as erase rows for ghost prevention) and messages are appended. |
| **\`TabsDemoApp\`** | Partial migration: top section and bottom-anchored footer each become their own \`Layout.Column\` resolved at fixed origins. The notes label stays as a deliberately-positioned sibling because its overlap with the header separator is intentional in the original layout. |

## Why partial on TabsDemoApp

`TabsDemoApp` deliberately renders the notes label *on top of* the header separator — the label's characters overwrite the dashes below it. This visual overlap doesn't translate to a single-pass layout (\`Layout.Column\` would treat them as siblings on different rows). Two clean options:

1. Keep the overlap as a sibling node outside the column (chosen here)
2. Add an overlay/z-order primitive to \`Layout\` (scope creep — would belong in a follow-up)

Option 1 keeps the PR additive and the PR scope tight. The boundaries of v1 Layout surface clearly through this exercise — they map onto the deferred features I called out in #77 (alignment, padding, overlay).

## What this PR demonstrates

- **Layout.Column for vertical flow** — \`SyncCounter\` text rows
- **Layout.Spacer for explicit blank rows** — used in both apps where a gap is meaningful
- **Bottom-anchored sub-layouts via computed origin** — \`TabsDemoApp\`'s footer at \`Coord(2.x, (boxHeight - 4).y)\`
- **Hybrid: Layout + sibling absolute-positioned VNodes** — \`TabsDemoApp\`'s notes label overlap
- **Explicit blank-text Elems vs Spacer** — \`EchoApp\` uses the former where ghost-prevention erasure matters; \`Spacer\` doesn't draw cells, so it can leave stale content behind on shrink

## Test plan

- [x] All 4 \`SyncCounterSnapshotSpec\` golden frames match unchanged
- [x] All 4 \`EchoAppSnapshotSpec\` golden frames match unchanged
- [x] All 4 \`TabsDemoAppSnapshotSpec\` golden frames match unchanged
- [x] \`sbt ciCheck\` green — **239 tests total**, no goldens re-recorded
- [x] Manually inspected each \`view\` against the original to verify the same set of \`VNode\`s (with the same coords) is produced

## Pointers to follow-up issues

The pain points encountered during the migration map to existing follow-ups:

- Bottom anchoring would benefit from an explicit alignment primitive — would belong in a future Layout enhancement issue (none filed yet; happy to file if useful)
- Notes label overlap motivates an overlay/z-ordering primitive — same as above
- The \`EchoApp\` ghost-prevention pattern (blank-text Elem vs \`Spacer\`) suggests \`Layout.Spacer\` could grow a \"clear-on-reflow\" variant — also a future enhancement candidate

## Out of scope (per the issue)

- New Layout features (alignment, padding, flex weights)
- Migrating non-headline samples (clock variants, stress, repro apps, hub) — those are smaller and don't add new patterns
- Behavioural changes to the apps themselves