### PR TITLE
Fix form demo bugs + add Shift+Tab

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala
@@ -8,16 +8,24 @@ import termflow.tui.widgets.*
 /**
  * Multi-field form demo wiring [[TextField]], [[FocusManager]], [[Keymap]],
  * and [[Layout]] together. Three editable fields (Name / Email / Bio) plus
- * Submit and Reset buttons share one focus order; Tab cycles through them
- * all and Enter does the right thing per element type.
+ * Submit and Reset buttons share one focus order; Tab cycles forward,
+ * Shift+Tab backward, and Enter does the right thing per element type.
  *
  * ## Keys
  *
- *   - `Tab`              cycle focus forward (Name → Email → Bio → Submit → Reset → Name)
- *   - `Enter` (in field) advance focus to the next element (keeps the typed text)
- *   - `Enter` (button)   activate Submit / Reset
- *   - `t`                toggle dark / light theme
- *   - `q` / `Ctrl+C` / `Esc` quit
+ *   - `Tab`               cycle focus forward (Name → Email → Bio → Submit → Reset → Name)
+ *   - `Shift+Tab`         cycle focus backward
+ *   - `Enter` (in field)  submit the form (capture all field values)
+ *   - `Enter` / `Space` (button) activate Submit / Reset
+ *   - `Backspace` / `Arrow*` / `Home` / `End` etc. — standard text editing in the focused field
+ *   - `Ctrl+T`            toggle dark / light theme (works even inside a text field)
+ *   - `t` (when not in a field) also toggles theme
+ *   - `q` (when not in a field) / `Ctrl+C` / `Esc` quit
+ *
+ * `t` and `q` are deliberately **not** global — they would collide with
+ * legitimate text input. Inside a focused [[TextField]] those keys are
+ * routed straight to the field's buffer; on a focused [[Button]] (or with
+ * no focus) they fall through to the app-level shortcuts table.
  *
  * Run with:
  * {{{
@@ -42,15 +50,18 @@ object FormDemoApp:
   /** The Tab cycle: fields first, then the buttons. */
   val FocusOrder: Vector[FocusId] = Vector(NameId, EmailId, BioId, SubmitId, ResetId)
 
-  /** Form result captured when Submit is activated. */
+  /** `true` when `id` corresponds to one of the editable text fields. */
+  def isFieldId(id: FocusId): Boolean = id == NameId || id == EmailId || id == BioId
+
+  /** Form result captured when Submit is activated (or Enter fires from a field). */
   final case class Submission(name: String, email: String, bio: String)
 
   enum Msg:
     case NextFocus
     case PrevFocus
-    case Activate
-    case ToggleTheme
+    case Submit
     case Reset
+    case ToggleTheme
     case ConsoleInputKey(key: KeyDecoder.InputKey)
     case ConsoleInputError(error: Throwable)
     case Quit
@@ -68,14 +79,29 @@ object FormDemoApp:
 
   import Msg.*
 
-  /** Global key bindings. Editing keys for the focused field/button are routed separately. */
-  val Keys: Keymap[Msg] =
-    Keymap.quit(Quit) ++
-      Keymap.focus(next = NextFocus, previous = PrevFocus) ++
-      Keymap(
-        KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
-        KeyDecoder.InputKey.CharKey('T') -> ToggleTheme
-      )
+  /**
+   * Keys that fire regardless of which element is focused. These never
+   * conflict with text input because they're either control sequences
+   * (`Ctrl+T`, `Ctrl+C`, `Esc`) or special keys (`Tab`, `Shift+Tab`).
+   */
+  val Globals: Keymap[Msg] = Keymap(
+    KeyDecoder.InputKey.Ctrl('C') -> Quit,
+    KeyDecoder.InputKey.Escape    -> Quit,
+    KeyDecoder.InputKey.Ctrl('I') -> NextFocus, // Tab
+    KeyDecoder.InputKey.BackTab   -> PrevFocus, // Shift+Tab
+    KeyDecoder.InputKey.Ctrl('T') -> ToggleTheme
+  )
+
+  /**
+   * Letter shortcuts that only fire when focus is **not** on a [[TextField]] —
+   * inside a field they would collide with legitimate text input.
+   */
+  val NonTextShortcuts: Keymap[Msg] = Keymap(
+    KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
+    KeyDecoder.InputKey.CharKey('T') -> ToggleTheme,
+    KeyDecoder.InputKey.CharKey('q') -> Quit,
+    KeyDecoder.InputKey.CharKey('Q') -> Quit
+  )
 
   /** Initial state for the three fields — placeholders shown until typed-in. */
   private def freshFields: (TextField.State, TextField.State, TextField.State) =
