### PR TITLE
Add ListView stateful widget

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/widgets/ListView.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/ListView.scala
@@ -1,0 +1,202 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Scrollable list of items with a selection cursor.
+ *
+ * Renamed from `List` to avoid shadowing `scala.List` inside callers.
+ *
+ * Like every stateful widget in this package, `ListView` is purely
+ * value-based: state lives in the app's model, `handleKey` advances it
+ * without side effects, and `view` renders a tree of `VNode`s.
+ *
+ * ## Anatomy
+ *
+ *   - [[ListView.State]] — `(items, selected, scrollOffset, visibleRows)`
+ *   - [[ListView.handleKey]] — pure function: `(state, key) → (state, Option[Msg])`
+ *   - [[ListView.view]] — produces a [[BoxNode]] of exactly `visibleRows` cells tall
+ *
+ * ## Usage
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.widgets.*
+ *
+ * given Theme = Theme.dark
+ * val ListId  = FocusId("tasks")
+ *
+ * case class Model(
+ *   tasks: ListView.State[String],
+ *   fm:    FocusManager
+ * )
+ *
+ * // In update:
+ * case Msg.ConsoleInputKey(k) if model.fm.isFocused(ListId) =>
+ *   val (next, maybe) = ListView.handleKey(model.tasks, k)(item => Some(Msg.Open(item)))
+ *   val nextModel = model.copy(tasks = next)
+ *   maybe.fold(nextModel.tui)(m => Tui(nextModel, Cmd.GCmd(m)))
+ *
+ * // In view:
+ * ListView.view(model.tasks, lineWidth = 30, focused = model.fm.isFocused(ListId))
+ * }}}
+ *
+ * ## Selection rendering
+ *
+ * Focus gates the cursor:
+ *   - **focused + selected**: row painted in inverse video
+ *     (`bg = theme.primary, fg = theme.background`) with a `▸ ` prefix
+ *   - **focused, non-selected**: `  ` (two-space) prefix, `theme.foreground`
+ *   - **unfocused**: every row shows `  ` and `theme.foreground`, no
+ *     visible selection mark — consistent with Button which shows no
+ *     focused-state visuals when it isn't actually focused
+ *
+ * The two-cell prefix is preserved across all rows to keep column
+ * alignment stable when focus arrives or leaves.
+ */
+object ListView:
+
+  /**
+   * State for a single list.
+   *
+   * Invariants maintained by [[handleKey]]:
+   *   - `selected` is in `[0, items.size)` when non-empty, or `0` when empty
+   *   - `scrollOffset` is in `[0, max(0, items.size - visibleRows)]`
+   *   - `selected` is always inside the visible window
+   *     `[scrollOffset, scrollOffset + visibleRows)`
+   *
+   * `visibleRows` is the viewport height in cells, not the number of items.
+   *
+   * @param items        The full collection, not just the visible slice.
+   * @param selected     Index of the currently-highlighted item.
+   * @param scrollOffset Index of the topmost visible item.
+   * @param visibleRows  Number of rows rendered at a time (minimum 1).
+   */
+  final case class State[A](
+    items: Vector[A],
+    selected: Int,
+    scrollOffset: Int,
+    visibleRows: Int
+  ):
+
+    /** `true` when the list has no items. */
+    def isEmpty: Boolean = items.isEmpty
+
+    /** Total number of items. */
+    def size: Int = items.size
+
+    /** The currently highlighted item, if any. */
+    def selectedItem: Option[A] = items.lift(selected)
+
+    /** Replace the items collection; re-clamps `selected` / `scrollOffset`. */
+    def withItems(newItems: Vector[A]): State[A] =
+      if newItems.isEmpty then copy(items = Vector.empty, selected = 0, scrollOffset = 0)
+      else
+        val sel    = math.max(0, math.min(newItems.size - 1, selected))
+        val vis    = math.max(1, visibleRows)
+        val maxOff = math.max(0, newItems.size - vis)
+        val off    = math.max(0, math.min(maxOff, scrollOffset))
+        // Ensure selected is visible.
+        val fixedOff =
+          if sel < off then sel
+          else if sel >= off + vis then sel - vis + 1
+          else off
+        copy(items = newItems, selected = sel, scrollOffset = math.max(0, math.min(maxOff, fixedOff)))
+
+  object State:
+
+    /** Empty list with the given viewport height. */
+    def empty[A](visibleRows: Int = 5): State[A] =
+      State(Vector.empty[A], 0, 0, math.max(1, visibleRows))
+
+    /** List populated with `items`; selection parks at the first item. */
+    def of[A](items: Vector[A], visibleRows: Int = 5): State[A] =
+      State(items, 0, 0, math.max(1, visibleRows))
+
+  /**
+   * Process one keystroke, returning a new state and optionally a message
+   * (typically when the user presses Enter on the highlighted row).
+   *
+   * Behaviour:
+   *   - `ArrowUp` / `ArrowDown`     move selection by 1, clamped
+   *   - `Home` / `End`              jump to first / last item
+   *   - `Enter` / `Space`           call `onSelect(selectedItem)` if any
+   *   - other keys                  no change
+   *
+   * Selection movements also scroll the viewport to keep the selection
+   * visible. Pass-through for unrecognised keys so the caller can layer
+   * on additional shortcuts (e.g. a page-down) via composition.
+   */
+  def handleKey[A, Msg](
+    state: State[A],
+    key: KeyDecoder.InputKey
+  )(onSelect: A => Option[Msg]): (State[A], Option[Msg]) =
+    import KeyDecoder.InputKey.*
+    if state.isEmpty then (state, None)
+    else
+      key match
+        case ArrowUp              => (moveTo(state, state.selected - 1), None)
+        case ArrowDown            => (moveTo(state, state.selected + 1), None)
+        case Home                 => (moveTo(state, 0), None)
+        case End                  => (moveTo(state, state.size - 1), None)
+        case Enter | CharKey(' ') => (state, state.selectedItem.flatMap(onSelect))
+        case _                    => (state, None)
+
+  /** Move selection to `target` (clamped) and adjust scroll offset so it stays visible. */
+  private def moveTo[A](state: State[A], target: Int): State[A] =
+    val vis     = math.max(1, state.visibleRows)
+    val clamped = math.max(0, math.min(state.size - 1, target))
+    val off =
+      if clamped < state.scrollOffset then clamped
+      else if clamped >= state.scrollOffset + vis then clamped - vis + 1
+      else state.scrollOffset
+    state.copy(selected = clamped, scrollOffset = math.max(0, off))
+
+  /**
+   * Render the list as a `BoxNode` (no border) exactly `visibleRows` tall
+   * and `lineWidth` wide.
+   *
+   * @param state     List state.
+   * @param at        Top-left cell. Defaults to `(1, 1)` for layout composition.
+   * @param lineWidth Row width in cells.
+   * @param focused   Whether the list currently has focus.
+   * @param render    How to format one item. Defaults to `_.toString`.
+   */
+  def view[A](
+    state: State[A],
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    lineWidth: Int = 30,
+    focused: Boolean = false,
+    render: A => String = (a: A) => a.toString
+  )(using theme: Theme): VNode =
+    val width = math.max(3, lineWidth) // need room for "▸ " + at least 1 char
+    val vis   = math.max(1, state.visibleRows)
+
+    val children = (0 until vis).map { row =>
+      val itemIdx = state.scrollOffset + row
+      val rowY    = at.y + row
+      if itemIdx >= state.size then
+        // Blank filler row (erases any prior content when the list shrinks).
+        TextNode(at.x, rowY, List(Text(" " * width, Style())))
+      else
+        val isSelected = itemIdx == state.selected
+        val content    = render(state.items(itemIdx))
+        val truncated  = content.take(width - 2)
+        val padded     = truncated.padTo(width - 2, ' ')
+        val showCursor = isSelected && focused
+        val prefix     = if showCursor then "▸ " else "  "
+        val style =
+          if showCursor then Style(fg = theme.background, bg = theme.primary)
+          else Style(fg = theme.foreground)
+        TextNode(
+          at.x,
+          rowY,
+          List(Text(prefix, style), Text(padded, style))
+        )
+    }.toList
+
+    BoxNode(at.x, at.y, width, vis, children = children, style = Style())
+
+  /** Width of a rendered list with the given `lineWidth`. Mirrors [[view]]. */
+  def width(lineWidth: Int): Int = math.max(3, lineWidth)

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/ListViewSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/ListViewSpec.scala
@@ -1,0 +1,208 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.KeyDecoder.InputKey
+
+class ListViewSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private val items3 = Vector("alpha", "beta", "gamma")
+  private val items5 = Vector("a", "b", "c", "d", "e")
+
+  private def submit: String => Option[String] = _ => None
+
+  // --- state construction --------------------------------------------------
+
+  test("State.empty starts with no items, selection 0, scroll 0"):
+    val s = ListView.State.empty[String](visibleRows = 4)
+    assert(s.isEmpty)
+    assert(s.size == 0)
+    assert(s.selected == 0)
+    assert(s.scrollOffset == 0)
+    assert(s.visibleRows == 4)
+    assert(s.selectedItem.isEmpty)
+
+  test("State.of pre-populates and parks selection at index 0"):
+    val s = ListView.State.of(items3, visibleRows = 5)
+    assert(s.size == 3)
+    assert(s.selectedItem.contains("alpha"))
+
+  test("State.empty clamps visibleRows to >= 1"):
+    val s = ListView.State.empty[String](visibleRows = 0)
+    assert(s.visibleRows == 1)
+
+  test("withItems clamps selected and scrollOffset when the list shrinks"):
+    val s0 = ListView.State.of(items5, visibleRows = 3).copy(selected = 4, scrollOffset = 2)
+    val s1 = s0.withItems(Vector("x", "y"))
+    assert(s1.size == 2)
+    assert(s1.selected == 1)
+    assert(s1.scrollOffset == 0)
+
+  test("withItems of an empty collection resets everything to zero"):
+    val s = ListView.State.of(items5).copy(selected = 3)
+    val e = s.withItems(Vector.empty)
+    assert(e.isEmpty)
+    assert(e.selected == 0)
+    assert(e.scrollOffset == 0)
+
+  // --- handleKey: empty list -----------------------------------------------
+
+  test("handleKey on an empty list is a no-op for every key"):
+    val s0      = ListView.State.empty[String](visibleRows = 4)
+    val (s1, m) = ListView.handleKey(s0, InputKey.ArrowDown)(submit)
+    assert(s1 == s0 && m.isEmpty)
+
+  // --- handleKey: movement -------------------------------------------------
+
+  test("ArrowDown advances selection, clamping at the last item"):
+    val s0      = ListView.State.of(items3)
+    val (s1, _) = ListView.handleKey(s0, InputKey.ArrowDown)(submit)
+    assert(s1.selected == 1)
+    val (s2, _) = ListView.handleKey(s1, InputKey.ArrowDown)(submit)
+    assert(s2.selected == 2)
+    val (s3, _) = ListView.handleKey(s2, InputKey.ArrowDown)(submit)
+    assert(s3.selected == 2, "clamped at end, no overflow")
+
+  test("ArrowUp retreats selection, clamping at 0"):
+    val s0      = ListView.State.of(items3).copy(selected = 2)
+    val (s1, _) = ListView.handleKey(s0, InputKey.ArrowUp)(submit)
+    assert(s1.selected == 1)
+    val (s2, _) = ListView.handleKey(s1, InputKey.ArrowUp)(submit)
+    val (s3, _) = ListView.handleKey(s2, InputKey.ArrowUp)(submit)
+    assert(s3.selected == 0, "clamped at 0, no underflow")
+
+  test("Home and End jump to the endpoints"):
+    val s0     = ListView.State.of(items5).copy(selected = 2)
+    val (h, _) = ListView.handleKey(s0, InputKey.Home)(submit)
+    assert(h.selected == 0)
+    val (e, _) = ListView.handleKey(s0, InputKey.End)(submit)
+    assert(e.selected == 4)
+
+  // --- handleKey: Enter / Space --------------------------------------------
+
+  test("Enter on the selected item calls onSelect and dispatches its message"):
+    val s0      = ListView.State.of(items3).copy(selected = 1)
+    val (s1, m) = ListView.handleKey(s0, InputKey.Enter)(item => Some(s"chose:$item"))
+    assert(s1 == s0, "Enter must not mutate state")
+    assert(m.contains("chose:beta"))
+
+  test("Space also activates onSelect"):
+    val s0     = ListView.State.of(items3).copy(selected = 2)
+    val (_, m) = ListView.handleKey(s0, InputKey.CharKey(' '))(item => Some(item))
+    assert(m.contains("gamma"))
+
+  test("Enter when onSelect returns None dispatches nothing"):
+    val s0     = ListView.State.of(items3)
+    val (_, m) = ListView.handleKey(s0, InputKey.Enter)(_ => None)
+    assert(m.isEmpty)
+
+  // --- scroll viewport -----------------------------------------------------
+
+  test("scrolling down past the viewport advances scrollOffset"):
+    val s0 = ListView.State.of(items5, visibleRows = 3)
+    // Walk selection to 3 (past the 3-row window).
+    val s1 = (1 to 3).foldLeft(s0) { case (acc, _) =>
+      ListView.handleKey(acc, InputKey.ArrowDown)(submit)._1
+    }
+    assert(s1.selected == 3)
+    assert(s1.scrollOffset == 1, "viewport should have scrolled down by 1")
+
+  test("scrolling up above the viewport decreases scrollOffset"):
+    val s0 = ListView.State.of(items5, visibleRows = 2).copy(selected = 3, scrollOffset = 2)
+    // Selected=3 is visible at offset 2 (rows 2,3). Move up one more.
+    val (s1, _) = ListView.handleKey(s0, InputKey.ArrowUp)(submit)
+    assert(s1.selected == 2)
+    assert(s1.scrollOffset == 2, "still visible; offset unchanged")
+    val (s2, _) = ListView.handleKey(s1, InputKey.ArrowUp)(submit)
+    assert(s2.selected == 1)
+    assert(s2.scrollOffset == 1, "scrolled up one row")
+
+  test("End places the last item in the bottom-most viewport row"):
+    val s0      = ListView.State.of(items5, visibleRows = 2)
+    val (s1, _) = ListView.handleKey(s0, InputKey.End)(submit)
+    assert(s1.selected == 4)
+    assert(s1.scrollOffset == 3, "last item shown at row 2 of a 2-row window")
+
+  // --- rendering -----------------------------------------------------------
+
+  private def render(v: VNode, width: Int, height: Int): (Array[Array[Char]], Array[Array[Style]]) =
+    val frame = AnsiRenderer.buildFrame(RootNode(width, height, List(v), None))
+    val chars = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).ch)
+    val style = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).style)
+    (chars, style)
+
+  test("unfocused render shows every item with an unstyled prefix"):
+    val s       = ListView.State.of(items3, visibleRows = 3)
+    val v       = ListView.view(s, lineWidth = 10, focused = false, render = (s: String) => s)
+    val (cs, _) = render(v, 10, 3)
+    val rows    = cs.map(_.mkString)
+    assert(rows(0).startsWith("  alpha"))
+    assert(rows(1).startsWith("  beta"))
+    assert(rows(2).startsWith("  gamma"))
+
+  test("focused render highlights the selected row in inverse video"):
+    val s            = ListView.State.of(items3, visibleRows = 3).copy(selected = 1)
+    val v            = ListView.view(s, lineWidth = 10, focused = true, render = (s: String) => s)
+    val (cs, styles) = render(v, 10, 3)
+    val row1         = cs(1).mkString
+    assert(row1.startsWith("▸ beta"))
+    // All cells of row 1 use theme.primary as background.
+    (0 until 10).foreach(c => assert(styles(1)(c).bg == Theme.dark.primary, s"row 1 col $c expected inverse bg"))
+    // Rows 0 and 2 do not.
+    assert(styles(0)(0).bg == Color.Default)
+    assert(styles(2)(0).bg == Color.Default)
+
+  test("unfocused render does NOT mark the selection (focus gates the cursor)"):
+    val s            = ListView.State.of(items3, visibleRows = 3).copy(selected = 1)
+    val v            = ListView.view(s, lineWidth = 10, focused = false, render = (s: String) => s)
+    val (cs, styles) = render(v, 10, 3)
+    // No inverse video on the selected row…
+    assert(styles(1)(0).bg == Color.Default)
+    // …and no ▸ marker either; every row has the "  " prefix so column
+    // alignment stays stable across focus transitions.
+    assert(cs(1).mkString.startsWith("  beta"))
+    assert(!cs.exists(_.contains('▸')))
+
+  test("viewport scrolls so the selected item is visible"):
+    val s0      = ListView.State.of(items5, visibleRows = 2).copy(selected = 4, scrollOffset = 3)
+    val v       = ListView.view(s0, lineWidth = 6, focused = true, render = (s: String) => s)
+    val (cs, _) = render(v, 6, 2)
+    // With selected=4, scrollOffset=3, vis=2: rows should show items[3]='d' and items[4]='e'.
+    assert(cs(0).mkString.trim.endsWith("d"))
+    assert(cs(1).mkString.trim.endsWith("e"))
+
+  test("empty items render as blank filler rows sized to visibleRows"):
+    val s       = ListView.State.empty[String](visibleRows = 3)
+    val v       = ListView.view(s, lineWidth = 5, focused = true)
+    val (cs, _) = render(v, 5, 3)
+    cs.foreach(row => assert(row.mkString == "     "))
+
+  test("a viewport taller than the list fills remaining rows with blanks"):
+    val s       = ListView.State.of(Vector("one"), visibleRows = 3)
+    val v       = ListView.view(s, lineWidth = 8, focused = false, render = (s: String) => s)
+    val (cs, _) = render(v, 8, 3)
+    assert(cs(0).mkString.startsWith("  one"))
+    // Rows 1 and 2 should be blank — no ghost items.
+    assert(cs(1).mkString == "        ")
+    assert(cs(2).mkString == "        ")
+
+  test("renders overflow items truncated to (lineWidth - 2)"):
+    val long    = Vector("this-is-a-very-long-item-name")
+    val s       = ListView.State.of(long, visibleRows = 1)
+    val v       = ListView.view(s, lineWidth = 8, focused = false, render = (s: String) => s)
+    val (cs, _) = render(v, 8, 1)
+    // "  " prefix (unfocused, no cursor) + 6 chars of truncated content.
+    assert(cs(0).mkString == "  this-i")
+
+  test("width helper reports >= 3 regardless of input"):
+    assert(ListView.width(30) == 30)
+    assert(ListView.width(2) == 3)
+    assert(ListView.width(-1) == 3)
+
+  test("ListView composes inside Layout.column with its full visibleRows height"):
+    val s = ListView.State.of(items5, visibleRows = 4)
+    val v = ListView.view(s, lineWidth = 12)
+    val c = Layout.column(gap = 0)(v)
+    assert(c.measure == (12, 4))


