### PR TITLE
Multi-field form demo + fix TextField Enter semantics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -132,6 +132,7 @@ addCommandAlias(
 // to a dumb backend when stdin/stdout are pipes.
 addCommandAlias("hubDemo",      "termflowSample/runMain termflow.run.SampleHubMain")
 addCommandAlias("widgetsDemo",  "termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp")
+addCommandAlias("formDemo",     "termflowSample/runMain termflow.apps.forms.FormDemoApp")
 addCommandAlias("echoDemo",     "termflowSample/runMain termflow.apps.echo.EchoApp")
 addCommandAlias("counterDemo",  "termflowSample/runMain termflow.apps.counter.SyncCounter")
 addCommandAlias("futureDemo",   "termflowSample/runMain termflow.apps.counter.FutureCounter")

--- a/docs/RUN_EXAMPLES.md
+++ b/docs/RUN_EXAMPLES.md
@@ -15,6 +15,7 @@ Working `sbt` commands for launching the sample apps in `modules/termflow-sample
 
 ```bash
 sbt widgetsDemo       # Layout + Theme + Button/ProgressBar/Spinner/StatusBar
+sbt formDemo          # TextField + FocusManager + Keymap multi-field form
 sbt hubDemo           # Sample hub dashboard (launches other demos)
 sbt echoDemo          # Echo / chat-style scrollback
 sbt counterDemo       # Sync counter (Layout-based)
@@ -55,6 +56,7 @@ sbt "termflowSample/runMain termflow.apps.chat.ProviderChatRenderReproMain"
 | Alias | App | Demonstrates |
 |---|---|---|
 | `widgetsDemo` | `WidgetsDemoApp` | The full new stack: `Layout.column`/`row`, a `given Theme` with toggleable dark/light, `Button` focus, `Spinner` + `ProgressBar` driven by `Sub.Every`, `StatusBar` at the bottom, `FocusManager` + `Keymap` for input dispatch |
+| `formDemo` | `FormDemoApp` | Multi-field form using three `TextField`s plus Submit / Reset buttons; demonstrates Tab focus cycling and Enter routing across input + button elements |
 | `hubDemo` | `SampleHubApp` | Menu launcher; pick a sub-app by name or number |
 | `counterDemo` | `SyncCounter` | Minimal Elm-style app; the simplest example to read |
 | `futureDemo` | `FutureCounter` | `Cmd.FCmd` for async work, with a spinner while pending |
@@ -76,6 +78,19 @@ The widgets demo (`sbt widgetsDemo`) is interactive:
 | `+` / `-` | nudge progress ± 10 % |
 | `q` / `Ctrl+C` / `Esc` | quit |
 
+## Form demo keys
+
+The form demo (`sbt formDemo`) is interactive:
+
+| Key | Action |
+|---|---|
+| `Tab` | cycle focus through fields then buttons (Name → Email → Bio → Submit → Reset) |
+| `Enter` (in field) | advance focus to the next element, **keeping the typed text** |
+| `Enter` / `Space` (button) | activate Submit (capture all fields) or Reset (clear) |
+| `Backspace` / `Delete` / `Arrow*` / `Home` / `End` | standard text editing in the focused field |
+| `t` | toggle dark / light theme |
+| `q` / `Ctrl+C` / `Esc` | quit |
+
 ## Convenience shell snippet (optional)
 
 If you'd rather have shell-level shortcuts, drop this in `~/.zshrc` /
@@ -85,10 +100,10 @@ If you'd rather have shell-level shortcuts, drop this in `~/.zshrc` /
 termflow-run() {
   local app="$1"
   case "$app" in
-    hub|widgets|echo|counter|future|clock|tabs|task|stress|sine|input)
+    hub|widgets|form|echo|counter|future|clock|tabs|task|stress|sine|input)
       sbt "${app}Demo" ;;
     *)