@@ -110,74 +136,76 @@ object FormDemoApp:
     override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
       val sized = syncTerminalSize(m, ctx)
       msg match
-        case NextFocus =>
-          sized.copy(fm = sized.fm.next).tui
+        case NextFocus   => sized.copy(fm = sized.fm.next).tui
+        case PrevFocus   => sized.copy(fm = sized.fm.previous).tui
+        case ToggleTheme => sized.copy(darkTheme = !sized.darkTheme).tui
+        case Quit        => Tui(sized, Cmd.Exit)
 
-        case PrevFocus =>
-          sized.copy(fm = sized.fm.previous).tui
-
-        case ToggleTheme =>
-          sized.copy(darkTheme = !sized.darkTheme).tui
-
-        case Quit =>
-          Tui(sized, Cmd.Exit)
-
-        case Activate =>
-          sized.fm.current match
-            case Some(id) if id == SubmitId =>
-              sized
-                .copy(
-                  submitted = Some(Submission(sized.name.buffer, sized.email.buffer, sized.bio.buffer))
-                )
-                .tui
-            case Some(id) if id == ResetId =>
-              update(sized, Reset, ctx)
-            case _ => sized.tui
+        case Submit =>
+          sized
+            .copy(submitted = Some(Submission(sized.name.buffer, sized.email.buffer, sized.bio.buffer)))
+            .tui
 
         case Reset =>
           val (n, e, b) = freshFields
           sized.copy(name = n, email = e, bio = b, submitted = None).tui
 
         case ConsoleInputKey(key) =>
-          // Global bindings always win.
-          Keys.lookup(key) match
+          // 1. True globals (Tab / Shift+Tab / Ctrl+C / Esc / Ctrl+T) win
+          //    everywhere — including inside a TextField — because they
+          //    don't collide with any printable input.
+          Globals.lookup(key) match
             case Some(next) => update(sized, next, ctx)
             case None       =>
-              // Route uncaught keys to whichever element is focused. Each
-              // TextField uses Enter to advance focus (keeping its buffer);
-              // each Button activates on Enter / Space.
+              // 2. Otherwise route by focused element. Fields get all
+              //    remaining keys; buttons activate on Enter/Space and
+              //    fall through to NonTextShortcuts for letter shortcuts.
               sized.fm.current match
-                case Some(id) if id == NameId =>
-                  routeField(sized, key, _.name, (m, ns) => m.copy(name = ns), ctx)
-                case Some(id) if id == EmailId =>
-                  routeField(sized, key, _.email, (m, ns) => m.copy(email = ns), ctx)
-                case Some(id) if id == BioId =>
-                  routeField(sized, key, _.bio, (m, ns) => m.copy(bio = ns), ctx)
-                case Some(id) if id == SubmitId || id == ResetId =>
+                case Some(id) if isFieldId(id) =>
+                  routeField(sized, id, key, ctx)
+                case Some(id) if id == SubmitId =>
                   key match
                     case KeyDecoder.InputKey.Enter | KeyDecoder.InputKey.CharKey(' ') =>
-                      update(sized, Activate, ctx)
-                    case _ => sized.tui
-                case _ => sized.tui
+                      update(sized, Submit, ctx)
+                    case _ =>
+                      NonTextShortcuts.lookup(key).fold(sized.tui)(m => update(sized, m, ctx))
+                case Some(id) if id == ResetId =>
+                  key match
+                    case KeyDecoder.InputKey.Enter | KeyDecoder.InputKey.CharKey(' ') =>
+                      update(sized, Reset, ctx)
+                    case _ =>
+                      NonTextShortcuts.lookup(key).fold(sized.tui)(m => update(sized, m, ctx))
+                case _ =>
+                  NonTextShortcuts.lookup(key).fold(sized.tui)(m => update(sized, m, ctx))
 
         case ConsoleInputError(_) => sized.tui
 
     /**
-     * Forward a key to a focused [[TextField]] and pump any resulting message
-     * (typically `NextFocus` on Enter) back through `update`.
+     * Forward a key to a focused [[TextField]]. Enter triggers a form
+     * Submit (the user-requested behaviour); other keys edit the buffer.
      */
     private def routeField(
       m: Model,
+      id: FocusId,
       key: KeyDecoder.InputKey,
-      get: Model => TextField.State,
-      set: (Model, TextField.State) => Model,
       ctx: RuntimeCtx[Msg]
     ): Tui[Model, Msg] =
