### PR TITLE
Add Devtools.History recording primitive (Phase 1 of #83)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
@@ -1,0 +1,192 @@
+package termflow.tui
+
+/**
+ * In-memory recording primitives for time-travel debugging of TermFlow apps.
+ *
+ * The [[TuiApp]] contract is already pure with respect to `model` and `msg`,
+ * which is exactly the property Elm's debugger exploits. This object provides
+ * the data structures an app (or a future devtools wrapper) needs to capture
+ * a sequence of `(msg, model)` transitions and inspect or rewind them.
+ *
+ * ## Phase 1 (this object)
+ *
+ *   - [[Devtools.History]] — bounded immutable ring buffer of [[Devtools.Frame]]s
+ *   - [[Devtools.Frame]] — one transition: timestamp, optional `Msg`, resulting `Model`
+ *   - Apps record manually in `update`; nothing in the runtime changes
+ *
+ * ## Phase 2 (deferred follow-up)
+ *
+ * A `TuiApp` wrapper that:
+ *   - records every transition automatically
+ *   - exposes a hotkey-toggled overlay (history list + rewind controls)
+ *   - intercepts replay messages and re-applies forward transitions
+ *
+ * Phase 2 needs more design work around overlay rendering and key
+ * interception — see the follow-up issue filed alongside this PR.
+ *
+ * ## Manual integration today
+ *
+ * {{{
+ * case class Model(
+ *   count: Int,
+ *   history: Devtools.History[Msg, Model]
+ * )
+ *
+ * def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+ *   val initial = Model(0, Devtools.History.empty(capacity = 200))
+ *   initial.copy(history = initial.history.snapshot(initial)).tui
+ *
+ * def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+ *   val nextModel = msg match
+ *     case Msg.Inc => m.copy(count = m.count + 1)
+ *     case Msg.Dec => m.copy(count = m.count - 1)
+ *   nextModel.copy(history = nextModel.history.record(msg, nextModel)).tui
+ *
+ * // Later, dump the recording to a file or surface it in a debug overlay:
+ * println(model.history.toReport)
+ * }}}
+ */
+object Devtools:
+
+  /** Wall-clock timestamp from `System.currentTimeMillis`. */
+  def now(): Long = System.currentTimeMillis()
+
+  /**
+   * One entry in a [[History]] — a snapshot of the model after a transition,
+   * with the message that caused it.
+   *
+   * @param index           Monotonically increasing position in the recording. Survives ring-buffer wrap-around.
+   * @param timestampMillis Wall-clock time the frame was captured.
+   * @param msg             The dispatched message, or `None` for an initial `snapshot`.
+   * @param model           The model after the transition (or the initial state).
+   */
+  final case class Frame[+Msg, +Model](
+    index: Int,
+    timestampMillis: Long,
+    msg: Option[Msg],
+    model: Model
+  )
+
+  /**
+   * Bounded immutable ring buffer of [[Frame]]s.
+   *
+   * `capacity` is the maximum number of frames retained; once full, recording
+   * a new frame discards the oldest. The `index` on each frame is unique
+   * across the lifetime of the history (it does **not** reset on wrap), so
+   * callers can refer to a specific frame even after older entries have
+   * been evicted — `at(index)` returns `None` once a frame has fallen off
+   * the back.
+   *
+   * Every transition method returns a new `History` — the receiver is never
+   * mutated.
+   *
+   * @param capacity  Maximum number of retained frames. Must be positive.
+   * @param frames    Frames in chronological order, oldest first.
+   * @param nextIndex The index that will be assigned to the next recorded frame.
+   */
+  final case class History[+Msg, +Model] private[tui] (
+    capacity: Int,
+    frames: Vector[Frame[Msg, Model]],
+    nextIndex: Int
+  ):
+    require(capacity > 0, s"History capacity must be > 0 (got $capacity)")
+
+    /** Number of frames currently retained. */
+    def size: Int = frames.size
+
+    /** `true` when no frames have been recorded yet. */
+    def isEmpty: Boolean = frames.isEmpty
+
+    /** `true` when the buffer is at capacity; the next record will evict the oldest. */
+    def isFull: Boolean = frames.size == capacity
+
+    /** Most recent frame, if any. */
+    def latest: Option[Frame[Msg, Model]] = frames.lastOption
+
+    /** Oldest retained frame, if any. */
+    def oldest: Option[Frame[Msg, Model]] = frames.headOption
+
+    /** Look up a frame by its (lifetime-unique) index. Returns `None` if evicted. */
+    def at(index: Int): Option[Frame[Msg, Model]] =
+      frames.find(_.index == index)
+
+    /**
+     * Record an initial-state snapshot (no causing message).
+     *
+     * Conventionally used once after `init` to capture the starting model.
+     * Multiple snapshots are allowed if the app wants to mark waypoints,
+     * but the more idiomatic way to log them is `record(msg, model)`.
+     */
+    def snapshot[M2 >: Model](model: M2, atMillis: Long = now()): History[Msg, M2] =
+      append(Frame(nextIndex, atMillis, None, model))
+
+    /** Record a `(msg → model)` transition. */
+    def record[Ms2 >: Msg, M2 >: Model](
+      msg: Ms2,
+      model: M2,
+      atMillis: Long = now()
+    ): History[Ms2, M2] =
+      append(Frame(nextIndex, atMillis, Some(msg), model))
+
+    private def append[Ms2 >: Msg, M2 >: Model](f: Frame[Ms2, M2]): History[Ms2, M2] =
+      val nextFrames = if isFull then frames.tail :+ f else frames :+ f
+      copy(frames = nextFrames, nextIndex = nextIndex + 1)
+
+    /**
+     * Truncate history at the given frame index, preserving frames up to and
+     * including `index` and dropping everything after.
+     *
+     * After a successful rewind, `nextIndex` is set to `index + 1` so that
+     * subsequently recorded frames continue with fresh, monotonically
+     * increasing indices. Returns `None` if the requested index isn't in the
+     * retained window (either never recorded or already evicted).
+     */
+    def rewindTo(index: Int): Option[History[Msg, Model]] =
+      val keepUpto = frames.indexWhere(_.index == index)
+      if keepUpto < 0 then None
+      else Some(copy(frames = frames.take(keepUpto + 1), nextIndex = index + 1))
+
+    /**
+     * Drop every retained frame but keep `capacity` and `nextIndex`.
+     *
+     * Useful between independent scenarios in long-lived sessions; the
+     * preserved `nextIndex` means later frames don't collide with previously
+     * exported references.
+     */
+    def cleared: History[Msg, Model] = copy(frames = Vector.empty)
+
+    /**
+     * Render a human-readable text dump of the recording.
+     *
+     * Format is one line per frame:
+     * {{{
+     *   #  4 | t=+ 120ms | Increment       | Model(count=3)
+     * }}}
+     * Timestamps are reported relative to the first retained frame for
+     * readability. Useful for printing on shutdown, logging, or pasting
+     * into a bug report.
+     */
+    def toReport: String =
+      if frames.isEmpty then "(no recorded frames)"
+      else
+        val base = frames.head.timestampMillis
+        val sb   = new StringBuilder
+        sb.append(s"History — ${frames.size}/$capacity frames retained\n")
+        frames.foreach { f =>
+          val rel = f.timestampMillis - base
+          val msg = f.msg.fold("(initial)")(_.toString)
+          sb.append(
+            f"  #${f.index}%4d | t=+${rel}%5dms | ${truncate(msg, 32)}%-32s | ${truncate(f.model.toString, 60)}\n"
+          )
+        }
+        sb.toString
+
+    private def truncate(s: String, maxLen: Int): String =
+      if s.length <= maxLen then s
+      else s.take(math.max(0, maxLen - 1)) + "…"
+
+  object History:
+
+    /** Build an empty history with the given retention capacity. */
+    def empty[Msg, Model](capacity: Int): History[Msg, Model] =
+      History(capacity, Vector.empty, 0)

--- a/modules/termflow/src/test/scala/termflow/tui/DevtoolsSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DevtoolsSpec.scala
@@ -1,0 +1,170 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DevtoolsSpec extends AnyFunSuite:
+
+  enum DemoMsg:
+    case Inc, Dec, Reset
+
+  // --- construction ---------------------------------------------------------
+
+  test("History.empty starts with size 0 and isEmpty true"):
+    val h = Devtools.History.empty[DemoMsg, Int](capacity = 8)
+    assert(h.isEmpty)
+    assert(h.size == 0)
+    assert(!h.isFull)
+    assert(h.latest.isEmpty)
+    assert(h.oldest.isEmpty)
+
+  test("History rejects non-positive capacity"):
+    intercept[IllegalArgumentException](Devtools.History.empty[DemoMsg, Int](capacity = 0))
+    intercept[IllegalArgumentException](Devtools.History.empty[DemoMsg, Int](capacity = -1))
+
+  // --- snapshot / record ----------------------------------------------------
+
+  test("snapshot adds an initial frame with no message"):
+    val h = Devtools.History.empty[DemoMsg, Int](capacity = 4).snapshot(0, atMillis = 100L)
+    assert(h.size == 1)
+    val f = h.latest.get
+    assert(f.index == 0)
+    assert(f.timestampMillis == 100L)
+    assert(f.msg.isEmpty)
+    assert(f.model == 0)
+
+  test("record adds a transition frame with the dispatched message"):
+    val h = Devtools.History
+      .empty[DemoMsg, Int](capacity = 4)
+      .snapshot(0, atMillis = 100L)
+      .record(DemoMsg.Inc, 1, atMillis = 200L)
+    assert(h.size == 2)
+    val f = h.latest.get
+    assert(f.index == 1)
+    assert(f.timestampMillis == 200L)
+    assert(f.msg.contains(DemoMsg.Inc))
+    assert(f.model == 1)
+
+  test("indices increment monotonically across snapshot and record"):
+    val h = Devtools.History
+      .empty[DemoMsg, Int](capacity = 8)
+      .snapshot(0, atMillis = 0L)
+      .record(DemoMsg.Inc, 1, atMillis = 0L)
+      .record(DemoMsg.Inc, 2, atMillis = 0L)
+      .record(DemoMsg.Dec, 1, atMillis = 0L)
+    assert(h.frames.map(_.index) == Vector(0, 1, 2, 3))
+
+  // --- ring-buffer wrap ----------------------------------------------------
+
+  test("recording past capacity evicts the oldest frame"):
+    val h0 = Devtools.History.empty[DemoMsg, Int](capacity = 3)
+    val h  = (1 to 5).foldLeft(h0)((acc, n) => acc.record(DemoMsg.Inc, n, atMillis = n.toLong))
+    assert(h.size == 3)
+    assert(h.isFull)
+    // Oldest two frames (indices 0 and 1) were evicted.
+    assert(h.frames.map(_.index) == Vector(2, 3, 4))
+    assert(h.frames.map(_.model) == Vector(3, 4, 5))
+    // nextIndex continues unaffected.
+    assert(h.nextIndex == 5)
+
+  test("at(index) returns the frame for retained indices and None for evicted ones"):
+    val h0 = Devtools.History.empty[DemoMsg, Int](capacity = 3)
+    val h  = (0 to 4).foldLeft(h0)((acc, n) => acc.record(DemoMsg.Inc, n, atMillis = n.toLong))
+    // Indices 0 and 1 evicted; 2..4 retained.
+    assert(h.at(0).isEmpty)
+    assert(h.at(1).isEmpty)
+    assert(h.at(2).map(_.model).contains(2))
+    assert(h.at(4).map(_.model).contains(4))
+    assert(h.at(99).isEmpty)
+
+  // --- rewindTo ------------------------------------------------------------
+
+  test("rewindTo truncates to the named frame and resets nextIndex"):
+    val h0 = (0 to 4).foldLeft(Devtools.History.empty[DemoMsg, Int](capacity = 8))((acc, n) =>
+      acc.record(DemoMsg.Inc, n, atMillis = 0L)
+    )
+    val rewound = h0.rewindTo(2).get
+    assert(rewound.frames.map(_.index) == Vector(0, 1, 2))
+    assert(rewound.nextIndex == 3)
+    // A new record after rewind continues with the next index.
+    val branched = rewound.record(DemoMsg.Reset, 99, atMillis = 0L)
+    assert(branched.latest.get.index == 3)
+    assert(branched.latest.get.msg.contains(DemoMsg.Reset))
+    assert(branched.latest.get.model == 99)
+
+  test("rewindTo returns None for indices not present in the window"):
+    val h0 = Devtools.History.empty[DemoMsg, Int](capacity = 2)
+    val h  = h0.record(DemoMsg.Inc, 1, atMillis = 0L).record(DemoMsg.Inc, 2, atMillis = 0L)
+    // Frame at index 0 was evicted; rewindTo(0) should fail.
+    val h2 = h.record(DemoMsg.Inc, 3, atMillis = 0L)
+    assert(h2.rewindTo(0).isEmpty)
+    // Future indices likewise.
+    assert(h2.rewindTo(99).isEmpty)
+
+  test("rewindTo to the latest index is a no-op"):
+    val h = Devtools.History
+      .empty[DemoMsg, Int](capacity = 4)
+      .record(DemoMsg.Inc, 1, atMillis = 0L)
+      .record(DemoMsg.Inc, 2, atMillis = 0L)
+    val rewound = h.rewindTo(1).get
+    assert(rewound.frames == h.frames)
+    assert(rewound.nextIndex == 2)
+
+  // --- cleared --------------------------------------------------------------
+
+  test("cleared empties frames but preserves capacity and nextIndex"):
+    val h = Devtools.History
+      .empty[DemoMsg, Int](capacity = 8)
+      .record(DemoMsg.Inc, 1, atMillis = 0L)
+      .record(DemoMsg.Inc, 2, atMillis = 0L)
+    val cleared = h.cleared
+    assert(cleared.isEmpty)
+    assert(cleared.capacity == 8)
+    assert(cleared.nextIndex == 2)
+    // Subsequent records get fresh, non-colliding indices.
+    val next = cleared.record(DemoMsg.Reset, 0, atMillis = 0L)
+    assert(next.latest.get.index == 2)
+
+  // --- toReport ------------------------------------------------------------
+
+  test("toReport on an empty history returns a placeholder"):
+    val r = Devtools.History.empty[DemoMsg, Int](capacity = 4).toReport
+    assert(r == "(no recorded frames)")
+
+  test("toReport renders the header and one line per frame with relative timestamps"):
+    val h = Devtools.History
+      .empty[DemoMsg, Int](capacity = 8)
+      .snapshot(0, atMillis = 1000L)
+      .record(DemoMsg.Inc, 1, atMillis = 1120L)
+      .record(DemoMsg.Inc, 2, atMillis = 1300L)
+    val r = h.toReport
+    assert(r.contains("3/8 frames retained"))
+    // Timestamps are relative to the first retained frame.
+    assert(r.contains("t=+    0ms"))
+    assert(r.contains("t=+  120ms"))
+    assert(r.contains("t=+  300ms"))
+    // Initial snapshot is labelled as such; transitions show their msg.
+    assert(r.contains("(initial)"))
+    assert(r.contains("Inc"))
+
+  test("toReport truncates very long msg / model strings"):
+    case class BigModel(label: String)
+    val long = "a" * 200
+    val h = Devtools.History
+      .empty[String, BigModel](capacity = 4)
+      .record(long, BigModel(long), atMillis = 0L)
+    val r = h.toReport
+    // Truncation marker '…' should appear for both columns.
+    assert(r.contains("…"))
+
+  // --- immutability ---------------------------------------------------------
+
+  test("transitions never mutate the receiver"):
+    val h0 = Devtools.History.empty[DemoMsg, Int](capacity = 4).snapshot(0, atMillis = 0L)
+    val h1 = h0.record(DemoMsg.Inc, 1, atMillis = 0L)
+    val h2 = h0.record(DemoMsg.Dec, -1, atMillis = 0L)
+    // Both branches see the same h0.
+    assert(h0.size == 1)
+    assert(h0.latest.get.model == 0)
+    // The two branches diverge.
+    assert(h1.latest.get.model == 1)
+    assert(h2.latest.get.model == -1)


### PR DESCRIPTION
Phase 1 of #83. Phase 2 (TuiApp wrapper + overlay UI) tracked in #99.

**Stacked on #98 → #97 → #96 → #95 → #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base is \`feature/run-examples-doc\`.

## Summary

The data primitives for time-travel debugging — fully tested, ScalaDoc'd, and integrable manually today. The user-facing wrapper + overlay UI is Phase 2, filed as #99.

- **\`Devtools.Frame[Msg, Model]\`** — single recording entry: index, timestamp, optional Msg, resulting Model
- **\`Devtools.History[Msg, Model]\`** — bounded immutable ring buffer with \`snapshot\` / \`record\` / \`rewindTo\` / \`cleared\` / \`toReport\`

15 unit tests, 200+ lines of ScalaDoc, no runtime changes — purely additive.

## Why split into phases

The original #83 issue describes a complete dev-mode wrapper with overlay rendering, hotkey toggle, scrollable history list, and rewind controls. Trying to land that in one PR would either:

1. **Over-scope**: combine three substantial design decisions (key interception strategy, overlay rendering on top of an opaque-only renderer, configuration ergonomics) into one PR with no room to iterate
2. **Short-change**: pick quick choices for each and discover they're wrong in PR review

Splitting cleanly: Phase 1 ships the data primitive (this PR), Phase 2 (#99) builds the user-facing wrapper on top with proper design space to make the right calls. The data primitive is independently useful — apps can integrate it manually today.

## API at a glance

\`\`\`scala
val h0 = Devtools.History.empty[Msg, Model](capacity = 200)

// Record an initial-state snapshot:
val h1 = h0.snapshot(initialModel)

// Record a transition (in update):
val h2 = h1.record(msg, nextModel)

// Inspect:
h2.size              // 2
h2.latest            // Some(Frame(index=1, msg=Some(msg), model=nextModel, ...))
h2.at(0)             // Some(Frame(index=0, msg=None, ...))
h2.toReport          // human-readable text dump

// Rewind:
val h3 = h2.rewindTo(0).get  // truncates to index 0; nextIndex = 1
\`\`\`

## Manual integration today

Apps that want devtools before Phase 2 ships can integrate manually:

\`\`\`scala
case class Model(
  count: Int,
  history: Devtools.History[Msg, Model]
)

def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
  val initial = Model(0, Devtools.History.empty(capacity = 200))
  initial.copy(history = initial.history.snapshot(initial)).tui

def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
  val nextModel = msg match
    case Msg.Inc => m.copy(count = m.count + 1)
    // ...
  nextModel.copy(history = nextModel.history.record(msg, nextModel)).tui

// Later, dump the recording (e.g. on shutdown or via a debug message):
println(model.history.toReport)
\`\`\`

## Design notes

- **Indices survive ring-buffer wrap-around.** If frames \`#0\`–\`#1\` are evicted by capacity, \`at(0)\` returns \`None\` (not a misleading frame). This means external references to a frame stay valid until eviction, then fail loudly.
- **Rewind resets \`nextIndex\` to \`rewoundTo + 1\`.** New recordings after a rewind get fresh, monotonically increasing indices — matches Elm-debugger behaviour where a rewind discards the \"future\" and the timeline branches from the rewind point.
- **\`toReport\` is the only \"render\" surface in v1.** Pretty-prints to text suitable for logs / pasting into bug reports. Real overlay rendering belongs to Phase 2.
- **Timestamps are explicit parameters with a \`now()\` default.** Production code uses \`System.currentTimeMillis\`; tests pass deterministic values.

## Test plan

- [x] **15 DevtoolsSpec tests** covering construction (zero/negative capacity rejection), snapshot/record, monotonic indices, ring-buffer wrap, \`at()\` pre/post eviction, \`rewindTo\` (success / missing / no-op), \`cleared\` preserving \`nextIndex\`, \`toReport\` (empty / multi-frame / truncation of wide values), and immutability across branching transitions
- [x] \`sbt ciCheck\` green — **254 tests total** (215 termflow + 39 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly with the new content (only the pre-existing \`-classpath\` warning remains)

## Out of scope (Phase 2 / #99)

- The \`Devtools.wrap(app)\` decorator
- Hotkey-toggled overlay rendering on top of \`inner.view\`
- Scrollable history list + rewind UI
- Replay-forward through captured \"future\" frames after a rewind
- File-export wiring (\`toReport\` exists; writing to a path is an app concern for now)

## Out of scope (per #83 itself)

- Full Redux-devtools-style persistence across restarts
- Editing messages inline
- Remote devtools over a socket