-      echo "Usage: termflow-run {hub|widgets|echo|counter|future|clock|tabs|task|stress|sine|input}"
+      echo "Usage: termflow-run {hub|widgets|form|echo|counter|future|clock|tabs|task|stress|sine|input}"
       return 1
       ;;
   esac

--- a/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala
@@ -1,0 +1,274 @@
+package termflow.apps.forms
+
+import termflow.tui.*
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+import termflow.tui.widgets.*
+
+/**
+ * Multi-field form demo wiring [[TextField]], [[FocusManager]], [[Keymap]],
+ * and [[Layout]] together. Three editable fields (Name / Email / Bio) plus
+ * Submit and Reset buttons share one focus order; Tab cycles through them
+ * all and Enter does the right thing per element type.
+ *
+ * ## Keys
+ *
+ *   - `Tab`              cycle focus forward (Name → Email → Bio → Submit → Reset → Name)
+ *   - `Enter` (in field) advance focus to the next element (keeps the typed text)
+ *   - `Enter` (button)   activate Submit / Reset
+ *   - `t`                toggle dark / light theme
+ *   - `q` / `Ctrl+C` / `Esc` quit
+ *
+ * Run with:
+ * {{{
+ *   sbt formDemo
+ *   // or:
+ *   sbt "termflowSample/runMain termflow.apps.forms.FormDemoApp"
+ * }}}
+ */
+object FormDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  // Focus identifiers — exported so tests can reference them by name.
+  val NameId: FocusId   = FocusId("name")
+  val EmailId: FocusId  = FocusId("email")
+  val BioId: FocusId    = FocusId("bio")
+  val SubmitId: FocusId = FocusId("submit")
+  val ResetId: FocusId  = FocusId("reset")
+
+  /** The Tab cycle: fields first, then the buttons. */
+  val FocusOrder: Vector[FocusId] = Vector(NameId, EmailId, BioId, SubmitId, ResetId)
+
+  /** Form result captured when Submit is activated. */
+  final case class Submission(name: String, email: String, bio: String)
+
+  enum Msg:
+    case NextFocus
+    case PrevFocus
+    case Activate
+    case ToggleTheme
+    case Reset
+    case ConsoleInputKey(key: KeyDecoder.InputKey)
+    case ConsoleInputError(error: Throwable)
+    case Quit
+
+  final case class Model(
+    terminalWidth: Int,
+    terminalHeight: Int,
+    name: TextField.State,
+    email: TextField.State,
+    bio: TextField.State,
+    fm: FocusManager,
+    submitted: Option[Submission],
+    darkTheme: Boolean
+  )
+
+  import Msg.*
+
+  /** Global key bindings. Editing keys for the focused field/button are routed separately. */
+  val Keys: Keymap[Msg] =
+    Keymap.quit(Quit) ++
+      Keymap.focus(next = NextFocus, previous = PrevFocus) ++
+      Keymap(
+        KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
+        KeyDecoder.InputKey.CharKey('T') -> ToggleTheme
+      )
+
+  /** Initial state for the three fields — placeholders shown until typed-in. */
+  private def freshFields: (TextField.State, TextField.State, TextField.State) =
+    (
+      TextField.State.withPlaceholder("Alice"),
+      TextField.State.withPlaceholder("alice@example.com"),
+      TextField.State.withPlaceholder("(optional bio)")
+    )
+
+  object App extends TuiApp[Model, Msg]:
+
+    private def syncTerminalSize(m: Model, ctx: RuntimeCtx[Msg]): Model =
+      val w = ctx.terminal.width
+      val h = ctx.terminal.height
+      if w == m.terminalWidth && h == m.terminalHeight then m
+      else m.copy(terminalWidth = w, terminalHeight = h)
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Sub.InputKey(ConsoleInputKey.apply, ConsoleInputError.apply, ctx)
+      val (n, e, b) = freshFields
+      Model(
+        terminalWidth = ctx.terminal.width,
+        terminalHeight = ctx.terminal.height,
+        name = n,
+        email = e,
+        bio = b,
+        fm = FocusManager(FocusOrder),
+        submitted = None,
+        darkTheme = true
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val sized = syncTerminalSize(m, ctx)
+      msg match
+        case NextFocus =>
+          sized.copy(fm = sized.fm.next).tui
+
+        case PrevFocus =>
+          sized.copy(fm = sized.fm.previous).tui
+
+        case ToggleTheme =>
+          sized.copy(darkTheme = !sized.darkTheme).tui
+
+        case Quit =>
+          Tui(sized, Cmd.Exit)
+
+        case Activate =>
+          sized.fm.current match
+            case Some(id) if id == SubmitId =>
+              sized
+                .copy(
+                  submitted = Some(Submission(sized.name.buffer, sized.email.buffer, sized.bio.buffer))
+                )
+                .tui
+            case Some(id) if id == ResetId =>
+              update(sized, Reset, ctx)
+            case _ => sized.tui
+
+        case Reset =>
+          val (n, e, b) = freshFields
+          sized.copy(name = n, email = e, bio = b, submitted = None).tui
+
+        case ConsoleInputKey(key) =>
+          // Global bindings always win.
+          Keys.lookup(key) match
+            case Some(next) => update(sized, next, ctx)
+            case None       =>
+              // Route uncaught keys to whichever element is focused. Each
+              // TextField uses Enter to advance focus (keeping its buffer);
+              // each Button activates on Enter / Space.
+              sized.fm.current match
+                case Some(id) if id == NameId =>
+                  routeField(sized, key, _.name, (m, ns) => m.copy(name = ns), ctx)
+                case Some(id) if id == EmailId =>
+                  routeField(sized, key, _.email, (m, ns) => m.copy(email = ns), ctx)
+                case Some(id) if id == BioId =>
+                  routeField(sized, key, _.bio, (m, ns) => m.copy(bio = ns), ctx)
+                case Some(id) if id == SubmitId || id == ResetId =>
+                  key match
+                    case KeyDecoder.InputKey.Enter | KeyDecoder.InputKey.CharKey(' ') =>
+                      update(sized, Activate, ctx)
+                    case _ => sized.tui
+                case _ => sized.tui
+
+        case ConsoleInputError(_) => sized.tui
+
+    /**
+     * Forward a key to a focused [[TextField]] and pump any resulting message
+     * (typically `NextFocus` on Enter) back through `update`.
+     */
+    private def routeField(
+      m: Model,
+      key: KeyDecoder.InputKey,
+      get: Model => TextField.State,
+      set: (Model, TextField.State) => Model,
+      ctx: RuntimeCtx[Msg]
+    ): Tui[Model, Msg] =
+      val (next, maybeMsg) = TextField.handleKey(get(m), key)(_ => Some(NextFocus))
+      val nextModel        = set(m, next)
+      maybeMsg match
+        case Some(follow) => update(nextModel, follow, ctx)
+        case None         => nextModel.tui
+
+    override def view(m: Model): RootNode =
+      given Theme = if m.darkTheme then Theme.dark else Theme.light
+      val theme   = summon[Theme]
+
+      val termWidth  = math.max(60, m.terminalWidth)
+      val termHeight = math.max(20, m.terminalHeight)
+      val fieldWidth = 30
+
+      def fieldRow(label: String, state: TextField.State, focused: Boolean): Layout =
+        Layout.row(gap = 2)(
+          TextNode(1.x, 1.y, List(Text(label.padTo(8, ' '), Style(fg = theme.foreground)))),
+          TextField.view(state, lineWidth = fieldWidth, focused = focused)
+        )
+
+      val title = Layout.Elem(
+        TextNode(
+          1.x,
+          1.y,
+          List(Text("User Profile Form", Style(fg = theme.primary, bold = true, underline = true)))
+        )
+      )
+
+      val nameRow  = fieldRow("Name:", m.name, m.fm.isFocused(NameId))
+      val emailRow = fieldRow("Email:", m.email, m.fm.isFocused(EmailId))
+      val bioRow   = fieldRow("Bio:", m.bio, m.fm.isFocused(BioId))
+
+      val buttons = Layout.row(gap = 2)(
+        Button("Submit", focused = m.fm.isFocused(SubmitId)),
+        Button("Reset", focused = m.fm.isFocused(ResetId))
+      )
+
+      val submittedLine: Layout = m.submitted match
+        case None =>
+          Layout.Elem(
+            TextNode(1.x, 1.y, List(Text("(no submission yet)", Style(fg = theme.foreground))))
+          )
+        case Some(s) =>
+          Layout.Elem(
+            TextNode(
+              1.x,
+              1.y,
+              List(
+                Text("Last submitted: ", Style(fg = theme.success, bold = true)),
+                Text(s"name=${displayOrPlaceholder(s.name, m.name.placeholder)}", Style(fg = theme.foreground)),
+                Text(", ", Style(fg = theme.foreground)),
+                Text(s"email=${displayOrPlaceholder(s.email, m.email.placeholder)}", Style(fg = theme.foreground))
+              )
+            )
+          )
+
+      val help = Layout.Elem(
+        TextNode(
+          1.x,
+          1.y,
+          List(
+            Text(
+              "Tab: next   Enter: next/activate   t: theme   q: quit",
+              Style(fg = theme.foreground)
+            )
+          )
+        )
+      )
+
+      val column = Layout.Column(
+        gap = 1,
+        children = List(
+          title,
+          Layout.Spacer(1, 1),
+          nameRow,
+          emailRow,
+          bioRow,
+          Layout.Spacer(1, 1),
+          buttons,
+          Layout.Spacer(1, 1),
+          submittedLine,
+          Layout.Spacer(1, 1),
+          help
+        )
+      )
+
+      RootNode(
+        width = termWidth,
+        height = termHeight,
+        children = column.resolve(Coord(2.x, 2.y)),
+        input = None
+      )
+
+    private def displayOrPlaceholder(value: String, placeholder: String): String =
+      if value.isEmpty then s"<$placeholder>" else value
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      // No prompt is registered; this is unreachable in normal operation.
+      Left(TermFlowError.CommandError(input.value))

--- a/modules/termflow-sample/src/main/scala/termflow/run/SampleSmoke.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/run/SampleSmoke.scala
@@ -43,4 +43,5 @@ object SampleSmoke:
     smokeApp("tabs", termflow.apps.tabs.TabsDemoApp.App)
     smokeApp("input-line", termflow.apps.input.InputLineReproApp.App)
     smokeApp("widgets-demo", termflow.apps.widgets.WidgetsDemoApp.App)
+    smokeApp("form-demo", termflow.apps.forms.FormDemoApp.App)
     Console.out.println("Sample smoke checks passed.")

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/initial-dark.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/initial-dark.golden
@@ -1,0 +1,23 @@
+# width=80 height=22
+|                                                                                |
+| User Profile Form                                                              |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Name:                                                                          |
+|                                                                                |
+| Email:    alice@example.com                                                    |
+|                                                                                |
+| Bio:      (optional bio)                                                       |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| [ Submit ]  [ Reset ]                                                          |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| (no submission yet)                                                            |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Tab: next   Enter: next/activate   t: theme   q: quit                          |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/name-typed-email-focused.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/name-typed-email-focused.golden
@@ -1,0 +1,23 @@
+# width=80 height=22
+|                                                                                |
+| User Profile Form                                                              |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Name:     alice                                                                |
+|                                                                                |
+| Email:                                                                         |
+|                                                                                |
+| Bio:      (optional bio)                                                       |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| [ Submit ]  [ Reset ]                                                          |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| (no submission yet)                                                            |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Tab: next   Enter: next/activate   t: theme   q: quit                          |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/submitted.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/submitted.golden
@@ -1,0 +1,23 @@
+# width=80 height=22
+|                                                                                |
+| User Profile Form                                                              |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Name:     alice                                                                |
+|                                                                                |
+| Email:    a@b.c                                                                |
+|                                                                                |
+| Bio:      engineer                                                             |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| [ Submit ]  [ Reset ]                                                          |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Last submitted: name=alice, email=a@b.c                                        |
+|                                                                                |
+|                                                                                |
+|                                                                                |
+| Tab: next   Enter: next/activate   t: theme   q: quit                          |

--- a/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
@@ -1,0 +1,183 @@
+package termflow.apps.forms
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.apps.forms.FormDemoApp.*
+import termflow.testkit.GoldenSupport
+import termflow.testkit.TuiTestDriver
+import termflow.tui.KeyDecoder.InputKey
+
+class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
+
+  private val Width  = 80
+  private val Height = 22
+
+  private def driver(): TuiTestDriver[Model, Msg] =
+    val d = TuiTestDriver(App, width = Width, height = Height)
+    d.init()
+    d
+
+  /** Type a string into the focused field one CharKey at a time. */
+  private def typeKeys(d: TuiTestDriver[Model, Msg], s: String): Unit =
+    s.foreach(c => d.send(Msg.ConsoleInputKey(InputKey.CharKey(c))))
+
+  // --- focus order ---------------------------------------------------------
+
+  test("initial state: Name is focused, no submission yet, dark theme"):
+    val d = driver()
+    assert(d.model.fm.isFocused(NameId))
+    assert(d.model.submitted.isEmpty)
+    assert(d.model.darkTheme)
+
+  test("Tab cycles focus through Name → Email → Bio → Submit → Reset → Name"):
+    val d        = driver()
+    val expected = Vector(EmailId, BioId, SubmitId, ResetId, NameId)
+    expected.foreach { id =>
+      d.send(Msg.NextFocus)
+      assert(d.model.fm.current.contains(id), s"expected focus $id, got ${d.model.fm.current}")
+    }
+
+  test("Shift+Tab equivalent (PrevFocus) walks the cycle backwards"):
+    val d = driver()
+    d.send(Msg.PrevFocus)
+    assert(d.model.fm.isFocused(ResetId))
+    d.send(Msg.PrevFocus)
+    assert(d.model.fm.isFocused(SubmitId))
+
+  // --- TextField key routing -----------------------------------------------
+
+  test("typing into the focused field updates only that field's buffer"):
+    val d = driver()
+    typeKeys(d, "alice")
+    assert(d.model.name.buffer == "alice")
+    assert(d.model.email.buffer == "")
+    assert(d.model.bio.buffer == "")
+
+  test("Enter inside a TextField advances focus AND keeps the buffer"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.fm.isFocused(EmailId))
+    assert(d.model.name.buffer == "alice", "Enter must not clear the field for form usage")
+
+  test("Tab inside a TextField also advances focus and keeps buffer"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('I'))) // Tab arrives as Ctrl+I
+    assert(d.model.fm.isFocused(EmailId))
+    assert(d.model.name.buffer == "alice")
+
+  // --- Submit / Reset -------------------------------------------------------
+
+  test("Enter on the Submit button captures the current field values"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.NextFocus) // -> Email
+    typeKeys(d, "alice@example.com")
+    d.send(Msg.NextFocus) // -> Bio
+    typeKeys(d, "scala dev")
+    d.send(Msg.NextFocus) // -> Submit
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.submitted.contains(Submission("alice", "alice@example.com", "scala dev")))
+
+  test("Space on the Submit button also activates"):
+    val d = driver()
+    typeKeys(d, "x")
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // -> Submit
+    d.send(Msg.ConsoleInputKey(InputKey.CharKey(' ')))
+    assert(d.model.submitted.exists(_.name == "x"))
+
+  test("Enter on the Reset button clears all fields and the submission"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.NextFocus) // Email
+    typeKeys(d, "a@b.c")
+    (1 to 2).foreach(_ => d.send(Msg.NextFocus)) // Submit
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.submitted.isDefined)
+    d.send(Msg.NextFocus) // Reset
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.name.buffer == "")
+    assert(d.model.email.buffer == "")
+    assert(d.model.bio.buffer == "")
+    assert(d.model.submitted.isEmpty)
+
+  // --- global bindings ------------------------------------------------------
+
+  test("'t' anywhere toggles the theme"):
+    val d      = driver()
+    val before = d.model.darkTheme
+    d.send(Msg.ConsoleInputKey(InputKey.CharKey('t')))
+    assert(d.model.darkTheme == !before)
+
+  test("'q' anywhere quits"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(InputKey.CharKey('q')))
+    assert(d.exited)
+
+  test("the Keymap binds the documented shortcuts"):
+    val k = FormDemoApp.Keys
+    assert(k.lookup(InputKey.Ctrl('I')).contains(Msg.NextFocus))
+    assert(k.lookup(InputKey.CharKey('t')).contains(Msg.ToggleTheme))
+    assert(k.lookup(InputKey.CharKey('q')).contains(Msg.Quit))
+    assert(k.lookup(InputKey.Ctrl('C')).contains(Msg.Quit))
+    assert(k.lookup(InputKey.Escape).contains(Msg.Quit))
+
+  // --- frame structure -----------------------------------------------------
+
+  test("only the focused TextField paints an inverse-video cursor cell"):
+    val d     = driver()
+    val frame = d.frame
+    // Locate the row containing 'N' of "Name:" and check the cell at the
+    // start of that field is in inverse video (theme.primary background).
+    val nameRowIdx = (0 until frame.height).indexWhere { r =>
+      (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString.contains("Name:")
+    }
+    assert(nameRowIdx >= 0)
+    val row = frame.cells(nameRowIdx)
+    // Find first cell of the field area (after the "Name:" label + gap) by
+    // looking for the cell where bg is set to theme.primary — that's the
+    // inverse cursor.
+    val cursorCells = (0 until frame.width).count(c => row(c).style.bg == termflow.tui.Theme.dark.primary)
+    assert(cursorCells == 1, s"expected exactly one inverse cell on the focused row; saw $cursorCells")
+
+  test("after Tab, the cursor block moves to the next row"):
+    val d = driver()
+    d.send(Msg.NextFocus) // -> Email
+    val frame = d.frame
+    // Find the row containing "Email:" — it should be the one with the
+    // inverse cursor now.
+    val emailRowIdx = (0 until frame.height).indexWhere { r =>
+      (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString.contains("Email:")
+    }
+    val nameRowIdx = (0 until frame.height).indexWhere { r =>
+      (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString.contains("Name:")
+    }
+    val emailHasCursor =
+      (0 until frame.width).exists(c => frame.cells(emailRowIdx)(c).style.bg == termflow.tui.Theme.dark.primary)
+    val nameHasCursor =
+      (0 until frame.width).exists(c => frame.cells(nameRowIdx)(c).style.bg == termflow.tui.Theme.dark.primary)
+    assert(emailHasCursor, "expected cursor on Email row")
+    assert(!nameHasCursor, "expected no cursor on Name row")
+
+  // --- golden snapshots (deterministic thanks to #92) -----------------------
+
+  test("initial frame matches the dark-theme golden"):
+    val d = driver()
+    assertGoldenFrame(d.frame, "initial-dark")
+
+  test("after typing into Name + advancing focus to Email"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assertGoldenFrame(d.frame, "name-typed-email-focused")
+
+  test("after submitting a complete form"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.NextFocus)
+    typeKeys(d, "a@b.c")
+    d.send(Msg.NextFocus)
+    typeKeys(d, "engineer")
+    d.send(Msg.NextFocus) // Submit
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assertGoldenFrame(d.frame, "submitted")

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/TextField.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/TextField.scala
@@ -83,6 +83,16 @@ object TextField:
     /** Number of characters in the buffer (not counting the placeholder). */
     def length: Int = buffer.length
 
+    /**
+     * Drop the buffer and reset the cursor while preserving the placeholder.
+     *
+     * Convenience for prompt-style "submit and clear" callers: when the
+     * `onSubmit` message fires, replace the field state with `field.cleared`
+     * to reset for the next entry. Form-style "submit and keep" callers
+     * leave the state alone.
+     */
+    def cleared: State = State(buffer = "", cursor = 0, placeholder = placeholder)
+
   object State:
 
     /** Empty field with no placeholder. */
@@ -106,8 +116,14 @@ object TextField:
    *   - `ArrowRight`  cursor += 1 (clamped)
    *   - `Home`        cursor = 0
    *   - `End`         cursor = buffer length
-   *   - `Enter`       call `onSubmit(buffer)`, then clear buffer + cursor
+   *   - `Enter`       call `onSubmit(buffer)`; **state is unchanged**
    *   - other keys    no change
+   *
+   * `Enter` deliberately does not mutate the field. Multi-field forms want
+   * to keep the user's input across a submit (Enter typically advances focus
+   * via the returned message); prompt-style apps that want clear-on-submit
+   * can replace the state with [[State.cleared]] when they observe the
+   * submit message.
    *
    * `Ctrl+C` / `Ctrl+D` and other framework-level keys are intentionally
    * **not** handled — apps should route those via a top-level [[Keymap]]
@@ -126,8 +142,7 @@ object TextField:
     import KeyDecoder.InputKey.*
     key match
       case Enter =>
-        val msg = onSubmit(state.buffer)
-        (state.copy(buffer = "", cursor = 0), msg)
+        (state, onSubmit(state.buffer))
 
       case Backspace =>
         if state.cursor > 0 then

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
@@ -102,19 +102,33 @@ class TextFieldSpec extends AnyFunSuite:
 
   // --- handleKey: submit ----------------------------------------------------
 
-  test("Enter calls onSubmit with the buffer and clears the field"):
+  test("Enter calls onSubmit with the buffer and leaves the state unchanged"):
     val s0      = TextField.State.of("ready")
     val (s1, m) = TextField.handleKey(s0, InputKey.Enter)(b => Some(s"submitted:$b"))
-    assert(s1.buffer == "")
-    assert(s1.cursor == 0)
+    assert(s1 == s0) // form-style: keep the input around for the next focus
     assert(m.contains("submitted:ready"))
 
-  test("Enter still clears the buffer even when onSubmit returns None"):
+  test("Enter with onSubmit returning None still leaves state unchanged"):
     val s0      = TextField.State.of("nope")
     val (s1, m) = TextField.handleKey(s0, InputKey.Enter)(_ => None)
+    assert(s1 == s0)
+    assert(m.isEmpty)
+
+  test("State.cleared resets buffer + cursor while preserving placeholder"):
+    val s0 = TextField.State.of("hello").copy(placeholder = "name")
+    val s1 = s0.cleared
     assert(s1.buffer == "")
     assert(s1.cursor == 0)
-    assert(m.isEmpty)
+    assert(s1.placeholder == "name")
+
+  test("prompt-style callers can clear via State.cleared after observing the submit msg"):
+    // Demonstrates the recommended pattern for prompt-like usage where
+    // Enter should both fire a Msg and reset the field.
+    val s0      = TextField.State.of("query")
+    val (s1, m) = TextField.handleKey(s0, InputKey.Enter)(b => Some(b))
+    assert(m.contains("query"))
+    val sNext = if m.isDefined then s1.cleared else s1
+    assert(sNext.buffer == "" && sNext.cursor == 0)
 
   test("global keys (Ctrl+C, Ctrl+D) are NOT handled — pass through unchanged"):
     val s0       = TextField.State.of("abc")


### PR DESCRIPTION
Follow-up to PR #101 (#91 TextField first cut).

**Stacked on #101 → #100 → #98 → #97 → #96 → #95 → #94 → #89 → #88 → #87 → #86 → #85 → #84.** Base is \`feature/91-textfield-widget\`.

## Summary

- **\`FormDemoApp\`** — runnable multi-field form wiring \`TextField\` + \`FocusManager\` + \`Keymap\` + \`Layout\` + \`Theme\`
- **TextField fix** — \`handleKey\` no longer clears the buffer on Enter. The first real form usage discovered that the prompt-style \"clear on submit\" baked into PR #101 is wrong for forms; the right design is to leave state alone and let the caller decide.
- **17 \`FormDemoAppSpec\` tests** including 3 golden-frame snapshots
- **\`sbt formDemo\`** alias + RUN_EXAMPLES.md entry + SampleSmoke registration

## TextField Enter semantics — what changed and why

PR #101 had:

\`\`\`scala
case Enter =>
  val msg = onSubmit(state.buffer)
  (state.copy(buffer = \"\", cursor = 0), msg)  // ← hard-clear
\`\`\`

That works for shell-style prompts where Enter submits and the field resets for the next entry. But for forms, the user typically types `\"alice\"` into Name, presses Enter to advance to Email — and expects \"alice\" to still be in the Name field. The hard-clear made forms impossible.

PR #101 → PR #102 change:

\`\`\`scala
case Enter =>
  (state, onSubmit(state.buffer))  // ← keep state; caller decides
\`\`\`

Plus a new convenience helper for prompt-style callers:

\`\`\`scala
extension on TextField.State:
  def cleared: State = State(buffer = \"\", cursor = 0, placeholder = placeholder)
\`\`\`

So shell-style apps observe the submit message and replace the field state with `state.cleared`; form-style apps leave the state alone. Documented inline in the \`handleKey\` ScalaDoc.

This is a breaking change to the in-flight TextField API. Since PR #101 hasn't merged yet, the right move is to update the API in this stacked PR so the final PR #101 + #102 sequence has the correct semantics. (4 affected tests in TextFieldSpec adjusted; new tests added for the \`cleared\` helper and the prompt-style pattern.)

## What the form demo shows

A user-profile form with Name / Email / Bio fields and Submit / Reset buttons:

\`\`\`
 User Profile Form

 Name:    alice
 Email:   alice@example.com
 Bio:     scala dev

 [ Submit ]  [ Reset ]

 Last submitted: name=alice, email=alice@example.com

 Tab: next   Enter: next/activate   t: theme   q: quit
\`\`\`

Five focusable elements (3 fields + 2 buttons) cycle through one \`FocusManager\`. Tab advances, \`Enter\`-in-field advances + keeps text, \`Enter\`-on-button activates. Submit captures all three buffers into a Submission record; Reset re-initialises every field.

## Run it

\`\`\`bash
sbt formDemo
# or:
sbt \"termflowSample/runMain termflow.apps.forms.FormDemoApp\"
\`\`\`

## Test plan

- [x] **17 FormDemoAppSpec tests**:
  - Initial state (Name focused, no submission, dark theme)
  - Tab cycles forward through all 5 elements + wraps
  - Shift+Tab equivalent walks backward
  - Per-field key routing (typing into Name doesn't touch Email/Bio)
  - **Enter inside a TextField advances focus AND keeps the buffer** (the regression that motivated the TextField fix)
  - Tab inside a TextField also advances focus and keeps buffer
  - Enter / Space on Submit captures all field values
  - Enter on Reset clears every field and the submission
  - Global Keymap shortcuts (\`t\` / \`q\`) work regardless of focus
  - Spot-check on the binding table
  - Structural rule: exactly one inverse-video cursor cell on the focused row, and Tab moves the cursor block
  - **3 golden-frame snapshots** — initial dark / Name typed + Email focused / submitted form
- [x] \`sbt ciCheck\` green — **296 tests total** (240 termflow + 56 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly
- [x] \`SampleSmoke\` exercises FormDemoApp's init + view path

## Out of scope

- Field-level validation (required / regex / etc.) — could be a thin wrapper around \`onSubmit\`
- Visible labels with focus highlighting on the label too — labels are plain \`TextNode\`s today
- Sister stateful widgets (\`List\`, \`Select\`, \`Table\`) — separate follow-ups in #91