-      val (next, maybeMsg) = TextField.handleKey(get(m), key)(_ => Some(NextFocus))
-      val nextModel        = set(m, next)
-      maybeMsg match
-        case Some(follow) => update(nextModel, follow, ctx)
-        case None         => nextModel.tui
+      def setField(state: TextField.State): Model =
+        if id == NameId then m.copy(name = state)
+        else if id == EmailId then m.copy(email = state)
+        else m.copy(bio = state)
+      def getField: TextField.State =
+        if id == NameId then m.name
+        else if id == EmailId then m.email
+        else m.bio
+
+      // Enter inside a field submits the whole form — TextField.handleKey
+      // would just fire onSubmit anyway, so dispatch directly here for
+      // clarity.
+      if key == KeyDecoder.InputKey.Enter then update(m, Submit, ctx)
+      else
+        val (next, _) = TextField.handleKey(getField, key)(_ => None)
+        setField(next).tui
 
     override def view(m: Model): RootNode =
       given Theme = if m.darkTheme then Theme.dark else Theme.light
@@ -186,6 +214,7 @@ object FormDemoApp:
       val termWidth  = math.max(60, m.terminalWidth)
       val termHeight = math.max(20, m.terminalHeight)
       val fieldWidth = 30
+      val themeName  = if m.darkTheme then "dark" else "light"
 
       def fieldRow(label: String, state: TextField.State, focused: Boolean): Layout =
         Layout.row(gap = 2)(
@@ -222,25 +251,14 @@ object FormDemoApp:
               1.y,
               List(
                 Text("Last submitted: ", Style(fg = theme.success, bold = true)),
-                Text(s"name=${displayOrPlaceholder(s.name, m.name.placeholder)}", Style(fg = theme.foreground)),
-                Text(", ", Style(fg = theme.foreground)),
-                Text(s"email=${displayOrPlaceholder(s.email, m.email.placeholder)}", Style(fg = theme.foreground))
+                Text(
+                  s"name=${displayOrPlaceholder(s.name, m.name.placeholder)}, " +
+                    s"email=${displayOrPlaceholder(s.email, m.email.placeholder)}",
+                  Style(fg = theme.foreground)
+                )
               )
             )
           )
-
-      val help = Layout.Elem(
-        TextNode(
-          1.x,
-          1.y,
-          List(
-            Text(
-              "Tab: next   Enter: next/activate   t: theme   q: quit",
-              Style(fg = theme.foreground)
-            )
-          )
-        )
-      )
 
       val column = Layout.Column(
         gap = 1,
@@ -253,16 +271,28 @@ object FormDemoApp:
           Layout.Spacer(1, 1),
           buttons,
           Layout.Spacer(1, 1),
-          submittedLine,
-          Layout.Spacer(1, 1),
-          help
+          submittedLine
         )
+      )
+
+      // Inverse-video status bar pinned to the bottom row. This is the only
+      // row guaranteed to be readable across all terminal backgrounds — the
+      // rest of the demo uses theme.foreground which can collide with the
+      // user's terminal bg colour (see the Theme ScalaDoc note about
+      // background slots). When toggling themes, watch the inverse colours
+      // here flip — that's the always-visible signal the toggle worked.
+      val helpBar = StatusBar(
+        left = " form ",
+        center = "Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit",
+        right = s" theme=$themeName ",
+        width = termWidth,
+        at = Coord(1.x, termHeight.y)
       )
 
       RootNode(
         width = termWidth,
         height = termHeight,
-        children = column.resolve(Coord(2.x, 2.y)),
+        children = column.resolve(Coord(2.x, 2.y)) :+ helpBar,
         input = None
       )
 

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/initial-dark.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/initial-dark.golden
@@ -20,4 +20,4 @@
 |                                                                                |
 |                                                                                |
 |                                                                                |
-| Tab: next   Enter: next/activate   t: theme   q: quit                          |
+| form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/name-typed-email-focused.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/name-typed-email-focused.golden
@@ -20,4 +20,4 @@
 |                                                                                |
 |                                                                                |
 |                                                                                |
-| Tab: next   Enter: next/activate   t: theme   q: quit                          |
+| form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/submitted.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/submitted.golden
@@ -20,4 +20,4 @@
 |                                                                                |
 |                                                                                |
 |                                                                                |
-| Tab: next   Enter: next/activate   t: theme   q: quit                          |
+| form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |

--- a/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
@@ -36,12 +36,14 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
       assert(d.model.fm.current.contains(id), s"expected focus $id, got ${d.model.fm.current}")
     }
 
-  test("Shift+Tab equivalent (PrevFocus) walks the cycle backwards"):
+  test("BackTab (Shift+Tab) walks focus backward through the cycle"):
     val d = driver()
-    d.send(Msg.PrevFocus)
+    d.send(Msg.ConsoleInputKey(InputKey.BackTab))
     assert(d.model.fm.isFocused(ResetId))
