### PR TITLE
Arrow-key focus navigation + TextField submit helper

### DIFF
--- a/docs/RUN_EXAMPLES.md
+++ b/docs/RUN_EXAMPLES.md
@@ -84,12 +84,15 @@ The form demo (`sbt formDemo`) is interactive:
 
 | Key | Action |
 |---|---|
-| `Tab` | cycle focus through fields then buttons (Name → Email → Bio → Submit → Reset) |
-| `Enter` (in field) | advance focus to the next element, **keeping the typed text** |
-| `Enter` / `Space` (button) | activate Submit (capture all fields) or Reset (clear) |
-| `Backspace` / `Delete` / `Arrow*` / `Home` / `End` | standard text editing in the focused field |
-| `t` | toggle dark / light theme |
-| `q` / `Ctrl+C` / `Esc` | quit |
+| `Tab` / `Shift+Tab` | cycle focus forward / backward (Name → Email → Bio → Submit → Reset) |
+| `↑` / `↓` | same as `Shift+Tab` / `Tab` — work anywhere, including inside a text field |
+| `←` / `→` (on a button) | previous / next focus |
+| `←` / `→` (in a text field) | move the **in-field cursor** (does not change focus) |
+| `Enter` (in field) | submit the form (capture all field values) |
+| `Enter` / `Space` (button) | activate Submit or Reset |
+| `Backspace` / `Delete` / `Home` / `End` | standard text editing in the focused field |
+| `Ctrl+T` (anywhere) / `t` (on a button) | toggle dark / light theme |
+| `q` (on a button) / `Ctrl+C` / `Esc` | quit |
 
 ## Convenience shell snippet (optional)
 

--- a/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala
@@ -13,19 +13,22 @@ import termflow.tui.widgets.*
  *
  * ## Keys
  *
- *   - `Tab`               cycle focus forward (Name → Email → Bio → Submit → Reset → Name)
- *   - `Shift+Tab`         cycle focus backward
- *   - `Enter` (in field)  submit the form (capture all field values)
+ *   - `Tab` / `Shift+Tab`  cycle focus forward / backward (Name → Email → Bio → Submit → Reset)
+ *   - `↑` / `↓`            same as Shift+Tab / Tab — work anywhere, including inside a text field
+ *   - `←` / `→`            on a button, move to the previous / next focus;
+ *                          inside a text field, move the in-field cursor (does NOT change focus)
+ *   - `Enter` (in field)   submit the form (capture all field values)
  *   - `Enter` / `Space` (button) activate Submit / Reset
- *   - `Backspace` / `Arrow*` / `Home` / `End` etc. — standard text editing in the focused field
- *   - `Ctrl+T`            toggle dark / light theme (works even inside a text field)
+ *   - `Backspace` / `Home` / `End` / `Delete` — standard text editing in the focused field
+ *   - `Ctrl+T`             toggle dark / light theme (works even inside a text field)
  *   - `t` (when not in a field) also toggles theme
  *   - `q` (when not in a field) / `Ctrl+C` / `Esc` quit
  *