### PR DESCRIPTION
Second stateful widget in the #91 series. Sister widgets (\`Select\`, \`Table\`) follow in PRs #107 and #108.

**Stacked on #105** (→ #104 → #102 → …). Base is \`feature/91-form-arrow-navigation\`.

## Summary

- **\`ListView\`** — scrollable list of items with a selection cursor
- State + handleKey + view following the TextField pattern
- 24 unit tests covering state transitions, viewport scrolling, rendering, and layout composition

## Why \`ListView\` not \`List\`

Widget lives under \`termflow.tui.widgets\`. Apps tend to wildcard-import the package, so \`List\` would shadow \`scala.List\` — bad ergonomics. \`ListView\` is unambiguous and mirrors common TUI library conventions.

## API

\`\`\`scala
// State
val s0 = ListView.State.empty[String](visibleRows = 5)
val s1 = ListView.State.of(Vector("alpha", "beta", "gamma"), visibleRows = 5)
val s2 = s1.withItems(newItems) // re-clamps selected + scroll

// Update
val (next, maybeMsg) = ListView.handleKey(state, key) { item =>
  Some(Msg.Open(item)) // fired on Enter/Space when an item is selected
}

// Render — BoxNode (no border) of exactly `visibleRows` tall
ListView.view(state, lineWidth = 30, focused = true, render = _.label)
\`\`\`

## Focus-gated cursor rendering

| State | Prefix | Style |
|---|---|---|
| focused + selected | \`▸ \` | inverse video (\`bg = theme.primary, fg = theme.background\`) |
| focused, non-selected | \`  \` (two spaces) | \`theme.foreground\` |
| unfocused (any row) | \`  \` | \`theme.foreground\` |

The two-cell prefix is reserved on every row so column alignment doesn't shift when focus arrives or leaves. Same discipline as the \`Button\` widget.

## Scroll behaviour

| Action | Effect |
|---|---|
| ArrowDown past the viewport | scrollOffset += 1 to keep selection visible |
| ArrowUp above the viewport | scrollOffset -= 1 |
| Home | selection = 0, scroll to top |
| End | selection = last, scroll so it's in the bottom row |

All movements clamp; out-of-range targets don't underflow or overflow. Verified by dedicated tests.

## Test plan

- [x] **24 ListViewSpec tests**:
  - State construction (\`empty\` / \`of\`), \`withItems\` re-clamping when the list shrinks, and reset to zeros for empty
  - Empty-list handleKey is a no-op for every key
  - ArrowUp/Down clamp at the endpoints
  - Home/End jump to endpoints
  - Enter/Space dispatch \`onSelect\` only when the list is non-empty
  - Scroll-down on selection overflow, scroll-up when selection retreats past the top, End places selection in the bottom viewport row
  - Focused render: inverse video on the selected row, non-selected rows use \`theme.foreground\`
  - Unfocused render: no \`▸\` marker, no inverse video, consistent two-cell prefix
  - Viewport shorter than the items → last visible item reflects the selected position
  - Viewport taller than the items → extra rows fill with blanks
  - Overflow items truncated to \`lineWidth - 2\`
  - \`ListView.width\` clamp to \`>= 3\`
  - Composes cleanly inside \`Layout.column\` — measure returns \`(lineWidth, visibleRows)\`
- [x] \`sbt ciCheck\` green — **344 tests total** (271 termflow + 73 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## Out of scope

- PageUp / PageDown (caller can compose via a \`Keymap\` today; can add to the widget later if useful)
- Multi-selection (v1 is single-selected)
- Custom row styling beyond \`render: A => String\` (would need a styled-render variant — follow-up if demand appears)