-    d.send(Msg.PrevFocus)
+    d.send(Msg.ConsoleInputKey(InputKey.BackTab))
     assert(d.model.fm.isFocused(SubmitId))
+    d.send(Msg.ConsoleInputKey(InputKey.BackTab))
+    assert(d.model.fm.isFocused(BioId))
 
   // --- TextField key routing -----------------------------------------------
 
@@ -52,32 +54,54 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
     assert(d.model.email.buffer == "")
     assert(d.model.bio.buffer == "")
 
-  test("Enter inside a TextField advances focus AND keeps the buffer"):
+  test("Tab inside a TextField advances focus and keeps the buffer"):
     val d = driver()
     typeKeys(d, "alice")
-    d.send(Msg.ConsoleInputKey(InputKey.Enter))
-    assert(d.model.fm.isFocused(EmailId))
-    assert(d.model.name.buffer == "alice", "Enter must not clear the field for form usage")
-
-  test("Tab inside a TextField also advances focus and keeps buffer"):
-    val d = driver()
-    typeKeys(d, "alice")
-    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('I'))) // Tab arrives as Ctrl+I
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('I'))) // Tab
     assert(d.model.fm.isFocused(EmailId))
     assert(d.model.name.buffer == "alice")
 
-  // --- Submit / Reset -------------------------------------------------------
+  test("'t' inside a TextField is a printable character, not a theme toggle"):
+    val d      = driver()
+    val before = d.model.darkTheme
+    typeKeys(d, "tomato")
+    assert(d.model.name.buffer == "tomato", "'t' and 'T' must reach the focused field's buffer")
+    assert(d.model.darkTheme == before, "theme must not have toggled from plain letter input")
 
-  test("Enter on the Submit button captures the current field values"):
+  test("'q' inside a TextField is a printable character, not a quit command"):
+    val d = driver()
+    typeKeys(d, "quinn")
+    assert(d.model.name.buffer == "quinn")
+    assert(!d.exited)
+
+  // --- Enter semantics inside fields ---------------------------------------
+
+  test("Enter inside a TextField submits the form (requested behaviour)"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.submitted.exists(_.name == "alice"), "Enter inside any field should submit")
+    // Buffer is preserved so the form stays editable for corrections.
+    assert(d.model.name.buffer == "alice")
+
+  test("Enter inside a mid-form field still submits with current partial values"):
     val d = driver()
     typeKeys(d, "alice")
     d.send(Msg.NextFocus) // -> Email