- * `t` and `q` are deliberately **not** global — they would collide with
- * legitimate text input. Inside a focused [[TextField]] those keys are
- * routed straight to the field's buffer; on a focused [[Button]] (or with
- * no focus) they fall through to the app-level shortcuts table.
+ * `t` / `q` and `←` / `→` are deliberately **not** in the true-global keymap —
+ * they would collide with legitimate text input. Inside a focused
+ * [[TextField]] those keys are routed straight to the field; on a focused
+ * [[Button]] (or with no focus) they fall through to the non-text shortcuts
+ * layer.
  *
  * Run with:
  * {{{
@@ -82,26 +85,34 @@ object FormDemoApp:
   /**
    * Keys that fire regardless of which element is focused. These never
    * conflict with text input because they're either control sequences
-   * (`Ctrl+T`, `Ctrl+C`, `Esc`) or special keys (`Tab`, `Shift+Tab`).
+   * (`Ctrl+T`, `Ctrl+C`, `Esc`), special keys (`Tab`, `Shift+Tab`), or
+   * vertical arrows (TextField is single-line so it doesn't consume them).
    */
-  val Globals: Keymap[Msg] = Keymap(
-    KeyDecoder.InputKey.Ctrl('C') -> Quit,
-    KeyDecoder.InputKey.Escape    -> Quit,
-    KeyDecoder.InputKey.Ctrl('I') -> NextFocus, // Tab
-    KeyDecoder.InputKey.BackTab   -> PrevFocus, // Shift+Tab
-    KeyDecoder.InputKey.Ctrl('T') -> ToggleTheme
-  )
+  val Globals: Keymap[Msg] =
+    Keymap(
+      KeyDecoder.InputKey.Ctrl('C') -> Quit,
+      KeyDecoder.InputKey.Escape    -> Quit,
+      KeyDecoder.InputKey.Ctrl('T') -> ToggleTheme
+    ) ++
+      Keymap.focus(next = NextFocus, previous = PrevFocus) ++
+      Keymap.focusVertical(previous = PrevFocus, next = NextFocus)
 
   /**
-   * Letter shortcuts that only fire when focus is **not** on a [[TextField]] —
-   * inside a field they would collide with legitimate text input.
+   * Shortcuts that only fire when focus is **not** on a [[TextField]] —
+   * inside a field they would collide with legitimate editing keys:
+   *   - `ArrowLeft` / `ArrowRight` move the in-field cursor there
+   *   - letter keys insert into the buffer
+   *
+   * Buttons (and no-focus) fall through to this layer after [[Globals]].
    */
-  val NonTextShortcuts: Keymap[Msg] = Keymap(
-    KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
-    KeyDecoder.InputKey.CharKey('T') -> ToggleTheme,
-    KeyDecoder.InputKey.CharKey('q') -> Quit,
-    KeyDecoder.InputKey.CharKey('Q') -> Quit
-  )
+  val NonTextShortcuts: Keymap[Msg] =
+    Keymap(
+      KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
+      KeyDecoder.InputKey.CharKey('T') -> ToggleTheme,
+      KeyDecoder.InputKey.CharKey('q') -> Quit,
+      KeyDecoder.InputKey.CharKey('Q') -> Quit
+    ) ++
+      Keymap.focusHorizontal(previous = PrevFocus, next = NextFocus)
 
   /** Initial state for the three fields — placeholders shown until typed-in. */
   private def freshFields: (TextField.State, TextField.State, TextField.State) =
@@ -182,7 +193,8 @@ object FormDemoApp:
 
     /**
      * Forward a key to a focused [[TextField]]. Enter triggers a form
-     * Submit (the user-requested behaviour); other keys edit the buffer.
+     * Submit via [[TextField.handleKeyOrSubmit]]; every other key edits
+     * the field buffer.
      */
     private def routeField(
       m: Model,
@@ -199,13 +211,11 @@ object FormDemoApp:
         else if id == EmailId then m.email
         else m.bio
 
-      // Enter inside a field submits the whole form — TextField.handleKey
-      // would just fire onSubmit anyway, so dispatch directly here for
-      // clarity.
-      if key == KeyDecoder.InputKey.Enter then update(m, Submit, ctx)
-      else
-        val (next, _) = TextField.handleKey(getField, key)(_ => None)
-        setField(next).tui
+      val (next, maybeMsg) = TextField.handleKeyOrSubmit(getField, key)(Submit)
+      val nextModel        = setField(next)
+      maybeMsg match
+        case Some(follow) => update(nextModel, follow, ctx)
+        case None         => nextModel.tui
 
     override def view(m: Model): RootNode =
       given Theme = if m.darkTheme then Theme.dark else Theme.light
@@ -283,7 +293,7 @@ object FormDemoApp:
       // here flip — that's the always-visible signal the toggle worked.
       val helpBar = StatusBar(
         left = " form ",
-        center = "Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit",
+        center = "Tab/⇧Tab/↑↓: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit",
         right = s" theme=$themeName ",
         width = termWidth,
         at = Coord(1.x, termHeight.y)

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/initial-dark.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/initial-dark.golden
@@ -20,4 +20,4 @@
 |                                                                                |
 |                                                                                |
 |                                                                                |
-| form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |
+| form   Tab/⇧Tab/↑↓: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/name-typed-email-focused.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/name-typed-email-focused.golden
@@ -20,4 +20,4 @@
 |                                                                                |
 |                                                                                |
 |                                                                                |
-| form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |
+| form   Tab/⇧Tab/↑↓: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/submitted.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/FormDemoAppSpec/submitted.golden
@@ -20,4 +20,4 @@
 |                                                                                |
 |                                                                                |
 |                                                                                |
-| form      Tab/⇧Tab: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |
+| form   Tab/⇧Tab/↑↓: nav  Enter: submit  Ctrl+T: theme  Ctrl+C: quit theme=dark |

--- a/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
@@ -45,6 +45,73 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
     d.send(Msg.ConsoleInputKey(InputKey.BackTab))
     assert(d.model.fm.isFocused(BioId))
 
+  // --- arrow-key focus navigation ------------------------------------------
+
+  test("ArrowDown advances focus from inside a TextField (vertical arrows are global)"):
+    val d = driver()
+    typeKeys(d, "alice")
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowDown))
+    assert(d.model.fm.isFocused(EmailId))
+    assert(d.model.name.buffer == "alice", "ArrowDown must not damage the field buffer")
+
+  test("ArrowUp on a TextField walks back through the cycle"):
+    val d = driver()
+    d.send(Msg.NextFocus) // Email
+    d.send(Msg.NextFocus) // Bio
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowUp))
+    assert(d.model.fm.isFocused(EmailId))
+
+  test("ArrowDown from the last element wraps back to Name"):
+    val d = driver()
+    (1 to 4).foreach(_ => d.send(Msg.NextFocus)) // -> Reset
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowDown))
+    assert(d.model.fm.isFocused(NameId))
+
+  test("ArrowUp from Name wraps to Reset"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowUp))
+    assert(d.model.fm.isFocused(ResetId))
+
+  test("ArrowRight / ArrowLeft on a button advances / retreats focus"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // -> Submit
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowRight))
+    assert(d.model.fm.isFocused(ResetId))
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowLeft))
+    assert(d.model.fm.isFocused(SubmitId))
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowLeft))
+    assert(d.model.fm.isFocused(BioId)) // linear cycle: Submit <- Bio
+
+  test("ArrowLeft inside a TextField moves the in-field cursor, NOT focus"):
+    val d = driver()
+    typeKeys(d, "abc")
+    assert(d.model.name.cursor == 3)
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowLeft))
+    assert(d.model.fm.isFocused(NameId), "focus must stay on Name")
+    assert(d.model.name.cursor == 2, "cursor should have moved within the buffer")
+
+  test("ArrowRight inside a TextField moves the in-field cursor, NOT focus"):
+    val d = driver()
+    typeKeys(d, "abc")
+    // Move to index 1, then press right and expect index 2.
+    d.send(Msg.ConsoleInputKey(InputKey.Home))
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowRight))
+    assert(d.model.fm.isFocused(NameId))
+    assert(d.model.name.cursor == 1)
+
+  test("Globals bind vertical arrows but NOT horizontal arrows"):
+    val g = FormDemoApp.Globals
+    assert(g.lookup(InputKey.ArrowUp).contains(Msg.PrevFocus))
+    assert(g.lookup(InputKey.ArrowDown).contains(Msg.NextFocus))
+    // Left/Right must stay out of Globals so they can reach TextField.
+    assert(g.lookup(InputKey.ArrowLeft).isEmpty)
+    assert(g.lookup(InputKey.ArrowRight).isEmpty)
+
+  test("NonTextShortcuts bind horizontal arrows for button-focus routing"):
+    val n = FormDemoApp.NonTextShortcuts
+    assert(n.lookup(InputKey.ArrowLeft).contains(Msg.PrevFocus))
+    assert(n.lookup(InputKey.ArrowRight).contains(Msg.NextFocus))
+
   // --- TextField key routing -----------------------------------------------
 
   test("typing into the focused field updates only that field's buffer"):

