### PR TITLE
docs(tui): add package-level Scaladoc landing page

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/package.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/package.scala
@@ -1,0 +1,58 @@
+/**
+ * TermFlow is an Elm-architecture TUI framework for Scala 3. An application
+ * defines a model, a message type, and four functions (`init`, `update`,
+ * `view`, `toMsg`); the runtime calls them in a loop and paints the rendered
+ * virtual DOM to the terminal.
+ *
+ * == Core types ==
+ *
+ * Every TermFlow app works with the same small vocabulary:
+ *
+ *  - [[termflow.tui.TuiApp]] — the trait your application extends. Wires
+ *    together `init` / `update` / `view` / `toMsg` and gives the runtime
+ *    enough structure to drive your program.
+ *  - [[termflow.tui.Tui]] — the `(Model, Cmd[Msg])` pair returned from
+ *    `init` and `update`. `Model.tui` lifts a model into a `Tui` with
+ *    `Cmd.NoCmd`; `Model.gCmd(msg)` lifts with a `GCmd(msg)`.
+ *  - [[termflow.tui.Cmd]] — imperative effects the runtime executes on your
+ *    behalf: send another message (`GCmd`), run a `Future` (`FCmd`), exit
+ *    (`Exit`), or report an error (`TermFlowErrorCmd`).
+ *  - [[termflow.tui.Sub]] — long-running sources of messages: keyboard
+ *    input, timers, terminal resize. Register with `RuntimeCtx.registerSub`
+ *    so the runtime cancels them on exit.
+ *  - [[termflow.tui.VNode]] — the virtual DOM that `view` produces. Text,
+ *    boxes, and inputs are positioned with `XCoord` / `YCoord` and styled
+ *    with [[termflow.tui.Style]] / [[termflow.tui.Color]].
+ *
+ * == Message loop ==
+ *
+ * The runtime starts by calling `init(ctx)` to build the first `Tui[Model,
+ * Msg]`. `toMsg` turns each user-entered prompt line into a `Msg`;
+ * subscription events (keyboard, timers, resize) are published as
+ * `Cmd.GCmd(msg)` and dispatched straight to `update` without going through
+ * `toMsg`. Either path lands at `update(model, msg, ctx)`, which produces
+ * the next `Tui`. `view(model)` renders after every update and the
+ * resulting `RootNode` is diffed and written to the terminal by
+ * `AnsiRenderer`.
+ *
+ * == Pointers ==
+ *
+ *  - Architecture overview: `docs/DESIGN.md`
+ *  - Rendering internals: `docs/RENDER_PIPELINE.md`
+ *  - Running the sample apps: `docs/RUN_EXAMPLES.md`
+ *
+ * == Sample apps ==
+ *
+ * The `termflow-sample` module contains runnable apps that exercise the
+ * framework end-to-end. Small starting points:
+ *
+ *  - `termflow.apps.task.RenderApp` — a minimal `TuiApp` wiring up
+ *    `init` / `update` / `view` / `toMsg`.
+ *  - `termflow.apps.echo.EchoApp` — prompt-line loop with a scrolling
+ *    history.
+ *  - `termflow.apps.tabs.TabsDemoApp` — a larger demo that composes
+ *    several `VNode` shapes.
+ *
+ * See `docs/RUN_EXAMPLES.md` for how to run them.
+ */
+package termflow.tui


### PR DESCRIPTION
## Summary

Add a package-level Scaladoc landing page for `termflow.tui` per #93, so the generated Scaladoc starts with an orientation instead of an alphabetised member list.

## What's in the doc

- **What TermFlow is** -- one paragraph: Elm-architecture TUI framework on Scala 3, with the `init` / `update` / `view` / `toMsg` contract.
- **Core types** -- `TuiApp`, `Tui`, `Cmd`, `Sub`, `VNode`, each with a one-liner and a `[[...]]` cross-link.
- **Message loop** -- prompt lines go through `toMsg`; subscription events publish `Cmd.GCmd(msg)` directly and skip `toMsg` entirely (verified against `Sub.scala` and `TuiRuntime.processCommand`).
- **Pointers** -- `docs/DESIGN.md`, `docs/RENDER_PIPELINE.md`, `docs/RUN_EXAMPLES.md`.
- **Sample apps** -- small starting points in `termflow-sample` (`task.RenderApp`, `echo.EchoApp`, `tabs.TabsDemoApp`). I picked these over an inline example to avoid drift between the docs and the real `RootNode` / `TuiApp` signatures.

## Scope notes

The original proposal listed `Layout`, `widgets`, and `Theme` as part of the composition stack, but I couldn't find matching types in the current tree -- `termflow/tui/` has `Tui`, `Cmd`, `Sub`, `VNode`, `Style`, `Color`, etc. Left those out of this PR; easy follow-up if they land in a separate module or under a different name.

## Test plan

Documentation-only; no code or tests change. File placement matches the path requested in the issue.

Refs #93
