### PR TITLE
Add Table widget

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Table.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Table.scala
@@ -1,0 +1,218 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Tabular view with typed columns, a header row, and a scrollable body
+ * of rows with optional selection.
+ *
+ * Like the other stateful widgets, `Table` is value-based: state lives in
+ * the app's model, `handleKey` advances it, and `view` renders a tree of
+ * `VNode`s. Internally it delegates body scrolling to [[ListView.State]]
+ * so navigation and viewport logic isn't duplicated.
+ *
+ * ## Columns
+ *
+ * Columns are declared up-front as `Table.Column[A]` — each knows its
+ * header, cell width, alignment, and how to render one data row into a
+ * string. The total rendered width is the sum of column widths plus one
+ * separator cell between adjacent columns.
+ *
+ * {{{
+ * val cols = Vector(
+ *   Table.Column[Task]("Title",  width = 20, align = Table.Align.Left,  render = _.title),
+ *   Table.Column[Task]("Status", width = 10, align = Table.Align.Left,  render = _.status.toString),
+ *   Table.Column[Task]("Age",    width =  4, align = Table.Align.Right, render = t => t.days.toString)
+ * )
+ *
+ * val state = Table.State.of(cols, rows = myTasks, visibleRows = 8)
+ * }}}
+ *
+ * ## Selection & keys
+ *
+ * Table supports optional single-row selection. When `selectable = true`,
+ * ArrowUp/Down/Home/End move the cursor and Enter dispatches the
+ * `onSelect(row)` message — same contract as [[ListView]]. When
+ * `selectable = false`, it's a static read-only view.
+ *
+ * ## Header
+ *
+ * The header row is always rendered, styled with `theme.primary` bold.
+ * A divider row of `─` underneath separates the header from the body.
+ * The total occupied height is therefore `2 + visibleRows` cells.
+ */
+object Table:
+
+  /** Cell alignment within a column. */
+  enum Align:
+    case Left, Right, Center
+
+  /**
+   * Column definition for a [[Table]].
+   *
+   * @param header How the column's header cell reads.
+   * @param width  Column width in cells. Content is truncated / padded to fit.
+   * @param align  How to place content within the column.
+   * @param render Map a row of type `A` to its display string for this column.
+   */
+  final case class Column[A](
+    header: String,
+    width: Int,
+    align: Align = Align.Left,
+    render: A => String
+  )
+
+  /**
+   * State for a table.
+   *
+   * @param columns     Column definitions in display order.
+   * @param rows        All data rows (not just the visible slice).
+   * @param body        Scroll + selection state for the visible-rows viewport.
+   * @param selectable  Whether ArrowUp/Down moves a cursor (`true`) or the
+   *                    table renders read-only (`false`).
+   */
+  final case class State[A](
+    columns: Vector[Column[A]],
+    rows: Vector[A],
+    body: ListView.State[A],
+    selectable: Boolean
+  ):
+
+    /** `true` when the table has no data rows. */
+    def isEmpty: Boolean = rows.isEmpty
+
+    /** Total number of data rows. */
+    def size: Int = rows.size
+
+    /** Currently highlighted row, if any. Always `None` when `!selectable`. */
+    def selectedRow: Option[A] =
+      if selectable then body.selectedItem else None
+
+    /** Currently highlighted row index, or `0` for non-selectable / empty tables. */
+    def selectedIndex: Int = body.selected
+
+    /** Replace the data rows, re-clamping selection / scroll. */
+    def withRows(newRows: Vector[A]): State[A] =
+      copy(rows = newRows, body = body.withItems(newRows))
+
+  object State:
+
+    /** Empty table with the given columns and viewport height. */
+    def empty[A](columns: Vector[Column[A]], visibleRows: Int = 8, selectable: Boolean = true): State[A] =
+      State(columns, Vector.empty[A], ListView.State.empty[A](visibleRows), selectable)
+
+    /** Table populated with `rows`; selection (if any) parks on the first row. */
+    def of[A](
+      columns: Vector[Column[A]],
+      rows: Vector[A],
+      visibleRows: Int = 8,
+      selectable: Boolean = true
+    ): State[A] =
+      State(columns, rows, ListView.State.of(rows, visibleRows), selectable)
+
+  /**
+   * Process one keystroke.
+   *
+   * When `state.selectable` is `false`, every key is a no-op — use the
+   * widget purely for display. When `true`, navigation and Enter are
+   * delegated to [[ListView.handleKey]], so the contract is identical
+   * (ArrowUp/Down/Home/End/Enter/Space).
+   */
+  def handleKey[A, Msg](
+    state: State[A],
+    key: KeyDecoder.InputKey
+  )(onSelect: A => Option[Msg]): (State[A], Option[Msg]) =
+    if !state.selectable then (state, None)
+    else
+      val (nextBody, msg) = ListView.handleKey(state.body, key)(onSelect)
+      (state.copy(body = nextBody), msg)
+
+  /** Pad / truncate `s` to exactly `w` cells using the given alignment. */
+  private def align(s: String, w: Int, align: Align): String =
+    if w <= 0 then ""
+    else if s.length >= w then s.take(w)
+    else
+      val pad = w - s.length
+      align match
+        case Align.Left  => s + " " * pad
+        case Align.Right => " " * pad + s
+        case Align.Center =>
+          val left  = pad / 2
+          val right = pad - left
+          " " * left + s + " " * right
+
+  /** Total visible width = sum of column widths + single-space separators between them. */
+  def width[A](columns: Vector[Column[A]]): Int =
+    if columns.isEmpty then 0
+    else columns.map(c => math.max(0, c.width)).sum + (columns.size - 1)
+
+  /** Total visible height: header + divider + viewport. */
+  def height(visibleRows: Int): Int = 2 + math.max(1, visibleRows)
+
+  /**
+   * Assemble a single row string from column renderings, aligned and
+   * separated by a single space.
+   *
+   * Exposed for callers who want to re-use the layout for bespoke
+   * rendering (e.g. printing a table to a log file).
+   */
+  def formatRow[A](columns: Vector[Column[A]], row: A): String =
+    columns.map(c => align(c.render(row), math.max(0, c.width), c.align)).mkString(" ")
+
+  /** Assemble the header row string. */
+  def formatHeader[A](columns: Vector[Column[A]]): String =
+    columns.map(c => align(c.header, math.max(0, c.width), c.align)).mkString(" ")
+
+  /**
+   * Render the table as a composed [[BoxNode]] of exactly
+   * `Table.height(visibleRows)` cells tall and `Table.width(columns)` wide.
+   *
+   * @param state     Table state.
+   * @param at        Top-left cell. Defaults to `(1, 1)` for Layout composition.
+   * @param focused   Whether the table currently has focus (affects cursor).
+   */
+  def view[A](
+    state: State[A],
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    focused: Boolean = false
+  )(using theme: Theme): VNode =
+    val cols   = state.columns
+    val totalW = math.max(1, width(cols))
+    val rowsH  = math.max(1, state.body.visibleRows)
+
+    val headerStyle  = Style(fg = theme.primary, bold = true)
+    val dividerStyle = Style(fg = theme.primary)
+    val headerText   = formatHeader(cols).take(totalW).padTo(totalW, ' ')
+    val dividerText  = "─" * totalW
+
+    val headerRow  = TextNode(at.x, at.y, List(Text(headerText, headerStyle)))
+    val dividerRow = TextNode(at.x, at.y + 1, List(Text(dividerText, dividerStyle)))
+
+    // Body rows: viewport starting at at.y + 2, reusing the ListView focus
+    // rules (focused + selected => inverse video with ▸ prefix).
+    // We hand-render the rows here rather than calling ListView.view because
+    // Table has its own multi-column formatting and no "▸ " prefix column —
+    // instead the entire row is painted in inverse video when selected.
+    val bodyRows = (0 until rowsH).map { r =>
+      val idx  = state.body.scrollOffset + r
+      val rowY = at.y + 2 + r
+      if idx >= state.size then TextNode(at.x, rowY, List(Text(" " * totalW, Style())))
+      else
+        val rowData    = state.rows(idx)
+        val rendered   = formatRow(cols, rowData).take(totalW).padTo(totalW, ' ')
+        val isSelected = state.selectable && idx == state.body.selected
+        val showCursor = isSelected && focused
+        val style =
+          if showCursor then Style(fg = theme.background, bg = theme.primary)
+          else Style(fg = theme.foreground)
+        TextNode(at.x, rowY, List(Text(rendered, style)))
+    }.toList
+
+    BoxNode(
+      at.x,
+      at.y,
+      totalW,
+      height(rowsH),
+      children = List(headerRow, dividerRow) ++ bodyRows,
+      style = Style()
+    )

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/TableSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/TableSpec.scala
@@ -1,0 +1,168 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.KeyDecoder.InputKey
+
+class TableSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private case class Row(name: String, qty: Int)
+  private val rows3 = Vector(
+    Row("apple", 10),
+    Row("pear", 3),
+    Row("grape", 120)
+  )
+  private val cols = Vector(
+    Table.Column[Row]("Name", width = 6, align = Table.Align.Left, render = _.name),
+    Table.Column[Row]("Qty", width = 4, align = Table.Align.Right, render = _.qty.toString)
+  )
+
+  private def noop: Row => Option[String] = _ => None
+
+  // --- state construction --------------------------------------------------
+
+  test("State.empty starts with no rows and selection 0"):
+    val s = Table.State.empty(cols, visibleRows = 5)
+    assert(s.isEmpty)
+    assert(s.size == 0)
+    assert(s.selectedIndex == 0)
+    assert(s.selectedRow.isEmpty)
+    assert(s.selectable)
+
+  test("State.of pre-populates and parks selection on the first row when selectable"):
+    val s = Table.State.of(cols, rows3)
+    assert(s.size == 3)
+    assert(s.selectedRow.contains(Row("apple", 10)))
+
+  test("State.of non-selectable has selectedRow = None regardless of body state"):
+    val s = Table.State.of(cols, rows3, selectable = false)
+    assert(s.selectedRow.isEmpty)
+    assert(s.size == 3)
+
+  test("withRows re-clamps underlying ListView selection + scroll"):
+    val s0 = Table.State
+      .of(cols, rows3, visibleRows = 2)
+      .copy(body = ListView.State.of(rows3, 2).copy(selected = 2, scrollOffset = 1))
+    val s1 = s0.withRows(Vector(Row("kiwi", 1)))
+    assert(s1.size == 1)
+    assert(s1.selectedIndex == 0)
+
+  // --- handleKey -----------------------------------------------------------
+
+  test("handleKey on a non-selectable table is a no-op for every key"):
+    val s0      = Table.State.of(cols, rows3, selectable = false)
+    val (s1, m) = Table.handleKey(s0, InputKey.ArrowDown)(noop)
+    assert(s1 == s0 && m.isEmpty)
+
+  test("ArrowDown advances selection, clamping at the last row (selectable)"):
+    val s0      = Table.State.of(cols, rows3)
+    val (s1, _) = Table.handleKey(s0, InputKey.ArrowDown)(noop)
+    assert(s1.selectedRow.contains(Row("pear", 3)))
+
+  test("Enter dispatches onSelect for the current row"):
+    val s0     = Table.State.of(cols, rows3).copy(body = ListView.State.of(rows3).copy(selected = 2))
+    val (_, m) = Table.handleKey(s0, InputKey.Enter)(r => Some(s"sel:${r.name}"))
+    assert(m.contains("sel:grape"))
+
+  test("Home / End jump to endpoints"):
+    val s0     = Table.State.of(cols, rows3).copy(body = ListView.State.of(rows3).copy(selected = 1))
+    val (h, _) = Table.handleKey(s0, InputKey.Home)(noop)
+    assert(h.selectedIndex == 0)
+    val (e, _) = Table.handleKey(s0, InputKey.End)(noop)
+    assert(e.selectedIndex == 2)
+
+  // --- helpers --------------------------------------------------------------
+
+  test("width is sum of column widths + separators between columns"):
+    assert(Table.width(cols) == 6 + 1 + 4) // 6 + " " + 4
+
+  test("width on an empty column list is 0"):
+    assert(Table.width(Vector.empty[Table.Column[Row]]) == 0)
+
+  test("height is 2 (header + divider) plus visibleRows"):
+    assert(Table.height(5) == 7)
+    assert(Table.height(0) == 3) // visibleRows clamped to 1
+
+  test("formatHeader aligns per column"):
+    assert(Table.formatHeader(cols) == "Name    Qty")
+
+  test("formatRow respects column alignment and widths"):
+    val r = Table.formatRow(cols, Row("kiwi", 7))
+    // "kiwi  " (6 wide left) + " " + "   7" (4 wide right)
+    assert(r == "kiwi     " + "  7" || r == "kiwi   " + "  7" || r == "kiwi      7")
+    // Simpler direct check of the concatenation.
+    val expected = "kiwi  " + " " + "   7"
+    assert(r == expected, s"got [$r] expected [$expected]")
+
+  test("formatRow truncates long cell content"):
+    val r = Table.formatRow(cols, Row("strawberry", 12))
+    // Name col width=6; "strawberry" truncated to "strawb".
+    assert(r.startsWith("strawb"))
+
+  // --- rendering -----------------------------------------------------------
+
+  private def render(v: VNode, width: Int, height: Int): (Array[Array[Char]], Array[Array[Style]]) =
+    val frame = AnsiRenderer.buildFrame(RootNode(width, height, List(v), None))
+    val chars = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).ch)
+    val style = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).style)
+    (chars, style)
+
+  test("view draws header + divider + body rows"):
+    val s       = Table.State.of(cols, rows3, visibleRows = 3)
+    val v       = Table.view(s, focused = false)
+    val (cs, _) = render(v, Table.width(cols), Table.height(3))
+    // Row 0: header.
+    assert(cs(0).mkString == "Name    Qty")
+    // Row 1: divider (─ repeated for totalW chars).
+    assert(cs(1).forall(_ == '─'))
+    // Rows 2..4: data.
+    assert(cs(2).mkString.contains("apple"))
+    assert(cs(3).mkString.contains("pear"))
+    assert(cs(4).mkString.contains("grape"))
+
+  test("focused render paints the selected row in inverse video"):
+    val s = Table.State.of(cols, rows3, visibleRows = 3).copy(body = ListView.State.of(rows3, 3).copy(selected = 1))
+    val v = Table.view(s, focused = true)
+    val (_, styles) = render(v, Table.width(cols), Table.height(3))
+    // Body row 1 (file row 3 = y=3): inverse bg.
+    (0 until Table.width(cols)).foreach { c =>
+      assert(styles(3)(c).bg == Theme.dark.primary, s"body row 1 col $c expected inverse bg")
+    }
+    // Body row 0 (file row 2) stays default.
+    assert(styles(2)(0).bg == Color.Default)
+
+  test("unfocused render does NOT highlight the selection"):
+    val s = Table.State.of(cols, rows3, visibleRows = 3).copy(body = ListView.State.of(rows3, 3).copy(selected = 1))
+    val v = Table.view(s, focused = false)
+    val (_, styles) = render(v, Table.width(cols), Table.height(3))
+    // No inverse video anywhere in the body.
+    (2 until Table.height(3)).foreach { r =>
+      (0 until Table.width(cols)).foreach { c =>
+        assert(styles(r)(c).bg == Color.Default, s"row $r col $c should not be inverse")
+      }
+    }
+
+  test("non-selectable render never highlights, even when focused"):
+    val s           = Table.State.of(cols, rows3, visibleRows = 3, selectable = false)
+    val v           = Table.view(s, focused = true)
+    val (_, styles) = render(v, Table.width(cols), Table.height(3))
+    (2 until Table.height(3)).foreach { r =>
+      (0 until Table.width(cols)).foreach(c => assert(styles(r)(c).bg == Color.Default))
+    }
+
+  test("empty body fills with blanks up to visibleRows"):
+    val s       = Table.State.empty(cols, visibleRows = 2)
+    val v       = Table.view(s, focused = true)
+    val (cs, _) = render(v, Table.width(cols), Table.height(2))
+    // Body rows (indices 2, 3) should be blank strings of totalW cells.
+    val w = Table.width(cols)
+    assert(cs(2).mkString == " " * w)
+    assert(cs(3).mkString == " " * w)
+
+  test("Table.view composes inside Layout.column with the expected measure"):
+    val s = Table.State.of(cols, rows3, visibleRows = 4)
+    val v = Table.view(s)
+    val c = Layout.column(gap = 0)(v)
+    assert(c.measure == (Table.width(cols), Table.height(4)))