-    typeKeys(d, "alice@example.com")
-    d.send(Msg.NextFocus) // -> Bio
-    typeKeys(d, "scala dev")
-    d.send(Msg.NextFocus) // -> Submit
+    typeKeys(d, "a@b.c")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter)) // while still in Email
+    val s = d.model.submitted.get
+    assert(s.name == "alice")
+    assert(s.email == "a@b.c")
+    assert(s.bio == "") // Bio never typed
+
+  // --- Submit / Reset buttons ----------------------------------------------
+
+  test("Enter on the Submit button captures the current field values"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // skip fields -> Submit
     d.send(Msg.ConsoleInputKey(InputKey.Enter))
-    assert(d.model.submitted.contains(Submission("alice", "alice@example.com", "scala dev")))
+    assert(d.model.submitted.contains(Submission("", "", "")))
 
   test("Space on the Submit button also activates"):
     val d = driver()
@@ -89,63 +113,83 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
   test("Enter on the Reset button clears all fields and the submission"):
     val d = driver()
     typeKeys(d, "alice")
-    d.send(Msg.NextFocus) // Email
-    typeKeys(d, "a@b.c")
-    (1 to 2).foreach(_ => d.send(Msg.NextFocus)) // Submit
-    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    d.send(Msg.ConsoleInputKey(InputKey.Enter)) // submit from inside Name
     assert(d.model.submitted.isDefined)
-    d.send(Msg.NextFocus) // Reset
+    (1 to 4).foreach(_ => d.send(Msg.NextFocus)) // -> Reset
     d.send(Msg.ConsoleInputKey(InputKey.Enter))
     assert(d.model.name.buffer == "")
     assert(d.model.email.buffer == "")
     assert(d.model.bio.buffer == "")
     assert(d.model.submitted.isEmpty)
 
-  // --- global bindings ------------------------------------------------------
+  // --- global bindings (true globals vs non-text shortcuts) ----------------
 
-  test("'t' anywhere toggles the theme"):
+  test("Ctrl+T toggles the theme from anywhere, including inside a TextField"):
     val d      = driver()
+    val before = d.model.darkTheme
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('T')))
+    assert(d.model.darkTheme == !before)
+
+  test("'t' on a button-focused row toggles the theme (non-text shortcut)"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // -> Submit
     val before = d.model.darkTheme
     d.send(Msg.ConsoleInputKey(InputKey.CharKey('t')))
     assert(d.model.darkTheme == !before)
 
-  test("'q' anywhere quits"):
+  test("'q' on a button-focused row quits (non-text shortcut)"):
     val d = driver()
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // -> Submit
     d.send(Msg.ConsoleInputKey(InputKey.CharKey('q')))
     assert(d.exited)
 
-  test("the Keymap binds the documented shortcuts"):
-    val k = FormDemoApp.Keys
-    assert(k.lookup(InputKey.Ctrl('I')).contains(Msg.NextFocus))
-    assert(k.lookup(InputKey.CharKey('t')).contains(Msg.ToggleTheme))
-    assert(k.lookup(InputKey.CharKey('q')).contains(Msg.Quit))
-    assert(k.lookup(InputKey.Ctrl('C')).contains(Msg.Quit))
-    assert(k.lookup(InputKey.Escape).contains(Msg.Quit))
+  test("Ctrl+C quits from anywhere"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('C')))
+    assert(d.exited)
+
+  test("Esc quits from anywhere"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(InputKey.Escape))
+    assert(d.exited)
+
+  // --- Keymap wiring -------------------------------------------------------
+
+  test("Globals bind only truly-global keys — no printable letters"):
+    val g = FormDemoApp.Globals
+    assert(g.lookup(InputKey.Ctrl('I')).contains(Msg.NextFocus)) // Tab
+    assert(g.lookup(InputKey.BackTab).contains(Msg.PrevFocus))   // Shift+Tab
+    assert(g.lookup(InputKey.Ctrl('C')).contains(Msg.Quit))
+    assert(g.lookup(InputKey.Escape).contains(Msg.Quit))
+    assert(g.lookup(InputKey.Ctrl('T')).contains(Msg.ToggleTheme))
+    // Critically, letters are NOT in Globals so they can reach text fields.
+    assert(g.lookup(InputKey.CharKey('t')).isEmpty)
+    assert(g.lookup(InputKey.CharKey('q')).isEmpty)
+
+  test("NonTextShortcuts hold the letter bindings that only fire outside fields"):
+    val n = FormDemoApp.NonTextShortcuts
+    assert(n.lookup(InputKey.CharKey('t')).contains(Msg.ToggleTheme))
+    assert(n.lookup(InputKey.CharKey('T')).contains(Msg.ToggleTheme))
+    assert(n.lookup(InputKey.CharKey('q')).contains(Msg.Quit))
+    assert(n.lookup(InputKey.CharKey('Q')).contains(Msg.Quit))
 
   // --- frame structure -----------------------------------------------------
 
-  test("only the focused TextField paints an inverse-video cursor cell"):
+  test("only the focused TextField row paints an inverse-video cursor cell"):
     val d     = driver()
     val frame = d.frame
-    // Locate the row containing 'N' of "Name:" and check the cell at the
-    // start of that field is in inverse video (theme.primary background).
     val nameRowIdx = (0 until frame.height).indexWhere { r =>
       (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString.contains("Name:")
     }
     assert(nameRowIdx >= 0)
-    val row = frame.cells(nameRowIdx)
-    // Find first cell of the field area (after the "Name:" label + gap) by
-    // looking for the cell where bg is set to theme.primary — that's the
-    // inverse cursor.
+    val row         = frame.cells(nameRowIdx)
     val cursorCells = (0 until frame.width).count(c => row(c).style.bg == termflow.tui.Theme.dark.primary)
     assert(cursorCells == 1, s"expected exactly one inverse cell on the focused row; saw $cursorCells")
 
-  test("after Tab, the cursor block moves to the next row"):
+  test("after Tab, the cursor block moves from Name row to Email row"):
     val d = driver()
-    d.send(Msg.NextFocus) // -> Email
+    d.send(Msg.NextFocus)
     val frame = d.frame
-    // Find the row containing "Email:" — it should be the one with the
-    // inverse cursor now.
     val emailRowIdx = (0 until frame.height).indexWhere { r =>
       (0 until frame.width).map(c => frame.cells(r)(c).ch).mkString.contains("Email:")
     }
@@ -159,16 +203,31 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
     assert(emailHasCursor, "expected cursor on Email row")
     assert(!nameHasCursor, "expected no cursor on Name row")
 
+  test("bottom status bar paints theme.primary bg so it's visible on any terminal"):
+    // Pins the fix for the 'theme invisible on black monitor' bug: the
+    // StatusBar at the last row uses inverse video (theme.primary as bg),
+    // which is always painted and therefore always visible, regardless of
+    // what colour the user's terminal happens to be configured with.
+    val d            = driver()
+    val frame        = d.frame
+    val last         = frame.cells(frame.height - 1)
+    val inverseCells = (0 until frame.width).count(c => last(c).style.bg == termflow.tui.Theme.dark.primary)
+    assert(inverseCells > 0, "expected the bottom status bar to paint theme.primary as bg")
+    // Spot-check it contains the documented hint.
+    val row = (0 until frame.width).map(c => last(c).ch).mkString
+    assert(row.contains("theme="))
+    assert(row.contains("Ctrl+T"))
+
   // --- golden snapshots (deterministic thanks to #92) -----------------------
 
   test("initial frame matches the dark-theme golden"):
     val d = driver()
     assertGoldenFrame(d.frame, "initial-dark")
 
-  test("after typing into Name + advancing focus to Email"):
+  test("after typing into Name + Tab to Email"):
     val d = driver()
     typeKeys(d, "alice")
-    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('I'))) // Tab
     assertGoldenFrame(d.frame, "name-typed-email-focused")
 
   test("after submitting a complete form"):
