### PR TITLE
Add TextField stateful widget (first cut of #91)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/widgets/TextField.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/TextField.scala
@@ -1,0 +1,215 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Single-line editable text field — the first stateful widget in the
+ * library and the building block for forms.
+ *
+ * `TextField` is **purely value-based**: state lives in the app's model,
+ * `handleKey` advances it, and `view` renders it. There is no implicit
+ * cursor placement: the cursor in a focused field is drawn as an
+ * inverse-video cell so multiple fields can be on screen simultaneously
+ * without competing for the OS cursor (which can only land in one place,
+ * via `RootNode.input`).
+ *
+ * For single-prompt apps that want the OS cursor (typing into a shell-like
+ * line at the bottom of the screen) the existing `Prompt` infrastructure
+ * is still the right choice. `TextField` is for forms where multiple
+ * editable fields live alongside other widgets.
+ *
+ * ## Anatomy
+ *
+ *   - [[TextField.State]] — `(buffer, cursor, placeholder)` triple
+ *   - [[TextField.handleKey]] — pure function: `(state, key) → (state, Option[Msg])`
+ *   - [[TextField.view]] — produces a `TextNode` of exactly `lineWidth` cells
+ *
+ * Unlike `Prompt.handleKey`, this one returns a plain `Option[Msg]` (not
+ * `Option[Cmd[Msg]]`) and does not hard-wire any global keys: `Ctrl+C` /
+ * `Ctrl+D` are not handled here. Apps should route those via [[Keymap]].
+ *
+ * ## Usage with FocusManager + Keymap
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.widgets.*
+ *
+ * given Theme = Theme.dark
+ * val NameId  = FocusId("name")
+ * val EmailId = FocusId("email")
+ *
+ * case class Model(
+ *   name: TextField.State,
+ *   email: TextField.State,
+ *   fm: FocusManager
+ * )
+ *
+ * enum Msg:
+ *   case Submit(name: String)
+ *   case ConsoleInputKey(k: KeyDecoder.InputKey)
+ *
+ * // In update:
+ * case Msg.ConsoleInputKey(k) if model.fm.isFocused(NameId) =>
+ *   val (next, maybe) = TextField.handleKey(model.name, k)(s => Some(Msg.Submit(s)))
+ *   val nextModel = model.copy(name = next)
+ *   maybe.fold(nextModel.tui)(m => Tui(nextModel, Cmd.GCmd(m)))
+ *
+ * // In view:
+ * Layout.column(gap = 1)(
+ *   TextField.view(model.name,  lineWidth = 30, focused = model.fm.isFocused(NameId)),
+ *   TextField.view(model.email, lineWidth = 30, focused = model.fm.isFocused(EmailId))
+ * )
+ * }}}
+ */
+object TextField:
+
+  /**
+   * Editable state for a single field.
+   *
+   * @param buffer      Current text content.
+   * @param cursor      Insertion-point index in `[0, buffer.length]`.
+   * @param placeholder Hint text shown when `buffer` is empty AND the field
+   *                    is not focused. Empty disables the placeholder.
+   */
+  final case class State(
+    buffer: String = "",
+    cursor: Int = 0,
+    placeholder: String = ""
+  ):
+
+    /** `true` when the buffer has no characters. */
+    def isEmpty: Boolean = buffer.isEmpty
+
+    /** Number of characters in the buffer (not counting the placeholder). */
+    def length: Int = buffer.length
+
+  object State:
+
+    /** Empty field with no placeholder. */
+    val empty: State = State()
+
+    /** Empty field with a placeholder shown when unfocused. */
+    def withPlaceholder(p: String): State = State(placeholder = p)
+
+    /** Pre-populated field with the cursor at the end. */
+    def of(text: String): State = State(buffer = text, cursor = text.length)
+
+  /**
+   * Process one keystroke, returning a new state and optionally a message
+   * to dispatch (typically the submitted value on `Enter`).
+   *
+   * Behaviour:
+   *   - `CharKey(c)`  insert at cursor
+   *   - `Backspace`   remove the char before cursor
+   *   - `Delete`      remove the char at cursor
+   *   - `ArrowLeft`   cursor -= 1 (clamped)
+   *   - `ArrowRight`  cursor += 1 (clamped)
+   *   - `Home`        cursor = 0
+   *   - `End`         cursor = buffer length
+   *   - `Enter`       call `onSubmit(buffer)`, then clear buffer + cursor
+   *   - other keys    no change
+   *
+   * `Ctrl+C` / `Ctrl+D` and other framework-level keys are intentionally
+   * **not** handled — apps should route those via a top-level [[Keymap]]
+   * before falling through to per-field key dispatch.
+   *
+   * @param state    Current field state.
+   * @param key      Decoded key event.
+   * @param onSubmit Callback invoked on `Enter` with the submitted buffer.
+   *                 Return `Some(msg)` to dispatch a message, `None` to
+   *                 silently accept the input.
+   */
+  def handleKey[Msg](
+    state: State,
+    key: KeyDecoder.InputKey
+  )(onSubmit: String => Option[Msg]): (State, Option[Msg]) =
+    import KeyDecoder.InputKey.*
+    key match
+      case Enter =>
+        val msg = onSubmit(state.buffer)
+        (state.copy(buffer = "", cursor = 0), msg)
+
+      case Backspace =>
+        if state.cursor > 0 then
+          val nb = state.buffer.take(state.cursor - 1) + state.buffer.drop(state.cursor)
+          (state.copy(buffer = nb, cursor = state.cursor - 1), None)
+        else (state, None)
+
+      case Delete =>
+        if state.cursor < state.buffer.length then
+          val nb = state.buffer.take(state.cursor) + state.buffer.drop(state.cursor + 1)
+          (state.copy(buffer = nb), None)
+        else (state, None)
+
+      case CharKey(ch) =>
+        val nb = state.buffer.take(state.cursor) + ch + state.buffer.drop(state.cursor)
+        (state.copy(buffer = nb, cursor = state.cursor + 1), None)
+
+      case ArrowLeft =>
+        (state.copy(cursor = math.max(0, state.cursor - 1)), None)
+
+      case ArrowRight =>
+        (state.copy(cursor = math.min(state.buffer.length, state.cursor + 1)), None)
+
+      case Home => (state.copy(cursor = 0), None)
+      case End  => (state.copy(cursor = state.buffer.length), None)
+
+      case _ => (state, None)
+
+  /**
+   * Render the field as a single-row [[TextNode]] of exactly `lineWidth`
+   * cells.
+   *
+   * Visual rules:
+   *   - **focused**: text in `theme.primary`, the cell at `cursor` painted
+   *     in inverse video (`bg = theme.primary, fg = theme.background`)
+   *     so users can see where they're editing without needing the OS
+   *     cursor. Placeholder is hidden on focus.
+   *   - **unfocused**: text in `theme.foreground`. If buffer is empty and a
+   *     placeholder was set, the placeholder is shown (no inverse cell).
+   *
+   * The buffer is truncated to `lineWidth` cells. If the cursor sits past
+   * `lineWidth - 1` it's drawn at the rightmost cell — basic "scroll-to-end"
+   * behaviour. A future PR can add a viewport that scrolls horizontally;
+   * for v1, prefer choosing `lineWidth` ≥ the realistic input length.
+   *
+   * @param state     Field state.
+   * @param at        Top-left cell. Defaults to `(1, 1)` for layout composition.
+   * @param lineWidth Cell-width of the rendered field.
+   * @param focused   Whether this field currently has focus.
+   */
+  def view(
+    state: State,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    lineWidth: Int = 20,
+    focused: Boolean = false
+  )(using theme: Theme): VNode =
+    val width           = math.max(1, lineWidth)
+    val showPlaceholder = state.buffer.isEmpty && !focused && state.placeholder.nonEmpty
+    val display         = if showPlaceholder then state.placeholder else state.buffer
+    val padded          = display.take(width).padTo(width, ' ')
+
+    if focused then
+      val cIdx        = math.min(width - 1, math.max(0, state.cursor))
+      val before      = padded.take(cIdx)
+      val cursorChar  = padded.charAt(cIdx).toString
+      val after       = padded.drop(cIdx + 1)
+      val baseStyle   = Style(fg = theme.primary)
+      val cursorStyle = Style(fg = theme.background, bg = theme.primary)
+      TextNode(
+        at.x,
+        at.y,
+        List(
+          Text(before, baseStyle),
+          Text(cursorChar, cursorStyle),
+          Text(after, baseStyle)
+        )
+      )
+    else
+      val style =
+        if showPlaceholder then Style(fg = theme.foreground)
+        else Style(fg = theme.foreground)
+      TextNode(at.x, at.y, List(Text(padded, style)))
+
+  /** Width of a `TextField` rendered with the given `lineWidth`. */
+  def width(lineWidth: Int): Int = math.max(1, lineWidth)

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
@@ -1,0 +1,201 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.KeyDecoder.InputKey
+
+class TextFieldSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  // --- State construction ---------------------------------------------------
+
+  test("State.empty has empty buffer, cursor 0, no placeholder"):
+    val s = TextField.State.empty
+    assert(s.buffer == "")
+    assert(s.cursor == 0)
+    assert(s.placeholder == "")
+    assert(s.isEmpty)
+    assert(s.length == 0)
+
+  test("State.withPlaceholder sets a hint without filling the buffer"):
+    val s = TextField.State.withPlaceholder("name")
+    assert(s.buffer == "")
+    assert(s.placeholder == "name")
+    assert(s.isEmpty)
+
+  test("State.of pre-populates and parks the cursor at end"):
+    val s = TextField.State.of("hello")
+    assert(s.buffer == "hello")
+    assert(s.cursor == 5)
+    assert(!s.isEmpty)
+    assert(s.length == 5)
+
+  // --- handleKey: insertion -------------------------------------------------
+
+  private def submitOpt: String => Option[String] = _ => None
+
+  test("CharKey inserts at the cursor and advances it"):
+    val (s1, _) = TextField.handleKey(TextField.State.empty, InputKey.CharKey('a'))(submitOpt)
+    val (s2, _) = TextField.handleKey(s1, InputKey.CharKey('b'))(submitOpt)
+    val (s3, _) = TextField.handleKey(s2, InputKey.CharKey('c'))(submitOpt)
+    assert(s3.buffer == "abc")
+    assert(s3.cursor == 3)
+
+  test("CharKey inserts at the cursor position when not at end"):
+    val s0      = TextField.State.of("ac")
+    val s1      = s0.copy(cursor = 1) // between 'a' and 'c'
+    val (s2, _) = TextField.handleKey(s1, InputKey.CharKey('b'))(submitOpt)
+    assert(s2.buffer == "abc")
+    assert(s2.cursor == 2)
+
+  // --- handleKey: deletion --------------------------------------------------
+
+  test("Backspace removes the char before the cursor"):
+    val s0      = TextField.State.of("abc")
+    val (s1, _) = TextField.handleKey(s0, InputKey.Backspace)(submitOpt)
+    assert(s1.buffer == "ab")
+    assert(s1.cursor == 2)
+
+  test("Backspace at cursor 0 is a no-op"):
+    val s0      = TextField.State.of("abc").copy(cursor = 0)
+    val (s1, _) = TextField.handleKey(s0, InputKey.Backspace)(submitOpt)
+    assert(s1.buffer == "abc")
+    assert(s1.cursor == 0)
+
+  test("Delete removes the char at the cursor"):
+    val s0      = TextField.State.of("abc").copy(cursor = 1) // between 'a' and 'b'
+    val (s1, _) = TextField.handleKey(s0, InputKey.Delete)(submitOpt)
+    assert(s1.buffer == "ac")
+    assert(s1.cursor == 1)
+
+  test("Delete at end-of-buffer is a no-op"):
+    val s0      = TextField.State.of("abc")
+    val (s1, _) = TextField.handleKey(s0, InputKey.Delete)(submitOpt)
+    assert(s1.buffer == "abc")
+    assert(s1.cursor == 3)
+
+  // --- handleKey: cursor motion ---------------------------------------------
+
+  test("ArrowLeft / ArrowRight move the cursor and clamp at the bounds"):
+    val s0      = TextField.State.of("abc")
+    val (s1, _) = TextField.handleKey(s0, InputKey.ArrowLeft)(submitOpt)
+    assert(s1.cursor == 2)
+    val (s2, _) = TextField.handleKey(s1, InputKey.ArrowLeft)(submitOpt)
+    val (s3, _) = TextField.handleKey(s2, InputKey.ArrowLeft)(submitOpt)
+    val (s4, _) = TextField.handleKey(s3, InputKey.ArrowLeft)(submitOpt)
+    assert(s4.cursor == 0) // clamped, no underflow
+    val (s5, _) = TextField.handleKey(s4, InputKey.ArrowRight)(submitOpt)
+    assert(s5.cursor == 1)
+    // Walk past end → clamp at length
+    val (sEnd, _) = (1 to 10).foldLeft((s5, Option.empty[String])) { case ((acc, _), _) =>
+      TextField.handleKey(acc, InputKey.ArrowRight)(submitOpt)
+    }
+    assert(sEnd.cursor == 3)
+
+  test("Home moves cursor to 0; End moves cursor to length"):
+    val s0      = TextField.State.of("abc").copy(cursor = 2)
+    val (s1, _) = TextField.handleKey(s0, InputKey.Home)(submitOpt)
+    assert(s1.cursor == 0)
+    val (s2, _) = TextField.handleKey(s1, InputKey.End)(submitOpt)
+    assert(s2.cursor == 3)
+
+  // --- handleKey: submit ----------------------------------------------------
+
+  test("Enter calls onSubmit with the buffer and clears the field"):
+    val s0      = TextField.State.of("ready")
+    val (s1, m) = TextField.handleKey(s0, InputKey.Enter)(b => Some(s"submitted:$b"))
+    assert(s1.buffer == "")
+    assert(s1.cursor == 0)
+    assert(m.contains("submitted:ready"))
+
+  test("Enter still clears the buffer even when onSubmit returns None"):
+    val s0      = TextField.State.of("nope")
+    val (s1, m) = TextField.handleKey(s0, InputKey.Enter)(_ => None)
+    assert(s1.buffer == "")
+    assert(s1.cursor == 0)
+    assert(m.isEmpty)
+
+  test("global keys (Ctrl+C, Ctrl+D) are NOT handled — pass through unchanged"):
+    val s0       = TextField.State.of("abc")
+    val (s1, m1) = TextField.handleKey(s0, InputKey.Ctrl('C'))(submitOpt)
+    val (s2, m2) = TextField.handleKey(s0, InputKey.Ctrl('D'))(submitOpt)
+    assert(s1 == s0 && m1.isEmpty)
+    assert(s2 == s0 && m2.isEmpty)
+
+  // --- view rendering -------------------------------------------------------
+
+  private def render(v: VNode, width: Int): (Array[Char], Array[Style]) =
+    val frame = AnsiRenderer.buildFrame(RootNode(width, 1, List(v), None))
+    val chars = (0 until width).map(c => frame.cells(0)(c).ch).toArray
+    val style = (0 until width).map(c => frame.cells(0)(c).style).toArray
+    (chars, style)
+
+  test("unfocused render with empty buffer + placeholder shows the placeholder"):
+    val s       = TextField.State.withPlaceholder("name…")
+    val v       = TextField.view(s, lineWidth = 10)
+    val (cs, _) = render(v, 10)
+    assert(cs.mkString == "name…     ")
+
+  test("unfocused render with empty buffer + no placeholder shows blanks"):
+    val v       = TextField.view(TextField.State.empty, lineWidth = 5)
+    val (cs, _) = render(v, 5)
+    assert(cs.mkString == "     ")
+
+  test("unfocused render of populated buffer shows the buffer left-aligned"):
+    val v       = TextField.view(TextField.State.of("hi"), lineWidth = 6)
+    val (cs, _) = render(v, 6)
+    assert(cs.mkString == "hi    ")
+
+  test("focused render shows an inverse-video cursor cell"):
+    val s            = TextField.State.of("hi") // cursor at 2 (past end)
+    val v            = TextField.view(s, lineWidth = 5, focused = true)
+    val (cs, styles) = render(v, 5)
+    assert(cs.mkString == "hi   ")
+    // Cell 0 ('h'): theme.primary fg, no bg
+    assert(styles(0).fg == Theme.dark.primary)
+    assert(styles(0).bg == Color.Default)
+    // Cell 2 (cursor on space past end): inverse video.
+    assert(styles(2).fg == Theme.dark.background)
+    assert(styles(2).bg == Theme.dark.primary)
+    // Cells past cursor: normal style.
+    assert(styles(3).bg == Color.Default)
+
+  test("focused render with cursor in the middle paints the right cell"):
+    val s            = TextField.State.of("abc").copy(cursor = 1) // between 'a' and 'b'
+    val v            = TextField.view(s, lineWidth = 4, focused = true)
+    val (cs, styles) = render(v, 4)
+    assert(cs.mkString == "abc ")
+    // Cursor is on 'b' — that cell should be inverse-video.
+    assert(styles(1).fg == Theme.dark.background)
+    assert(styles(1).bg == Theme.dark.primary)
+    // 'a' and 'c' are plain.
+    assert(styles(0).bg == Color.Default)
+    assert(styles(2).bg == Color.Default)
+
+  test("focused render hides the placeholder"):
+    val s            = TextField.State.withPlaceholder("name")
+    val v            = TextField.view(s, lineWidth = 6, focused = true)
+    val (cs, styles) = render(v, 6)
+    // Placeholder must not appear; field is blank with cursor at col 0.
+    assert(cs.mkString == "      ")
+    assert(styles(0).bg == Theme.dark.primary) // cursor inverse-video on first cell
+
+  test("focused render clamps the cursor to the rightmost cell when buffer overflows"):
+    val s            = TextField.State.of("abcdefgh") // cursor at 8
+    val v            = TextField.view(s, lineWidth = 4, focused = true)
+    val (cs, styles) = render(v, 4)
+    // Truncated to "abcd"; cursor visually pinned at the last cell.
+    assert(cs.mkString == "abcd")
+    assert(styles(3).bg == Theme.dark.primary)
+
+  test("TextField.width reports lineWidth (clamped to >= 1)"):
+    assert(TextField.width(20) == 20)
+    assert(TextField.width(0) == 1)
+    assert(TextField.width(-3) == 1)
+
+  test("TextField composes inside Layout.column with predictable measure"):
+    val a = TextField.view(TextField.State.of("alice"), lineWidth = 10)
+    val b = TextField.view(TextField.State.of("bob"), lineWidth = 10)
+    val c = Layout.column(gap = 1)(a, b)
+    assert(c.measure == (10, 3)) // 10 wide, two rows + 1 gap