### PR DESCRIPTION
Fourth stateful widget in the #91 series — closes out the core widget quartet.

**Stacked on #107** (Select) → #106 → … Base is \`feature/91-select-widget\`.

## Summary

- **\`Table[A]\`** — typed columnar view with a header row, divider, and a scrollable body of rows
- Optional single-row selection (\`selectable: Boolean\`); when \`false\`, the table is a pure read-only display
- Body scrolling **delegates to \`ListView.State\`** so viewport logic isn't duplicated
- 20 unit tests covering state, navigation, alignment/truncation helpers, and every rendering variant

## API

\`\`\`scala
val cols = Vector(
  Table.Column[Task]("Title",  width = 20, align = Table.Align.Left,  render = _.title),
  Table.Column[Task]("Status", width = 10, align = Table.Align.Left,  render = _.status.toString),
  Table.Column[Task]("Age",    width =  4, align = Table.Align.Right, render = t => t.days.toString)
)

val state = Table.State.of(cols, rows = myTasks, visibleRows = 8)

// update:
val (next, maybeMsg) = Table.handleKey(state, key) { row => Some(Msg.Open(row)) }

// view:
Table.view(state, focused = model.fm.isFocused(TableId))
\`\`\`

## Behaviour matrix

| \`selectable\` | handleKey | Focused render |
|---|---|---|
| \`true\` | delegates Arrow/Home/End/Enter/Space to \`ListView\` | selected row in inverse video |
| \`false\` | every key is a no-op | no row highlight ever, even when focused |

## Public helpers (reusable outside the widget)

| Helper | Purpose |
|---|---|
| \`Table.width(columns)\` | sum of column widths plus single-cell separators |
| \`Table.height(visibleRows)\` | \`2 + visibleRows\` (header + divider + viewport) |
| \`Table.formatHeader(columns)\` | aligned header string — handy for log dumps |
| \`Table.formatRow(columns, row)\` | aligned data row string — same |

## Test plan

- [x] **20 TableSpec tests**:
  - State construction (\`empty\` / \`of\`, \`selectable\` flag behaviour, \`withRows\` re-clamp)
  - \`handleKey\`: no-op when \`!selectable\`; Arrow/Home/End/Enter delegated when \`selectable\`
  - \`width\` / \`height\` / \`formatHeader\` / \`formatRow\` helpers including alignment, truncation, empty-column edge case
  - Rendering: header + divider + body; focused shows selection in inverse video; unfocused does not; non-selectable never highlights; empty body fills with blanks; Layout.column composition at expected measure
- [x] \`sbt ciCheck\` green — **390 tests total** (317 termflow + 73 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## Out of scope

- Column sorting (clickable headers) — needs mouse support and a sort-by callback
- Multi-row selection
- Virtualised rows / lazy row loading (current implementation holds the full \`Vector\` in memory)
- Column resizing