### PR TITLE
Add sbt aliases for sample apps and refresh RUN_EXAMPLES.md

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,3 +125,19 @@ addCommandAlias(
   "publishLocalFixed",
   s"""set ThisBuild / version := "$fixedLocalVersion"; publishLocal"""
 )
+
+// --- Sample-app launchers --------------------------------------------------
+// Short aliases so contributors can run a demo without typing the full
+// runMain incantation. Use a real interactive terminal — JLine falls back
+// to a dumb backend when stdin/stdout are pipes.
+addCommandAlias("hubDemo",      "termflowSample/runMain termflow.run.SampleHubMain")
+addCommandAlias("widgetsDemo",  "termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp")
+addCommandAlias("echoDemo",     "termflowSample/runMain termflow.apps.echo.EchoApp")
+addCommandAlias("counterDemo",  "termflowSample/runMain termflow.apps.counter.SyncCounter")
+addCommandAlias("futureDemo",   "termflowSample/runMain termflow.apps.counter.FutureCounter")
+addCommandAlias("clockDemo",    "termflowSample/runMain termflow.apps.clock.DigitalClock")
+addCommandAlias("tabsDemo",     "termflowSample/runMain termflow.apps.tabs.TabsDemoApp")
+addCommandAlias("taskDemo",     "termflowSample/runMain termflow.apps.task.Task")
+addCommandAlias("stressDemo",   "termflowSample/runMain termflow.apps.stress.RenderStressApp")
+addCommandAlias("sineDemo",     "termflowSample/runMain termflow.apps.stress.SineWaveApp")
+addCommandAlias("inputDemo",    "termflowSample/runMain termflow.apps.input.InputLineReproApp")

--- a/docs/RUN_EXAMPLES.md
+++ b/docs/RUN_EXAMPLES.md
@@ -1,57 +1,94 @@
 # Run TermFlow Sample Apps Quickly
 
-This guide collects working `sbt` commands for launching the sample apps in `modules/termflow-sample`.
+Working `sbt` commands for launching the sample apps in `modules/termflow-sample`.
 
-## One-off Runs
+> **Run these in a real interactive terminal.** TermFlow apps are full-screen
+> TUIs driven by JLine; if `sbt` is invoked with stdin/stdout piped or
+> redirected, JLine falls back to a dumb terminal and the demos won't render
+> correctly. If a TUI exits abnormally and leaves your terminal in a weird
+> state, run `reset`.
+
+## Short aliases (recommended)
+
+`build.sbt` defines short command aliases for the headline apps. From the
+`sbt` prompt or as a one-shot:
 
 ```bash
-# Sample hub dashboard (launches other demos)
-sbt "termflowSample/runMain termflow.run.SampleHubMain"
-
-# Echo app
-sbt "termflowSample/runMain termflow.apps.echo.EchoApp"
-
-# Counter (sync)
-sbt "termflowSample/runMain termflow.apps.counter.SyncCounter"
-
-# Counter (async + spinner)
-sbt "termflowSample/runMain termflow.apps.counter.FutureCounter"
-
-# Clock
-sbt "termflowSample/runMain termflow.apps.clock.DigitalClock"
-
-# Task manager
-sbt "termflowSample/runMain termflow.apps.task.Task"
-
-# Render stress test (high-frequency updates)
-sbt "termflowSample/runMain termflow.apps.stress.RenderStressApp"
-
-# Moving sine wave
-sbt "termflowSample/runMain termflow.apps.stress.SineWaveApp"
-
-# Tabs demo (switch tabs with independent state)
-sbt "termflowSample/runMain termflow.apps.tabs.TabsDemoApp"
+sbt widgetsDemo       # Layout + Theme + Button/ProgressBar/Spinner/StatusBar
+sbt hubDemo           # Sample hub dashboard (launches other demos)
+sbt echoDemo          # Echo / chat-style scrollback
+sbt counterDemo       # Sync counter (Layout-based)
+sbt futureDemo        # Async counter using Cmd.FCmd
+sbt clockDemo         # Digital clock driven by Sub.Every
+sbt tabsDemo          # Multi-tab dashboard
+sbt taskDemo          # Task manager
+sbt stressDemo        # High-frequency renders for repaint stress testing
+sbt sineDemo          # Animated sine wave
+sbt inputDemo         # Prompt / cursor regression repro (#73 / #74)
 ```
 
-## Convenience Shell Snippet
+Inside an `sbt` session you can chain them: `sbt> widgetsDemo`.
 