### PR DESCRIPTION
First cut of #91. Sister widgets (List, Select, Table) come in follow-up PRs once this one settles the integration pattern.

**Stacked on #100 → #98 → #97 → #96 → #95 → #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base is \`feature/83-devtools-history\`.

## Summary

Single-line editable text field, designed for forms with multiple fields. Composes with [\`FocusManager\`](../blob/main/modules/termflow/src/main/scala/termflow/tui/FocusManager.scala) (#94), [\`Keymap\`](../blob/main/modules/termflow/src/main/scala/termflow/tui/Keymap.scala) (#94), [\`Layout\`](../blob/main/modules/termflow/src/main/scala/termflow/tui/Layout.scala) (#87), and [\`Theme\`](../blob/main/modules/termflow/src/main/scala/termflow/tui/Theme.scala) (#86).

## Why TextField is separate from Prompt

\`Prompt\` already covers one editable line at the bottom of an app. Why not use it for forms?

- **Prompt is opinionated.** It handles \`Ctrl+C\` / \`Ctrl+D\` as global exit and returns \`Cmd[Msg]\` directly. That's right for shell-like apps but wrong for widget composition where global keys belong to the app's [\`Keymap\`](../blob/main/modules/termflow/src/main/scala/termflow/tui/Keymap.scala).
- **Prompt is tied to the OS cursor**, which can only be in one place (\`RootNode.input\`). A form with name + email + zip can't have all three fields show a cursor that way.

\`TextField\` resolves both:

- Returns a plain \`Option[Msg]\` from \`handleKey\` and ignores global keys
- Renders a **visual** cursor block (inverse video at the cursor cell) instead of relying on the OS cursor — multiple focused-but-not-current fields would be unusual but multiple field renders never compete

## API

\`\`\`scala
// State
val s0 = TextField.State.empty
val s1 = TextField.State.withPlaceholder("name…")
val s2 = TextField.State.of("alice")  // pre-populated, cursor at end

// Update
val (newState, maybeMsg) = TextField.handleKey(state, key) { buf =>
  Some(Msg.Submit(buf))  // None → silent submit, message dispatched only on Some
}

// Render — TextNode of exactly `lineWidth` cells
TextField.view(state, at = Coord(2.x, 5.y), lineWidth = 30, focused = true)
\`\`\`

## Forms-pattern example

\`\`\`scala
given Theme = Theme.dark
val NameId  = FocusId(\"name\")
val EmailId = FocusId(\"email\")

case class Model(
  name:  TextField.State,
  email: TextField.State,
  fm:    FocusManager
)

// In view:
Layout.column(gap = 1)(
  TextField.view(model.name,  lineWidth = 30, focused = model.fm.isFocused(NameId)),
  TextField.view(model.email, lineWidth = 30, focused = model.fm.isFocused(EmailId))
)
\`\`\`

## Visual cursor design

Where Prompt does:
\`\`\`
> hello█       <- OS cursor at end
\`\`\`

TextField does (focused, cursor at index 2):
\`\`\`
heLlo          <- 'L' painted theme.background on theme.primary
\`\`\`

Past end of buffer or beyond \`lineWidth\`:
\`\`\`
hello█         <- block on the trailing space
abcd█          <- block on the rightmost cell when buffer overflows
\`\`\`

This makes multi-field forms work without any new infrastructure in the runtime.

## Test plan

- [x] **23 TextFieldSpec tests** covering:
  - State construction (\`empty\` / \`withPlaceholder\` / \`of\`)
  - Every \`handleKey\` path: insert at end / insert mid-buffer / Backspace (and no-op at cursor=0) / Delete (and no-op at end) / Arrow Left+Right with bounds clamping / Home / End / Enter clearing buffer with onSubmit returning Some / None
  - Pass-through behaviour for \`Ctrl+C\` / \`Ctrl+D\` (intentionally not handled)
  - Render: unfocused empty + placeholder, unfocused empty + no placeholder, unfocused populated, focused with cursor at end / mid-buffer / past-end / clamped beyond \`lineWidth\`, focused hides placeholder
  - \`Layout.column\` composition with measured size
- [x] \`sbt ciCheck\` green — **277 tests total** (238 termflow + 39 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## Out of scope

- A demo wiring TextField + FocusManager + Keymap into a multi-field form. Worth doing as a follow-up — would mirror the \`WidgetsDemoApp\` style.
- Horizontal scrolling viewport (currently buffer truncates to \`lineWidth\`; for v1, prefer \`lineWidth\` ≥ realistic input length).
- Multi-line / textarea variant.
- Sister stateful widgets (\`List\`, \`Select\`, \`Table\`) — separate follow-up PRs in the #91 series. \`TextField\` settles the pattern first.