@@ -178,6 +237,5 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
     typeKeys(d, "a@b.c")
     d.send(Msg.NextFocus)
     typeKeys(d, "engineer")
-    d.send(Msg.NextFocus) // Submit
-    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    d.send(Msg.ConsoleInputKey(InputKey.Enter)) // Enter from Bio submits
     assertGoldenFrame(d.frame, "submitted")

--- a/modules/termflow/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
@@ -67,6 +67,8 @@ object ConsoleKeyPressSource:
         InputKey.Home
       case (F, List(ESC, `[`)) =>
         InputKey.End
+      case (Z, List(ESC, `[`)) =>
+        InputKey.BackTab
       case (H, List(ESC, O)) =>
         InputKey.Home
       case (F, List(ESC, O)) =>

--- a/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
@@ -16,6 +16,9 @@ object KeyDecoder:
     case ArrowDown
     case ArrowLeft
     case ArrowRight
+
+    /** Shift+Tab — produced by the `\u001b[Z` escape sequence on most terminals. */
+    case BackTab
     case F1
     case F2
     case F3
@@ -58,6 +61,7 @@ object AsciiControl:
   val D       = 68
   val F       = 70
   val H       = 72
+  val Z       = 90
   val `48`    = 48
   val `49`    = 49
   val `53`    = 53

--- a/modules/termflow/src/main/scala/termflow/tui/Keymap.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Keymap.scala
@@ -95,29 +95,19 @@ object Keymap:
   )
 
   /**
-   * Conventional focus bindings: `Tab` to advance, no shift-tab binding
-   * because the current `KeyDecoder` doesn't distinguish `Shift+Tab` from
-   * a bare ESC sequence.
+   * Conventional focus bindings: `Tab` advances, `Shift+Tab` retreats.
    *
-   * Apps that want explicit forward / backward bindings can pass both
-   * messages and add their own back-cycle key (e.g. `BackTick`):
+   * `Tab` arrives as `Ctrl+I` from the ASCII decoder; `Shift+Tab` arrives
+   * as `InputKey.BackTab` (decoded from the `\u001b[Z` escape sequence).
    *
-   * {{{
-   * Keymap.focus(next = Msg.NextFocus, previous = Msg.PrevFocus) ++
-   *   Keymap(InputKey.CharKey('`') -> Msg.PrevFocus)
-   * }}}
-   *
-   * `Tab` on most terminals is decoded as `Ctrl+I` by the ASCII control
-   * range, so that's the binding installed.
-   *
-   * @param next     Message to dispatch on Tab (`Ctrl+I`).
-   * @param previous Currently unused — wire your own binding via `++`. The
-   *                 parameter exists so the API doesn't have to change once
-   *                 `Shift+Tab` decoding is supported.
+   * @param next     Message dispatched on `Tab`.
+   * @param previous Message dispatched on `Shift+Tab`.
    */
   def focus[Msg](next: Msg, previous: Msg): Keymap[Msg] =