--- a/modules/termflow/src/main/scala/termflow/tui/Keymap.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Keymap.scala
@@ -110,6 +110,51 @@ object Keymap:
     )
 
   /**
+   * Bind `ArrowUp` / `ArrowDown` to `previous` / `next` focus messages.
+   *
+   * Safe to compose into a truly-global keymap because single-line widgets
+   * like [[termflow.tui.widgets.TextField]] don't consume vertical arrows.
+   *
+   * {{{
+   * val Globals =
+   *   Keymap.focus(next = NextFocus, previous = PrevFocus) ++
+   *     Keymap.focusVertical(previous = PrevFocus, next = NextFocus)
+   * }}}
+   *
+   * @param previous Message dispatched on `ArrowUp`.
+   * @param next     Message dispatched on `ArrowDown`.
+   */
+  def focusVertical[Msg](previous: Msg, next: Msg): Keymap[Msg] =
+    Keymap(
+      InputKey.ArrowUp   -> previous,
+      InputKey.ArrowDown -> next
+    )
+
+  /**
+   * Bind `ArrowLeft` / `ArrowRight` to `previous` / `next` focus messages.
+   *
+   * **Compose into a non-text focus layer only.** Inside a
+   * [[termflow.tui.widgets.TextField]], the horizontal arrows are used for
+   * in-field cursor movement — binding them globally would break editing.
+   * The idiom is to layer the apps' per-element routing so that fields
+   * consume these keys themselves and button-focused (or no-focus) rows
+   * fall through to this keymap.
+   *
+   * {{{
+   * val NonTextShortcuts =
+   *   Keymap.focusHorizontal(previous = PrevFocus, next = NextFocus)
+   * }}}
+   *
+   * @param previous Message dispatched on `ArrowLeft`.
+   * @param next     Message dispatched on `ArrowRight`.
+   */
+  def focusHorizontal[Msg](previous: Msg, next: Msg): Keymap[Msg] =
+    Keymap(
+      InputKey.ArrowLeft  -> previous,
+      InputKey.ArrowRight -> next
+    )
+
+  /**
    * Conventional editing bindings: arrow keys, Home, End, Enter, Backspace.
    *
    * Useful when wiring an app that handles its own text input (without

--- a/modules/termflow/src/main/scala/termflow/tui/Theme.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Theme.scala
@@ -70,8 +70,8 @@ package termflow.tui
  *       The renderer does not fill the whole frame with `theme.background` —
  *       it only colours cells that are actually drawn, so `theme.background`
  *       and `theme.foreground` only become visible on cells whose `Style`
- *       references them. If you toggle from [[dark]] to [[light]] on a
- *       black-background terminal, plain text using `fg = theme.foreground`
+ *       references them. If you toggle from [[Theme.dark]] to [[Theme.light]]
+ *       on a black-background terminal, plain text using `fg = theme.foreground`
  *       (i.e. black) becomes invisible because the surrounding cells are not
  *       repainted to white. Workarounds:
  *

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/TextField.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/TextField.scala
@@ -172,6 +172,36 @@ object TextField:
       case _ => (state, None)
 
   /**
+   * Convenience wrapper around [[handleKey]] that bundles the
+   * Enter-submits-form pattern. When the key is `Enter`, the returned
+   * message is `Some(submitMsg)`; otherwise it behaves exactly like
+   * `handleKey` with a no-op `onSubmit` (every other key edits the buffer
+   * as normal and returns `None`).
+   *
+   * This is the idiomatic way to route a key into a TextField inside a
+   * multi-field form whose Enter submits the whole form rather than the
+   * single field. Without this helper, callers either repeat the
+   * `handleKey(s, k)(_ => Some(submitMsg))` closure at every call site or
+   * intercept `Enter` explicitly before calling `handleKey`.
+   *
+   * {{{
+   * val (next, maybeMsg) = TextField.handleKeyOrSubmit(state, key)(Msg.Submit)
+   * maybeMsg.foreach(m => runtime.dispatch(m))
+   * }}}
+   *
+   * @param state     Current field state.
+   * @param key       Decoded key event.
+   * @param submitMsg By-name message produced on `Enter` — only evaluated
+   *                  when the key actually is `Enter`, so it's safe to pass
+   *                  a value that would be expensive to compute eagerly.
+   */
+  def handleKeyOrSubmit[Msg](
+    state: State,
+    key: KeyDecoder.InputKey
+  )(submitMsg: => Msg): (State, Option[Msg]) =
+    handleKey(state, key)(_ => Some(submitMsg))
+
+  /**
    * Render the field as a single-row [[TextNode]] of exactly `lineWidth`
    * cells.
    *

--- a/modules/termflow/src/test/scala/termflow/tui/KeymapSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/KeymapSpec.scala
@@ -61,6 +61,32 @@ class KeymapSpec extends AnyFunSuite:
     assert(k.lookup(InputKey.BackTab).contains(DemoMsg.A))
     assert(k.size == 2)
 
+  test("Keymap.focusVertical binds ArrowUp to previous and ArrowDown to next"):
+    val k = Keymap.focusVertical(previous = DemoMsg.A, next = DemoMsg.B)
+    assert(k.lookup(InputKey.ArrowUp).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.ArrowDown).contains(DemoMsg.B))
+    assert(k.size == 2)
+
+  test("Keymap.focusHorizontal binds ArrowLeft to previous and ArrowRight to next"):
+    val k = Keymap.focusHorizontal(previous = DemoMsg.A, next = DemoMsg.B)
+    assert(k.lookup(InputKey.ArrowLeft).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.ArrowRight).contains(DemoMsg.B))
+    assert(k.size == 2)
+
+  test("focus / focusVertical / focusHorizontal compose orthogonally via ++"):
+    val k =
+      Keymap.focus(next = DemoMsg.NextFocus, previous = DemoMsg.A) ++
+        Keymap.focusVertical(previous = DemoMsg.A, next = DemoMsg.NextFocus) ++
+        Keymap.focusHorizontal(previous = DemoMsg.A, next = DemoMsg.NextFocus)
+    assert(k.size == 6) // Tab + BackTab + Up + Down + Left + Right
+    // Spot-check that all six distinct keys land where expected.
+    assert(k.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus))
+    assert(k.lookup(InputKey.BackTab).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.ArrowUp).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.ArrowDown).contains(DemoMsg.NextFocus))
+    assert(k.lookup(InputKey.ArrowLeft).contains(DemoMsg.A))
+    assert(k.lookup(InputKey.ArrowRight).contains(DemoMsg.NextFocus))
+
   test("Keymap.editing binds Enter, Backspace, ArrowLeft, ArrowRight"):
     val k = Keymap.editing(
       onEnter = DemoMsg.A,

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
@@ -130,6 +130,45 @@ class TextFieldSpec extends AnyFunSuite:
     val sNext = if m.isDefined then s1.cleared else s1
     assert(sNext.buffer == "" && sNext.cursor == 0)
 
+  // --- handleKeyOrSubmit helper --------------------------------------------
+
+  test("handleKeyOrSubmit dispatches submitMsg on Enter"):
+    val s0      = TextField.State.of("ready")
+    val (s1, m) = TextField.handleKeyOrSubmit(s0, InputKey.Enter)("submit!")
+    assert(s1 == s0, "state must be preserved on Enter, same as handleKey")
+    assert(m.contains("submit!"))
+
+  test("handleKeyOrSubmit edits the buffer for non-Enter keys and returns None"):
+    val s0       = TextField.State.empty
+    val (s1, m1) = TextField.handleKeyOrSubmit(s0, InputKey.CharKey('a'))("submit!")
+    assert(s1.buffer == "a")
+    assert(s1.cursor == 1)
+    assert(m1.isEmpty)
+    val (s2, m2) = TextField.handleKeyOrSubmit(s1, InputKey.CharKey('b'))("submit!")
+    assert(s2.buffer == "ab")
+    assert(m2.isEmpty)
+
+  test("handleKeyOrSubmit's submitMsg is by-name — not evaluated for non-Enter keys"):
+    // If the by-name contract is broken, the counter would bump on every
+    // keystroke; with a correct by-name param it only bumps on Enter.
+    val counter = new java.util.concurrent.atomic.AtomicInteger(0)
+    def makeMsg: String = {
+      counter.incrementAndGet()
+      "hit"
+    }
+    val s0 = TextField.State.empty
+    // 5 non-Enter keys — makeMsg must not fire
+    val (s1, _) = TextField.handleKeyOrSubmit(s0, InputKey.CharKey('h'))(makeMsg)
+    val (s2, _) = TextField.handleKeyOrSubmit(s1, InputKey.CharKey('i'))(makeMsg)
+    val (s3, _) = TextField.handleKeyOrSubmit(s2, InputKey.ArrowLeft)(makeMsg)
+    val (s4, _) = TextField.handleKeyOrSubmit(s3, InputKey.ArrowRight)(makeMsg)
+    val (s5, _) = TextField.handleKeyOrSubmit(s4, InputKey.Backspace)(makeMsg)
+    assert(counter.get() == 0, s"makeMsg should not have fired; counter=${counter.get()}")
+    // Finally, an Enter — now it should fire exactly once.
+    val (_, msg) = TextField.handleKeyOrSubmit(s5, InputKey.Enter)(makeMsg)
+    assert(counter.get() == 1)
+    assert(msg.contains("hit"))
+
   test("global keys (Ctrl+C, Ctrl+D) are NOT handled — pass through unchanged"):
     val s0       = TextField.State.of("abc")
     val (s1, m1) = TextField.handleKey(s0, InputKey.Ctrl('C'))(submitOpt)


### PR DESCRIPTION
Two ergonomics improvements surfaced by running the form demo from PR #104.

**Stacked on #104 → #102 → #101 → … → #84.** Base branch is \`feature/91-form-demo-fixes\`.

## Summary

- **\`Keymap.focusVertical\` / \`focusHorizontal\`** preset factories mirroring the existing \`Keymap.focus\`
- **\`TextField.handleKeyOrSubmit\`** widget-level helper for the Enter-submits-form pattern
- **FormDemoApp** wires them up: \`↑\`/\`↓\` work anywhere (globals), \`←\`/\`→\` only on buttons (non-text layer — doesn't conflict with in-field cursor)
- Fixed a broken ScalaDoc link (\`[[dark]]\` → \`[[Theme.dark]]\`) that slipped into PR #104
- 15 net new tests, all green

## Key behaviour table

| Key | TextField focus | Button focus |
|---|---|---|
| \`↑\` / \`↓\` | prev/next **focus** (via \`Globals\`) | prev/next focus |
| \`←\` / \`→\` | in-field **cursor** (via \`TextField.handleKey\`) | prev/next focus (via \`NonTextShortcuts\`) |
| \`Tab\` / \`Shift+Tab\` | prev/next focus | prev/next focus |
| \`Enter\` | **submit** form (via \`handleKeyOrSubmit\`) | activate |

The linear \`FocusOrder = [Name, Email, Bio, Submit, Reset]\` means:
- \`↓\` from Bio → Submit
- \`↓\` from Reset → Name (wraps)
- \`→\` on Submit → Reset
- \`←\` on Submit → Bio (follows linear cycle)

## Why split horizontal / vertical arrows

The one real constraint is that \`TextField.handleKey\` already consumes \`ArrowLeft\` / \`ArrowRight\` for in-field cursor movement (TextField.scala:160-165). Putting those in the globally-first keymap would break text editing.

Solution: two new preset factories instead of one bundled one, so apps compose them at the right scope:

- \`focusVertical\` goes in globals (safe — TextField is single-line, doesn't use ↑/↓)
- \`focusHorizontal\` goes in the non-text layer (fields consume arrows first, buttons fall through)

## \`TextField.handleKeyOrSubmit\`

Before (what FormDemoApp did in PR #104):

\`\`\`scala
if key == KeyDecoder.InputKey.Enter then update(m, Submit, ctx)
else
  val (next, _) = TextField.handleKey(getField, key)(_ => None)
  setField(next).tui
\`\`\`

After:

\`\`\`scala
val (next, maybeMsg) = TextField.handleKeyOrSubmit(getField, key)(Submit)
val nextModel        = setField(next)
maybeMsg match
  case Some(follow) => update(nextModel, follow, ctx)
  case None         => nextModel.tui
\`\`\`

One call instead of two, and the pattern is now documented and reusable. \`submitMsg\` is by-name so expensive messages aren't constructed on every keystroke (a dedicated test with an \`AtomicInteger\` pins this).

## Test plan

- [x] 3 new **KeymapSpec** tests (11 → 12): \`focusVertical\` binding, \`focusHorizontal\` binding, compose-all-three covers 6 keys
- [x] 3 new **TextFieldSpec** tests (25 → 28): \`handleKeyOrSubmit\` dispatches on Enter; edits buffer otherwise; **by-name verification** via atomic counter
- [x] 9 new **FormDemoAppSpec** tests (25 → 34), including three **critical regression guards**:
  - \`ArrowLeft\` inside a TextField moves the cursor, NOT focus
  - \`ArrowRight\` inside a TextField moves the cursor, NOT focus
  - \`Globals\` contain vertical arrows but NOT horizontal (binding-table check prevents future slip-ups)
- [x] \`sbt ciCheck\` green — **320 tests total** (247 termflow + 73 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly (fixed the \`[[dark]]\`/\`[[light]]\` broken link from PR #104)
- [x] Goldens re-recorded for the StatusBar text now showing "↑↓" alongside Tab

## Run it

\`\`\`bash
git fetch origin
git checkout feature/91-form-arrow-navigation
sbt formDemo
\`\`\`

Try: \`↓\` to move between fields, \`→\` on Submit to cross to Reset, \`←\` inside the Name field to reposition the cursor (watch the inverse-video block move).

## Out of scope

- In-field cursor keys (Ctrl+A/E/K/U/W, word-wise Ctrl+Left/Right). You explicitly called this out as not-what-you-meant; if it's ever wanted it's a separate issue (needs new KeyDecoder escape-sequence handling).
- 2D grid-aware FocusManager so \`←\` on Submit only cycles Submit↔Reset without dipping into Bio. Current linear behaviour matches the stated mental model; only add grid awareness if/when the linear cycle feels wrong in practice.
- Equivalent wiring for WidgetsDemoApp — that demo has no TextFields so the horizontal-arrow conflict doesn't exist; trivial follow-up if worth doing.