-Put this in your shell profile (`~/.zshrc` / `~/.bashrc`) for shorter commands:
+## Full `runMain` form
+
+If you need to launch an app the aliases don't cover, the explicit form is:
+
+```bash
+sbt "termflowSample/runMain <fully.qualified.AppObject>"
+```
+
+For example:
+
+```bash
+# Diagnostics demo (logging + render metrics)
+sbt "termflowSample/runMain termflow.apps.diagnostics.LoggingMetricsDemoApp"
+
+# Clock variant driven by a custom random source
+sbt "termflowSample/runMain termflow.apps.clock.DigitalClockWithRandomSource"
+
+# Provider-chat repro reproduction (chat scrollback + render edge cases)
+sbt "termflowSample/runMain termflow.apps.chat.ProviderChatRenderReproMain"
+```
+
+## What each headline demo shows
+
+| Alias | App | Demonstrates |
+|---|---|---|
+| `widgetsDemo` | `WidgetsDemoApp` | The full new stack: `Layout.column`/`row`, a `given Theme` with toggleable dark/light, `Button` focus, `Spinner` + `ProgressBar` driven by `Sub.Every`, `StatusBar` at the bottom, `FocusManager` + `Keymap` for input dispatch |
+| `hubDemo` | `SampleHubApp` | Menu launcher; pick a sub-app by name or number |
+| `counterDemo` | `SyncCounter` | Minimal Elm-style app; the simplest example to read |
+| `futureDemo` | `FutureCounter` | `Cmd.FCmd` for async work, with a spinner while pending |
+| `tabsDemo` | `TabsDemoApp` | Multiple tabs with independent state, layout-driven |
+| `clockDemo` | `DigitalClock` | `Sub.Every` ticking at 1 Hz |
+| `stressDemo` | `RenderStressApp` | High-frequency updates — useful for spotting flicker |
+| `sineDemo` | `SineWaveApp` | Animated sine wave; same purpose as `stressDemo` with smoother motion |
+| `inputDemo` | `InputLineReproApp` | Pinned reproduction of the prompt/cursor regressions behind #73 and #74 |
+
+## Widgets demo keys
+
+The widgets demo (`sbt widgetsDemo`) is interactive:
+
+| Key | Action |
+|---|---|
+| `Tab` | cycle button focus (Save ↔ Cancel) |
+| `Enter` / `Space` | activate the focused button |
+| `t` | toggle dark / light theme |
+| `+` / `-` | nudge progress ± 10 % |
+| `q` / `Ctrl+C` / `Esc` | quit |
+
+## Convenience shell snippet (optional)
+
+If you'd rather have shell-level shortcuts, drop this in `~/.zshrc` /
+`~/.bashrc`:
 
 ```bash
 termflow-run() {
   local app="$1"
   case "$app" in
-    hub) sbt "termflowSample/runMain termflow.run.SampleHubMain" ;;
-    echo) sbt "termflowSample/runMain termflow.apps.echo.EchoApp" ;;
-    sync-counter) sbt "termflowSample/runMain termflow.apps.counter.SyncCounter" ;;
-    future-counter) sbt "termflowSample/runMain termflow.apps.counter.FutureCounter" ;;
-    clock) sbt "termflowSample/runMain termflow.apps.clock.DigitalClock" ;;
-    task) sbt "termflowSample/runMain termflow.apps.task.Task" ;;
-    stress) sbt "termflowSample/runMain termflow.apps.stress.RenderStressApp" ;;
-    sine) sbt "termflowSample/runMain termflow.apps.stress.SineWaveApp" ;;
-    tabs) sbt "termflowSample/runMain termflow.apps.tabs.TabsDemoApp" ;;
+    hub|widgets|echo|counter|future|clock|tabs|task|stress|sine|input)
+      sbt "${app}Demo" ;;
     *)
-      echo "Usage: termflow-run {hub|echo|sync-counter|future-counter|clock|task|stress|sine|tabs}"
+      echo "Usage: termflow-run {hub|widgets|echo|counter|future|clock|tabs|task|stress|sine|input}"
       return 1
       ;;
   esac
@@ -61,11 +98,11 @@ termflow-run() {
 Then run:
 
 ```bash
-termflow-run future-counter
+termflow-run widgets
 ```
 
 ## Notes
 
 - These apps run in an interactive TUI; use a normal terminal.
 - If terminal state looks odd after interruption, run `reset`.
-- `termflow.run.TermFlowMain` now defaults to the sample hub when run without args.
+- `termflow.run.TermFlowMain` defaults to the sample hub when run without args, so `sbt "termflowSample/runMain termflow.run.TermFlowMain"` is equivalent to `sbt hubDemo`.


### PR DESCRIPTION
Follow-up to PR #97 (#90 sample refactors).

**Stacked on #97 → #96 → #95 → #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base branch is \`feature/90-layout-samples\`.

## Summary

- 11 new \`sbt\` command aliases for the headline sample apps
- \`docs/RUN_EXAMPLES.md\` rewritten to lead with the aliases, add the missing apps (\`WidgetsDemoApp\`, \`InputLineReproApp\`), document the new keybindings, and call out the \"use a real terminal\" caveat I hit during PR #89's smoke run

## What you get

\`\`\`bash
sbt widgetsDemo       # Layout + Theme + widgets + FocusManager + Keymap
sbt counterDemo       # Sync counter (Layout-based after #97)
sbt tabsDemo          # Multi-tab dashboard
sbt clockDemo         # Sub.Every ticker
sbt stressDemo        # High-frequency repaint stress test
# ...and 6 more
\`\`\`

Verified via \`sbt 'help widgetsDemo'\`:
\`\`\`
Alias of 'termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp'
\`\`\`

## Files changed

- **\`build.sbt\`** — 11 \`addCommandAlias\` lines for hub / widgets / echo / counter / future / clock / tabs / task / stress / sine / input
- **\`docs/RUN_EXAMPLES.md\`** — restructured: short-alias table first (recommended path), full \`runMain\` form for less common apps, per-demo \"what it shows\" table, widgets-demo keybindings table, refreshed shell helper that delegates to the aliases

## Test plan

- [x] \`sbt ciCheck\` green — **239 tests** still passing (no source code changes)
- [x] \`sbt 'help widgetsDemo'\` confirms the alias resolves to the right command
- [x] Manually inspected the rendered Markdown — tables and code blocks render cleanly on GitHub

## Out of scope

- Wiring the demo into the \`SampleHubApp\` menu (would touch the Choice enum + dispatch — own concern)
- A test that asserts each alias resolves (\`sbt 'aliases'\` returns nothing useful from a shell — there's no clean automated way to introspect command aliases)