-    val _ = previous // reserved; see ScalaDoc
-    Keymap(InputKey.Ctrl('I') -> next)
+    Keymap(
+      InputKey.Ctrl('I') -> next,
+      InputKey.BackTab   -> previous
+    )
 
   /**
    * Conventional editing bindings: arrow keys, Home, End, Enter, Backspace.

--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -106,7 +106,7 @@ object Sub:
       override def cancel(): Unit =
         lock.synchronized {
           active = false
-          if handle != null then handle.cancel(true)
+          if handle != null then handle.cancel(true): Unit
           if scheduler != null then
             scheduler.shutdownNow(): Unit
             try scheduler.awaitTermination(200L, TimeUnit.MILLISECONDS): Unit

--- a/modules/termflow/src/main/scala/termflow/tui/Theme.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Theme.scala
@@ -65,6 +65,24 @@ package termflow.tui
  * @note `muted` / `dim` is intentionally omitted from v1. TermFlow's [[Style]]
  *       has no dim attribute, so a muted slot would have to alias an existing
  *       colour, which is misleading. Add when `Style` grows a dim/faint flag.
+ *
+ * @note **Background slots only paint cells that explicitly set them.**
+ *       The renderer does not fill the whole frame with `theme.background` —
+ *       it only colours cells that are actually drawn, so `theme.background`
+ *       and `theme.foreground` only become visible on cells whose `Style`
+ *       references them. If you toggle from [[dark]] to [[light]] on a
+ *       black-background terminal, plain text using `fg = theme.foreground`
+ *       (i.e. black) becomes invisible because the surrounding cells are not
+ *       repainted to white. Workarounds:
+ *
+ *         - Use [[termflow.tui.widgets.StatusBar]] for any row that needs to
+ *           stay visible across themes — it uses inverse video
+ *           (`fg = theme.background, bg = theme.primary`) which is always
+ *           painted.
+ *         - Pin foreground colours to a specific accent slot
+ *           (`theme.primary`, `theme.success`, …) rather than `foreground`.
+ *         - Or paint backgrounds explicitly via `Style(bg = theme.background)`
+ *           on each text run.
  */
 final case class Theme(
   primary: Color,

--- a/modules/termflow/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
@@ -29,6 +29,13 @@ class ConsoleKeyPressSourceSpec extends AnyFunSuite:
     assert(source.close().isSuccess)
     assert(source.close().isSuccess)
 
+  test("decodes ESC [ Z as BackTab (Shift+Tab)"):
+    val source = ConsoleKeyPressSource(new StringReader("\u001b[Z"))
+    try assert(source.next() == Key(InputKey.BackTab))
+    finally
+      assert(source.close().isSuccess)
+      ()
+
   test("close closes underlying reader once"):
     final class CountingReader(data: String) extends StringReader(data):
       val closedCount = new AtomicInteger(0)

--- a/modules/termflow/src/test/scala/termflow/tui/KeymapSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/KeymapSpec.scala
@@ -55,11 +55,11 @@ class KeymapSpec extends AnyFunSuite:
     assert(k.lookup(InputKey.CharKey('q')).contains(DemoMsg.Quit))
     assert(k.lookup(InputKey.CharKey('Q')).contains(DemoMsg.Quit))
 
-  test("Keymap.focus binds Tab (Ctrl+I) to the next-focus message"):
+  test("Keymap.focus binds Tab (Ctrl+I) to next and BackTab (Shift+Tab) to previous"):
     val k = Keymap.focus(next = DemoMsg.NextFocus, previous = DemoMsg.A)
     assert(k.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus))
