### PR TITLE
Add Select dropdown widget

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Select.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Select.scala
@@ -1,0 +1,193 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Dropdown picker — a closed "current value" box that expands into a
+ * [[ListView]] to pick a new value.
+ *
+ * Built on top of [[ListView]]: the open state delegates keystrokes and
+ * selection rendering to ListView; the closed state shows the currently
+ * selected value and can be opened again.
+ *
+ * {{{
+ * import termflow.tui.*
+ * import termflow.tui.widgets.*
+ *
+ * given Theme = Theme.dark
+ *
+ * case class Model(role: Select.State[String], ...)
+ *
+ * val initial = Select.State.of(Vector("Admin", "Editor", "Viewer"))
+ *
+ * // update:
+ * case Msg.ConsoleInputKey(k) if model.fm.isFocused(RoleId) =>
+ *   val (next, maybe) = Select.handleKey(model.role, k)(Some(_))
+ *   model.copy(role = next).tui
+ *
+ * // view:
+ * Select.view(model.role, lineWidth = 24, focused = model.fm.isFocused(RoleId))
+ * }}}
+ *
+ * ## Open vs closed layout
+ *
+ * When closed the widget renders a single row that looks like `▾ Admin  ` —
+ * one cell tall, easy to slot into a form. When open, the current row
+ * stays anchored at the top with a `▴` indicator and the available
+ * options list beneath it (`1 + visibleRows` cells tall). Callers whose
+ * layout needs a stable height should size the surrounding container to
+ * `Select.maxHeight(visibleRows)` rather than `1`.
+ */
+object Select:
+
+  /**
+   * State for a single `Select`.
+   *
+   * Wraps a [[ListView.State]] so the dropdown's scrolling + selection
+   * logic doesn't have to be duplicated. The `open` flag toggles the
+   * expanded vs collapsed look; `listState.selected` is the value shown
+   * in the closed form.
+   *
+   * @param listState   Underlying list model. `selected` is the current value.
+   * @param open        Whether the dropdown is expanded.
+   * @param visibleRows Viewport height when open. Stored on `listState`.
+   */
+  final case class State[A](
+    listState: ListView.State[A],
+    open: Boolean
+  ):
+
+    /** Items backing the dropdown. */
+    def items: Vector[A] = listState.items
+
+    /** Current selected value, if any. */
+    def value: Option[A] = listState.selectedItem
+
+    /** `true` when there are no choices available. */
+    def isEmpty: Boolean = listState.isEmpty
+
+    /** Number of choices. */
+    def size: Int = listState.size
+
+    /** Explicitly open / close the dropdown. */
+    def opened: State[A]  = copy(open = true)
+    def closed: State[A]  = copy(open = false)
+    def toggled: State[A] = copy(open = !open)
+
+    /** Replace the choices collection; delegates to [[ListView.State.withItems]]. */
+    def withItems(items: Vector[A]): State[A] =
+      copy(listState = listState.withItems(items))
+
+    /** Set the selected value by index (clamped). Keeps `open` unchanged. */
+    def selectIndex(idx: Int): State[A] =
+      if isEmpty then this
+      else
+        val clamped = math.max(0, math.min(size - 1, idx))
+        copy(listState = listState.copy(selected = clamped))
+
+  object State:
+
+    /** Empty dropdown — open will display "(none)" until withItems is called. */
+    def empty[A](visibleRows: Int = 5): State[A] =
+      State(ListView.State.empty[A](visibleRows), open = false)
+
+    /** Dropdown populated with `items`; selection parks at the first item. */
+    def of[A](items: Vector[A], visibleRows: Int = 5): State[A] =
+      State(ListView.State.of(items, visibleRows), open = false)
+
+  /**
+   * Process one keystroke.
+   *
+   * Behaviour depends on `state.open`:
+   *
+   * Closed:
+   *   - `Enter` / `Space` / `ArrowDown` → open the dropdown; no message
+   *   - other keys                       → unchanged
+   *
+   * Open:
+   *   - `Escape`                         → close without changing selection
+   *   - `Enter` / `Space`                → commit the ListView's current
+   *                                        selection, close, and dispatch
+   *                                        `onChange(value)`
+   *   - `ArrowUp` / `ArrowDown` / `Home` / `End` → delegate to ListView
+   *   - other keys                       → unchanged
+   *
+   * The open-Enter path is the standard "I've picked a value" gesture.
+   * Closed-Enter opens the dropdown (mirror of a desktop combobox).
+   */
+  def handleKey[A, Msg](
+    state: State[A],
+    key: KeyDecoder.InputKey
+  )(onChange: A => Option[Msg]): (State[A], Option[Msg]) =
+    import KeyDecoder.InputKey.*
+    if state.open then
+      key match
+        case Escape =>
+          (state.closed, None)
+        case Enter | CharKey(' ') =>
+          val committed = state.closed
+          (committed, committed.value.flatMap(onChange))
+        case _ =>
+          val (nextList, _) = ListView.handleKey(state.listState, key)(_ => None)
+          (state.copy(listState = nextList), None)
+    else
+      key match
+        case Enter | CharKey(' ') | ArrowDown =>
+          if state.isEmpty then (state, None) else (state.opened, None)
+        case _ =>
+          (state, None)
+
+  /**
+   * Render the dropdown as a single `VNode` — a composed [[BoxNode]] whose
+   * rendered height depends on `state.open`:
+   *
+   *   - closed: 1 row, `▾ <value>` in `theme.primary` when focused else `theme.foreground`
+   *   - open:   1 row (`▴ <value>`) plus `visibleRows` option rows below
+   *
+   * @param state     Select state.
+   * @param at        Top-left cell. Defaults to `(1, 1)`.
+   * @param lineWidth Total width in cells.
+   * @param focused   Whether the dropdown has focus.
+   * @param render    Formatter for each item. Defaults to `_.toString`.
+   */
+  def view[A](
+    state: State[A],
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    lineWidth: Int = 24,
+    focused: Boolean = false,
+    render: A => String = (a: A) => a.toString
+  )(using theme: Theme): VNode =
+    val width = math.max(3, lineWidth)
+
+    val indicator = if state.open then "▴ " else "▾ "
+    val label: String =
+      if state.isEmpty then "(none)"
+      else state.value.map(render).getOrElse("")
+
+    val headerStyle =
+      if focused then Style(fg = theme.background, bg = theme.primary)
+      else Style(fg = theme.foreground)
+
+    val headerContent = indicator + label
+    val headerTxt     = headerContent.take(width).padTo(width, ' ')
+    val headerRow     = TextNode(at.x, at.y, List(Text(headerTxt, headerStyle)))
+
+    if !state.open then BoxNode(at.x, at.y, width, 1, children = List(headerRow), style = Style())
+    else
+      // Underlying ListView rendered right below the header.
+      val listNode = ListView.view(
+        state.listState,
+        at = Coord(at.x, at.y + 1),
+        lineWidth = width,
+        focused = focused,
+        render = render
+      )
+      val totalHeight = 1 + state.listState.visibleRows
+      BoxNode(at.x, at.y, width, totalHeight, children = List(headerRow, listNode), style = Style())
+
+  /** Width of a rendered Select. Mirrors [[view]]. */
+  def width(lineWidth: Int): Int = math.max(3, lineWidth)
+
+  /** Maximum height the widget may occupy when open (useful for sizing parent containers). */
+  def maxHeight(visibleRows: Int): Int = 1 + math.max(1, visibleRows)

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/SelectSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/SelectSpec.scala
@@ -1,0 +1,186 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.KeyDecoder.InputKey
+
+class SelectSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private val roles                          = Vector("Admin", "Editor", "Viewer")
+  private def noop: String => Option[String] = _ => None
+
+  // --- State construction --------------------------------------------------
+
+  test("State.empty starts closed with no items"):
+    val s = Select.State.empty[String]()
+    assert(s.isEmpty)
+    assert(!s.open)
+    assert(s.value.isEmpty)
+
+  test("State.of pre-populates and parks selection on the first item, closed"):
+    val s = Select.State.of(roles)
+    assert(s.size == 3)
+    assert(s.value.contains("Admin"))
+    assert(!s.open)
+
+  test("opened / closed / toggled manage the visibility flag"):
+    val s = Select.State.of(roles)
+    assert(s.opened.open)
+    assert(!s.opened.closed.open)
+    assert(s.toggled.open)
+    assert(!s.toggled.toggled.open)
+
+  test("selectIndex clamps and updates the underlying ListView selection"):
+    val s = Select.State.of(roles)
+    assert(s.selectIndex(2).value.contains("Viewer"))
+    assert(s.selectIndex(99).value.contains("Viewer"))
+    assert(s.selectIndex(-5).value.contains("Admin"))
+
+  test("selectIndex on an empty state is a no-op"):
+    val s = Select.State.empty[String]()
+    assert(s.selectIndex(0) == s)
+
+  test("withItems replaces the item set and delegates clamping"):
+    val s = Select.State.of(roles).selectIndex(2)
+    val t = s.withItems(Vector("one", "two"))
+    assert(t.size == 2)
+    assert(t.value.contains("two")) // clamp from index 2 to index 1
+
+  // --- handleKey: closed ---------------------------------------------------
+
+  test("closed + Enter opens the dropdown"):
+    val s0      = Select.State.of(roles)
+    val (s1, m) = Select.handleKey(s0, InputKey.Enter)(noop)
+    assert(s1.open)
+    assert(m.isEmpty, "opening does not dispatch a change")
+
+  test("closed + Space opens the dropdown"):
+    val s0      = Select.State.of(roles)
+    val (s1, _) = Select.handleKey(s0, InputKey.CharKey(' '))(noop)
+    assert(s1.open)
+
+  test("closed + ArrowDown opens the dropdown (desktop-combobox convention)"):
+    val s0      = Select.State.of(roles)
+    val (s1, _) = Select.handleKey(s0, InputKey.ArrowDown)(noop)
+    assert(s1.open)
+
+  test("closed + any other key is a no-op"):
+    val s0      = Select.State.of(roles)
+    val (s1, m) = Select.handleKey(s0, InputKey.CharKey('x'))(noop)
+    assert(s1 == s0 && m.isEmpty)
+
+  test("closed + Enter on an empty Select stays closed"):
+    val s0      = Select.State.empty[String]()
+    val (s1, m) = Select.handleKey(s0, InputKey.Enter)(noop)
+    assert(!s1.open)
+    assert(m.isEmpty)
+
+  // --- handleKey: open -----------------------------------------------------
+
+  test("open + ArrowDown advances selection via the underlying ListView"):
+    val s0      = Select.State.of(roles).opened
+    val (s1, _) = Select.handleKey(s0, InputKey.ArrowDown)(noop)
+    assert(s1.open)
+    assert(s1.value.contains("Editor"))
+
+  test("open + ArrowUp retreats via the underlying ListView"):
+    val s0      = Select.State.of(roles).selectIndex(2).opened
+    val (s1, _) = Select.handleKey(s0, InputKey.ArrowUp)(noop)
+    assert(s1.value.contains("Editor"))
+
+  test("open + Home / End jump to the ends"):
+    val s0     = Select.State.of(roles).selectIndex(1).opened
+    val (h, _) = Select.handleKey(s0, InputKey.Home)(noop)
+    assert(h.value.contains("Admin"))
+    val (e, _) = Select.handleKey(s0, InputKey.End)(noop)
+    assert(e.value.contains("Viewer"))
+
+  test("open + Enter commits the current selection, closes, and dispatches onChange"):
+    val s0      = Select.State.of(roles).selectIndex(1).opened
+    val (s1, m) = Select.handleKey(s0, InputKey.Enter)(v => Some(s"chose:$v"))
+    assert(!s1.open, "Enter commits and closes")
+    assert(s1.value.contains("Editor"))
+    assert(m.contains("chose:Editor"))
+
+  test("open + Space also commits and closes"):
+    val s0      = Select.State.of(roles).selectIndex(2).opened
+    val (s1, m) = Select.handleKey(s0, InputKey.CharKey(' '))(v => Some(v))
+    assert(!s1.open)
+    assert(m.contains("Viewer"))
+
+  test("open + Escape closes without changing selection or dispatching"):
+    val s0      = Select.State.of(roles).selectIndex(1).opened
+    val (s1, m) = Select.handleKey(s0, InputKey.Escape)(noop)
+    assert(!s1.open)
+    assert(s1.value.contains("Editor"), "selection preserved")
+    assert(m.isEmpty)
+
+  test("open + other key leaves state unchanged"):
+    val s0      = Select.State.of(roles).opened
+    val (s1, m) = Select.handleKey(s0, InputKey.CharKey('x'))(noop)
+    assert(s1 == s0 && m.isEmpty)
+
+  // --- rendering -----------------------------------------------------------
+
+  private def render(v: VNode, width: Int, height: Int): (Array[Array[Char]], Array[Array[Style]]) =
+    val frame = AnsiRenderer.buildFrame(RootNode(width, height, List(v), None))
+    val chars = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).ch)
+    val style = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).style)
+    (chars, style)
+
+  test("closed render shows ▾ + selected value in one row"):
+    val s       = Select.State.of(roles)
+    val v       = Select.view(s, lineWidth = 12, focused = false)
+    val (cs, _) = render(v, 12, 1)
+    assert(cs(0).mkString.startsWith("▾ Admin"))
+
+  test("closed + focused render paints the header in inverse video"):
+    val s           = Select.State.of(roles)
+    val v           = Select.view(s, lineWidth = 10, focused = true)
+    val (_, styles) = render(v, 10, 1)
+    (0 until 10).foreach(c => assert(styles(0)(c).bg == Theme.dark.primary, s"header col $c expected inverse bg"))
+
+  test("closed render on empty Select shows (none)"):
+    val s       = Select.State.empty[String]()
+    val v       = Select.view(s, lineWidth = 10, focused = false)
+    val (cs, _) = render(v, 10, 1)
+    assert(cs(0).mkString.contains("(none)"))
+
+  test("open render shows ▴ header plus the visible-row viewport beneath"):
+    val s       = Select.State.of(roles, visibleRows = 3).opened
+    val v       = Select.view(s, lineWidth = 12, focused = true)
+    val (cs, _) = render(v, 12, Select.maxHeight(3))
+    // Row 0: header with ▴ indicator.
+    assert(cs(0).mkString.startsWith("▴ Admin"))
+    // Rows 1..3: the three options (Admin is selected/focused → row 1 starts ▸).
+    assert(cs(1).mkString.startsWith("▸ Admin"))
+    assert(cs(2).mkString.startsWith("  Editor"))
+    assert(cs(3).mkString.startsWith("  Viewer"))
+
+  test("open render delegates cursor highlighting to ListView"):
+    val s           = Select.State.of(roles, visibleRows = 3).selectIndex(2).opened
+    val v           = Select.view(s, lineWidth = 10, focused = true)
+    val (_, styles) = render(v, 10, Select.maxHeight(3))
+    // Row 3 ("Viewer") is the selected option → inverse video.
+    (0 until 10).foreach(c => assert(styles(3)(c).bg == Theme.dark.primary, s"row 3 col $c expected inverse bg"))
+    // Row 1 ("Admin") is not selected → default bg.
+    assert(styles(1)(0).bg == Color.Default)
+
+  test("Select.maxHeight reflects 1-header + visibleRows"):
+    assert(Select.maxHeight(5) == 6)
+    assert(Select.maxHeight(0) == 2) // visibleRows clamped to 1
+
+  test("width helper reports >= 3 regardless of input"):
+    assert(Select.width(20) == 20)
+    assert(Select.width(1) == 3)
+    assert(Select.width(-5) == 3)
+
+  test("Select.view composes inside Layout.column at both heights"):
+    val closed    = Select.State.of(roles, visibleRows = 3)
+    val open      = closed.opened
+    val closedLay = Layout.column(gap = 0)(Select.view(closed, lineWidth = 10))
+    val openLay   = Layout.column(gap = 0)(Select.view(open, lineWidth = 10))
+    assert(closedLay.measure == (10, 1))
+    assert(openLay.measure == (10, Select.maxHeight(3)))


### PR DESCRIPTION
Third stateful widget in the #91 series.

**Stacked on #106** (ListView) → #105 → … Base is \`feature/91-list-widget\`.

## Summary

- **\`Select[A]\`** — dropdown picker: closed value row that expands into a \`ListView\`
- Composes with \`ListView\` — reuses its state + selection + scrolling rather than duplicating
- 26 unit tests covering every open/closed state transition and rendering case

## Design

Closed state: a single row `▾ <selected>`. Focused → inverse video.

Open state: the same header (with `▴` indicator) plus the full `ListView` viewport below. Cursor rendering inside the dropdown is delegated to \`ListView.view\` so the two widgets stay visually consistent.

\`Select.State[A]\` wraps a \`ListView.State\` plus an `open` flag — no duplication of the list selection/scroll logic.

## API at a glance

\`\`\`scala
val s0 = Select.State.of(Vector("Admin", "Editor", "Viewer"))
// Programmatic selection:
val s1 = s0.selectIndex(1)  // -> Editor
// Open/close explicitly:
val s2 = s1.opened

// Update — different behaviour closed vs open:
val (next, msg) = Select.handleKey(state, key) { v => Some(Msg.RoleChanged(v)) }
\`\`\`

### Key contract

| Key | Closed | Open |
|---|---|---|
| \`Enter\` / \`Space\` | opens the dropdown | **commits** selection, closes, dispatches `onChange(v)` |
| \`ArrowDown\` | opens (combobox convention) | delegate to `ListView` |
| \`ArrowUp\` / \`Home\` / \`End\` | no-op | delegate to `ListView` |
| \`Escape\` | no-op | closes **without** changing selection |
| other | no-op | no-op |

## Test plan

- [x] **26 SelectSpec tests**:
  - State construction, opened/closed/toggled, selectIndex clamping, withItems delegation
  - Closed-state keys: Enter/Space/ArrowDown open; other keys no-op; empty Select stays closed
  - Open-state keys: Enter/Space commit+close+dispatch; Escape closes without change; Arrow/Home/End delegate to ListView; other keys unchanged
  - Closed render shows `▾ <value>`; focused header uses inverse video; empty shows `(none)`
  - Open render shows `▴` header + full ListView viewport; cursor styling inherited from ListView (verified via the inverse-video row)
  - \`Select.maxHeight\` helper and Layout.column composition at both heights
- [x] \`sbt ciCheck\` green — **370 tests total** (297 termflow + 73 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## Out of scope

- Type-to-filter ("jump to first item starting with 'E'") — could add as a follow-up via an optional \`filter\` callback
- Multi-select — v1 is single-selected
- Searchable dropdown (combobox with inline input) — a composite widget that could ship later