-    // Shift+Tab is unsupported by KeyDecoder today; the parameter is reserved.
-    assert(k.size == 1)
+    assert(k.lookup(InputKey.BackTab).contains(DemoMsg.A))
+    assert(k.size == 2)
 
   test("Keymap.editing binds Enter, Backspace, ArrowLeft, ArrowRight"):
     val k = Keymap.editing(


### PR DESCRIPTION
Addresses a real bug report against the PR #102 form demo plus two feature requests.

**Stacked on #102 → #101 → #100 → #98 → … → #84.** Base is \`feature/91-form-demo\`.

## Reported issues → fixes

### Bug 1: letter keys reaching a focused TextField trigger global shortcuts

> \"the t is not input in the textbox — conflicting control items shouldn't work whilst in the textbox\"

PR #102's form demo installed \`'t' → ToggleTheme\` and \`'q' → Quit\` as global bindings. Typing \"tomato\" or \"quinn\" into a field silently fired those shortcuts instead of inserting the character.

**Fix:** split the bindings into two keymaps:

- **\`Globals\`** — only keys that can't collide with printable input: \`Ctrl+C\`, \`Escape\`, \`Tab\` (\`Ctrl+I\`), \`Shift+Tab\` (\`BackTab\`), \`Ctrl+T\`
- **\`NonTextShortcuts\`** — letter shortcuts (\`t\`, \`T\`, \`q\`, \`Q\`) that fire only when focus is on a **button** (or no focus)

Dispatch order: \`Globals\` always wins → then the focused element decides → fields consume everything else, buttons fall through to \`NonTextShortcuts\` for letters.

### Bug 2: light theme invisible on a dark terminal

> \"the theme is invisible on a black monitor\"

The colours are correct by design (\`foreground = Color.Black, background = Color.White\` for \`Theme.light\`). The problem is that the renderer doesn't fill unused cells with \`theme.background\` — it only paints cells where text is drawn. So on a black terminal, black-foreground text disappears.

**Fix (per-demo):** replace the plain help row with a \`StatusBar\`. \`StatusBar\` uses inverse video (\`fg=theme.background, bg=theme.primary\`), which IS always painted — so the bottom row stays visible on any terminal. The right section now shows \` theme=dark \` / \` theme=light \` as a visible confirmation when \`Ctrl+T\` flips the palette.

**Fix (documentation):** added a ScalaDoc \`@note\` on \`Theme\` explaining the limitation and the three workarounds (\`StatusBar\`, accent colours, explicit \`bg =\` on each \`Style\`).

### Bug 3 / request: Shift+Tab to walk focus backward

> \"can we add shift-tab for back a field\"

\`KeyDecoder\` didn't decode Shift+Tab at all — terminals emit \`\\u001b[Z\` and nothing translated it. Four-part fix:

- \`InputKey.BackTab\` variant
- \`AsciiControl.Z = 90\`
- \`ConsoleKeyPressSource\` case for \`(Z, [ESC, \\[])\` → \`BackTab\`
- \`Keymap.focus\` now actually binds its \`previous\` parameter to \`InputKey.BackTab\` (was a reserved no-op placeholder in #94)

New \`ConsoleKeyPressSourceSpec\` test pins the decoding; \`KeymapSpec\` updated to assert the new binding.

### Request: Enter inside a text field submits the form

> \"can we also have enter to submit in a text field?\"

Was: Enter advanced focus (clashes with Tab, which does the same).  
Now: Enter captures all field values into a \`Submission\`, keeping the text intact so the user can edit and re-submit. Tab / Shift+Tab continue to advance/retreat focus — the two keys now have distinct roles. Matches HTML-form expectations.

### Tangent: \"check the state of the alternate theme — what colours are expected?\"

Confirmed \`Theme.dark\` / \`Theme.light\` expose every slot with a non-default ANSI colour (already tested in \`ThemeSpec\`). Both themes share accent colours (primary=Blue, success=Green, error=Red, etc.); only \`background\` / \`foreground\` swap. The apparent invisibility of light theme is a renderer-paint limitation (Bug 2), not a theme mismatch. Documented in the Theme ScalaDoc.

## Behaviour before / after in one table

| Input | Focus | Before (PR #102) | After (this PR) |
|---|---|---|---|
| \`t\` | Name field | toggles theme, 't' lost | inserts 't' in buffer |
| \`q\` | Name field | quits app | inserts 'q' in buffer |
| \`Ctrl+T\` | anywhere | n/a (unbound) | toggles theme |
| \`Tab\` | Name field | advance focus (clear) | advance focus (keep buffer) |
| \`Shift+Tab\` | anywhere | n/a (undecoded) | retreat focus |
| \`Enter\` | Name field | advance focus + clear | **submit form** |
| \`t\` | Submit button | toggles theme | toggles theme |
| \`q\` | Submit button | quits | quits |

## Status bar visibility

Before — plain help row, black text on terminal bg, invisible under light theme on a black terminal:

\`\`\`
 Tab: next   Enter: next/activate   t: theme   q: quit
\`\`\`

After — inverse-video status bar with theme indicator, always visible:

\`\`\`
 form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit  theme=dark 
\`\`\`

## Test plan

- [x] **25 FormDemoAppSpec tests** (up from 17):
  - \`'t'\` / \`'q'\` inside a TextField are printable
  - \`Ctrl+T\` toggles theme even from inside a field
  - BackTab cycles focus backward
  - Enter inside any field submits
  - Enter inside Bio (the last field) also submits
  - Globals binding table has no printable letters
  - NonTextShortcuts holds the letter fallbacks
  - StatusBar row paints \`theme.primary\` as bg (pins the bug 2 fix)
- [x] 1 new \`ConsoleKeyPressSourceSpec\` test: \`ESC[Z\` → \`BackTab\`
- [x] \`KeymapSpec\` updated for \`Keymap.focus\` binding both Tab and BackTab
- [x] 3 re-recorded goldens for the new StatusBar layout
- [x] Cleaned up a pre-existing \`-Wvalue-discard\` warning in \`Sub.scala\` (unrelated but surfaced during ciCheck)
- [x] \`sbt ciCheck\` green — **305 tests total** (241 termflow + 64 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly