### PR TITLE
Add CatalogDemoApp: task manager showcasing List/Select/Table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,6 +133,7 @@ addCommandAlias(
 addCommandAlias("hubDemo",      "termflowSample/runMain termflow.run.SampleHubMain")
 addCommandAlias("widgetsDemo",  "termflowSample/runMain termflow.apps.widgets.WidgetsDemoApp")
 addCommandAlias("formDemo",     "termflowSample/runMain termflow.apps.forms.FormDemoApp")
+addCommandAlias("catalogDemo",  "termflowSample/runMain termflow.apps.catalog.CatalogDemoApp")
 addCommandAlias("echoDemo",     "termflowSample/runMain termflow.apps.echo.EchoApp")
 addCommandAlias("counterDemo",  "termflowSample/runMain termflow.apps.counter.SyncCounter")
 addCommandAlias("futureDemo",   "termflowSample/runMain termflow.apps.counter.FutureCounter")

--- a/docs/RUN_EXAMPLES.md
+++ b/docs/RUN_EXAMPLES.md
@@ -16,6 +16,7 @@ Working `sbt` commands for launching the sample apps in `modules/termflow-sample
 ```bash
 sbt widgetsDemo       # Layout + Theme + Button/ProgressBar/Spinner/StatusBar
 sbt formDemo          # TextField + FocusManager + Keymap multi-field form
+sbt catalogDemo       # ListView + Select + Table + TextField task catalog
 sbt hubDemo           # Sample hub dashboard (launches other demos)
 sbt echoDemo          # Echo / chat-style scrollback
 sbt counterDemo       # Sync counter (Layout-based)
@@ -57,6 +58,7 @@ sbt "termflowSample/runMain termflow.apps.chat.ProviderChatRenderReproMain"
 |---|---|---|
 | `widgetsDemo` | `WidgetsDemoApp` | The full new stack: `Layout.column`/`row`, a `given Theme` with toggleable dark/light, `Button` focus, `Spinner` + `ProgressBar` driven by `Sub.Every`, `StatusBar` at the bottom, `FocusManager` + `Keymap` for input dispatch |
 | `formDemo` | `FormDemoApp` | Multi-field form using three `TextField`s plus Submit / Reset buttons; demonstrates Tab focus cycling and Enter routing across input + button elements |
+| `catalogDemo` | `CatalogDemoApp` | Task manager combining `TextField` + `Select` dropdown + `ListView` (scrollable, selectable) + `Table` (live summary). Add tasks, remove them, switch priority — exercises every stateful widget at once. |
 | `hubDemo` | `SampleHubApp` | Menu launcher; pick a sub-app by name or number |
 | `counterDemo` | `SyncCounter` | Minimal Elm-style app; the simplest example to read |
 | `futureDemo` | `FutureCounter` | `Cmd.FCmd` for async work, with a spinner while pending |
@@ -94,6 +96,22 @@ The form demo (`sbt formDemo`) is interactive:
 | `Ctrl+T` (anywhere) / `t` (on a button) | toggle dark / light theme |
 | `q` (on a button) / `Ctrl+C` / `Esc` | quit |
 
+## Catalog demo keys
+
+The catalog demo (`sbt catalogDemo`) is interactive:
+
+| Key | Action |
+|---|---|
+| `Tab` / `Shift+Tab` | cycle focus (Task field → Priority → Add → Clear → Task list) |
+| `Enter` (in Task field) | add a task with the selected priority |
+| `Enter` / `Space` (on Priority) | open the dropdown (or, when open, commit the selection and close) |
+| `↑` / `↓` (in open Priority or Task list) | navigate items **within** that widget |
+| `Enter` (on a list row) | remove the selected task |
+| `Enter` / `Space` (on a button) | activate Add / Clear |
+| `←` / `→` (on a button) | previous / next focus |
+| `Ctrl+T` (anywhere) / `t` (on a button) | toggle dark / light theme |
+| `q` (on a button) / `Ctrl+C` / `Esc` | quit |
+
 ## Convenience shell snippet (optional)
 
 If you'd rather have shell-level shortcuts, drop this in `~/.zshrc` /
@@ -103,10 +121,10 @@ If you'd rather have shell-level shortcuts, drop this in `~/.zshrc` /
 termflow-run() {
   local app="$1"
   case "$app" in
-    hub|widgets|form|echo|counter|future|clock|tabs|task|stress|sine|input)
+    hub|widgets|form|catalog|echo|counter|future|clock|tabs|task|stress|sine|input)
       sbt "${app}Demo" ;;
     *)
-      echo "Usage: termflow-run {hub|widgets|form|echo|counter|future|clock|tabs|task|stress|sine|input}"
+      echo "Usage: termflow-run {hub|widgets|form|catalog|echo|counter|future|clock|tabs|task|stress|sine|input}"
       return 1
       ;;
   esac

--- a/modules/termflow-sample/src/main/scala/termflow/apps/catalog/CatalogDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/catalog/CatalogDemoApp.scala
@@ -1,0 +1,346 @@
+package termflow.apps.catalog
+
+import termflow.tui.*
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+import termflow.tui.widgets.*
+
+/**
+ * Showcase for the stateful widgets: [[TextField]] + [[Select]] +
+ * [[ListView]] + [[Table]] composed into a tiny task manager.
+ *
+ * Flow:
+ *   1. Type a new task in the text field
+ *   2. Pick its priority from the dropdown
+ *   3. Press `Add` (or hit Enter in the field) to push it onto the list
+ *   4. Navigate the list with arrow keys; Enter removes the selected task
+ *   5. The summary table on the right updates live as tasks are added /
+ *      removed
+ *
+ * ## Keys
+ *
+ *   - `Tab` / `Shift+Tab`                cycle focus forward / backward
+ *   - `Enter` (in the task field)        add the task with the selected priority
+ *   - `Enter` / `Space` (on a button)    activate Add / Clear
+ *   - `Enter` / `Space` (on the Select)  open/commit the dropdown
+ *   - `Enter` / `Space` (on a list row)  remove the selected task
+ *   - `↑` / `↓` (in List / open Select)  navigate the items
+ *   - `↑` / `↓` (elsewhere)              same as Shift+Tab / Tab
+ *   - `←` / `→` (on a button)            previous / next focus
+ *   - `Ctrl+T`                           toggle dark / light theme
+ *   - `Ctrl+C` / `Esc` / `q` (on a button) quit
+ *
+ * Run with:
+ * {{{
+ *   sbt catalogDemo
+ *   // or:
+ *   sbt "termflowSample/runMain termflow.apps.catalog.CatalogDemoApp"
+ * }}}
+ */
+object CatalogDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  /** Priority level for a task. */
+  enum Priority:
+    case High, Medium, Low
+    override def toString: String = this match
+      case High   => "high"
+      case Medium => "medium"
+      case Low    => "low"
+
+  /** One task in the catalog. */
+  final case class Task(title: String, priority: Priority)
+
+  // Focus identifiers.
+  val TaskFieldId: FocusId = FocusId("task-field")
+  val PriorityId: FocusId  = FocusId("priority")
+  val AddId: FocusId       = FocusId("add")
+  val ClearId: FocusId     = FocusId("clear")
+  val ListId: FocusId      = FocusId("list")
+
+  val FocusOrder: Vector[FocusId] = Vector(TaskFieldId, PriorityId, AddId, ClearId, ListId)
+
+  private val Priorities = Vector(Priority.High, Priority.Medium, Priority.Low)
+
+  /** Demo seeds — gives the user something to see on first load. */
+  private val SeedTasks = Vector(
+    Task("buy groceries", Priority.Medium),
+    Task("write report", Priority.High),
+    Task("review PR", Priority.Low),
+    Task("call alice", Priority.High)
+  )
+
+  enum Msg:
+    case NextFocus
+    case PrevFocus
+    case ToggleTheme
+    case AddTask
+    case ClearAll
+    case RemoveSelected
+    case ConsoleInputKey(key: KeyDecoder.InputKey)
+    case ConsoleInputError(error: Throwable)
+    case Quit
+
+  final case class Model(
+    terminalWidth: Int,
+    terminalHeight: Int,
+    newTask: TextField.State,
+    priority: Select.State[Priority],
+    tasks: ListView.State[Task],
+    fm: FocusManager,
+    darkTheme: Boolean
+  )
+
+  import Msg.*
+
+  /**
+   * True globals — safe everywhere, never consumed by a widget.
+   * Note: vertical arrows are deliberately NOT in Globals — the list and
+   * the open Select consume them for internal navigation.
+   */
+  val Globals: Keymap[Msg] =
+    Keymap(
+      KeyDecoder.InputKey.Ctrl('C') -> Quit,
+      KeyDecoder.InputKey.Escape    -> Quit,
+      KeyDecoder.InputKey.Ctrl('T') -> ToggleTheme
+    ) ++
+      Keymap.focus(next = NextFocus, previous = PrevFocus)
+
+  /** Letter shortcuts that only fire when focus isn't in the text field. */
+  val NonTextShortcuts: Keymap[Msg] =
+    Keymap(
+      KeyDecoder.InputKey.CharKey('t') -> ToggleTheme,
+      KeyDecoder.InputKey.CharKey('T') -> ToggleTheme,
+      KeyDecoder.InputKey.CharKey('q') -> Quit,
+      KeyDecoder.InputKey.CharKey('Q') -> Quit
+    ) ++ Keymap.focusHorizontal(previous = PrevFocus, next = NextFocus)
+
+  /** Arrow-key focus nav used by TextField + buttons (but NOT by List/open Select). */
+  private val ArrowFocusNav: Keymap[Msg] =
+    Keymap.focusVertical(previous = PrevFocus, next = NextFocus)
+
+  /** Column definitions for the summary table. Rendered right of the list. */
+  private val SummaryColumns: Vector[Table.Column[(Priority, Int)]] =
+    Vector(
+      Table.Column[(Priority, Int)]("Priority", width = 8, align = Table.Align.Left, render = _._1.toString),
+      Table.Column[(Priority, Int)]("Count", width = 5, align = Table.Align.Right, render = _._2.toString)
+    )
+
+  /** Always shows all three priorities with live counts, even when zero. */
+  private def summaryRows(tasks: Vector[Task]): Vector[(Priority, Int)] =
+    Priorities.map(p => (p, tasks.count(_.priority == p)))
+
+  object App extends TuiApp[Model, Msg]:
+
+    private def syncTerminalSize(m: Model, ctx: RuntimeCtx[Msg]): Model =
+      val w = ctx.terminal.width
+      val h = ctx.terminal.height
+      if w == m.terminalWidth && h == m.terminalHeight then m
+      else m.copy(terminalWidth = w, terminalHeight = h)
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Sub.InputKey(ConsoleInputKey.apply, ConsoleInputError.apply, ctx)
+      Model(
+        terminalWidth = ctx.terminal.width,
+        terminalHeight = ctx.terminal.height,
+        newTask = TextField.State.withPlaceholder("new task description…"),
+        priority = Select.State.of(Priorities, visibleRows = 3).selectIndex(1),
+        tasks = ListView.State.of(SeedTasks, visibleRows = 6),
+        fm = FocusManager(FocusOrder),
+        darkTheme = true
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val sized = syncTerminalSize(m, ctx)
+      msg match
+        case NextFocus   => sized.copy(fm = sized.fm.next).tui
+        case PrevFocus   => sized.copy(fm = sized.fm.previous).tui
+        case ToggleTheme => sized.copy(darkTheme = !sized.darkTheme).tui
+        case Quit        => Tui(sized, Cmd.Exit)
+
+        case AddTask =>
+          val title = sized.newTask.buffer.trim
+          if title.isEmpty then sized.tui
+          else
+            val priority = sized.priority.value.getOrElse(Priority.Medium)
+            val task     = Task(title, priority)
+            sized
+              .copy(
+                tasks = sized.tasks.withItems(sized.tasks.items :+ task),
+                newTask = sized.newTask.cleared
+              )
+              .tui
+
+        case ClearAll =>
+          sized.copy(tasks = sized.tasks.withItems(Vector.empty)).tui
+
+        case RemoveSelected =>
+          sized.tasks.selectedItem match
+            case None => sized.tui
+            case Some(task) =>
+              val remaining = sized.tasks.items.filterNot(_ == task)
+              sized.copy(tasks = sized.tasks.withItems(remaining)).tui
+
+        case ConsoleInputKey(key) =>
+          Globals.lookup(key) match
+            case Some(next) => update(sized, next, ctx)
+            case None       => routeByFocus(sized, key, ctx)
+
+        case ConsoleInputError(_) => sized.tui
+
+    /**
+     * Dispatch a key to the focused element. Each element has bespoke
+     * routing because their handleKey contracts differ (TextField cares
+     * about printable chars; Select has an open/closed state; List
+     * consumes arrows internally).
+     */
+    private def routeByFocus(m: Model, key: KeyDecoder.InputKey, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      import KeyDecoder.InputKey.*
+      m.fm.current match
+        case Some(id) if id == TaskFieldId =>
+          // TextField doesn't consume ↑/↓ — treat them as focus nav.
+          ArrowFocusNav.lookup(key) match
+            case Some(follow) => update(m, follow, ctx)
+            case None =>
+              val (next, maybeMsg) = TextField.handleKeyOrSubmit(m.newTask, key)(AddTask)
+              val nm               = m.copy(newTask = next)
+              maybeMsg.fold(nm.tui)(follow => update(nm, follow, ctx))
+
+        case Some(id) if id == PriorityId =>
+          // Select consumes arrows / Enter itself. Delegate everything not
+          // already in Globals.
+          val (next, _) = Select.handleKey(m.priority, key)(_ => None)
+          m.copy(priority = next).tui
+
+        case Some(id) if id == AddId =>
+          key match
+            case Enter | CharKey(' ') =>
+              update(m, AddTask, ctx)
+            case _ =>
+              ArrowFocusNav
+                .lookup(key)
+                .orElse(NonTextShortcuts.lookup(key))
+                .fold(m.tui)(follow => update(m, follow, ctx))
+
+        case Some(id) if id == ClearId =>
+          key match
+            case Enter | CharKey(' ') =>
+              update(m, ClearAll, ctx)
+            case _ =>
+              ArrowFocusNav
+                .lookup(key)
+                .orElse(NonTextShortcuts.lookup(key))
+                .fold(m.tui)(follow => update(m, follow, ctx))
+
+        case Some(id) if id == ListId =>
+          // List consumes arrows / Home / End / Enter itself. Enter on a
+          // row fires onSelect -> RemoveSelected.
+          val (next, maybeMsg) = ListView.handleKey(m.tasks, key)(_ => Some(RemoveSelected))
+          val nm               = m.copy(tasks = next)
+          maybeMsg.fold(nm.tui)(follow => update(nm, follow, ctx))
+
+        case _ =>
+          NonTextShortcuts.lookup(key).fold(m.tui)(follow => update(m, follow, ctx))
+
+    override def view(m: Model): RootNode =
+      given Theme = if m.darkTheme then Theme.dark else Theme.light
+      val theme   = summon[Theme]
+
+      val termWidth  = math.max(80, m.terminalWidth)
+      val termHeight = math.max(24, m.terminalHeight)
+      val themeName  = if m.darkTheme then "dark" else "light"
+
+      val fieldWidth  = 30
+      val selectWidth = 14
+
+      // Row 1: title.
+      val title = Layout.Elem(
+        TextNode(
+          1.x,
+          1.y,
+          List(Text("Task Catalog", Style(fg = theme.primary, bold = true, underline = true)))
+        )
+      )
+
+      // Row 3: labels for the input row — widths + gap match `inputRow`
+      // so "New:" sits above the text field and "Priority:" above the
+      // Select dropdown.
+      val labelRow = Layout.row(gap = 4)(
+        TextNode(1.x, 1.y, List(Text("New:".padTo(fieldWidth, ' '), Style(fg = theme.foreground)))),
+        TextNode(1.x, 1.y, List(Text("Priority:", Style(fg = theme.foreground))))
+      )
+
+      // Row 4: text field + Select (dropdown may expand when open).
+      val inputRow = Layout.row(gap = 4)(
+        TextField.view(m.newTask, lineWidth = fieldWidth, focused = m.fm.isFocused(TaskFieldId)),
+        Select.view(m.priority, lineWidth = selectWidth, focused = m.fm.isFocused(PriorityId), render = _.toString)
+      )
+
+      // Row: Add / Clear buttons.
+      val buttons = Layout.row(gap = 2)(
+        Button("Add", focused = m.fm.isFocused(AddId)),
+        Button("Clear all", focused = m.fm.isFocused(ClearId))
+      )
+
+      // Section header for the tasks list.
+      val tasksHeader = Layout.Elem(
+        TextNode(
+          1.x,
+          1.y,
+          List(
+            Text(s"Tasks (${m.tasks.size})", Style(fg = theme.primary, bold = true, underline = true))
+          )
+        )
+      )
+
+      // Tasks list + summary table side-by-side.
+      val listAndTable = Layout.row(gap = 4)(
+        ListView.view(
+          m.tasks,
+          lineWidth = 40,
+          focused = m.fm.isFocused(ListId),
+          render = (t: Task) => s"[${t.priority}] ${t.title}"
+        ),
+        Table.view(
+          Table.State.of(SummaryColumns, summaryRows(m.tasks.items), visibleRows = 3, selectable = false),
+          focused = false
+        )
+      )
+
+      // Compose into a single column. When the Select is open the column
+      // grows, pushing later rows down — the Layout DSL handles that.
+      val column = Layout.Column(
+        gap = 1,
+        children = List(
+          title,
+          Layout.Spacer(1, 1),
+          labelRow,
+          inputRow,
+          Layout.Spacer(1, 1),
+          buttons,
+          Layout.Spacer(1, 1),
+          tasksHeader,
+          listAndTable
+        )
+      )
+
+      val helpBar = StatusBar(
+        left = " catalog ",
+        center = "Tab/↑↓ nav  Enter add/select  Ctrl+T theme  Ctrl+C quit",
+        right = s" theme=$themeName ",
+        width = termWidth,
+        at = Coord(1.x, termHeight.y)
+      )
+
+      RootNode(
+        width = termWidth,
+        height = termHeight,
+        children = column.resolve(Coord(2.x, 2.y)) :+ helpBar,
+        input = None
+      )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      Left(TermFlowError.CommandError(input.value))

--- a/modules/termflow-sample/src/main/scala/termflow/run/SampleSmoke.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/run/SampleSmoke.scala
@@ -44,4 +44,5 @@ object SampleSmoke:
     smokeApp("input-line", termflow.apps.input.InputLineReproApp.App)
     smokeApp("widgets-demo", termflow.apps.widgets.WidgetsDemoApp.App)
     smokeApp("form-demo", termflow.apps.forms.FormDemoApp.App)
+    smokeApp("catalog-demo", termflow.apps.catalog.CatalogDemoApp.App)
     Console.out.println("Sample smoke checks passed.")

--- a/modules/termflow-sample/src/test/resources/termflow/golden/CatalogDemoAppSpec/after-add.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/CatalogDemoAppSpec/after-add.golden
@@ -1,0 +1,25 @@
+# width=96 height=24
+|                                                                                                |
+| Task Catalog                                                                                   |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| New:                              Priority:                                                    |
+|                                                                                                |
+|                                   ▾ medium                                                     |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| [ Add ]  [ Clear all ]                                                                         |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| Tasks (5)                                                                                      |
+|                                                                                                |
+|   [medium] buy groceries                    Priority Count                                     |
+|   [high] write report                       ──────────────                                     |
+|   [low] review PR                           high         2                                     |
+|   [high] call alice                         medium       2                                     |
+|   [medium] ship v1                          low          1                                     |
+|                                                                                                |
+| catalog            Tab/↑↓ nav  Enter add/select  Ctrl+T theme  Ctrl+C quit          theme=dark |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/CatalogDemoAppSpec/initial-dark.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/CatalogDemoAppSpec/initial-dark.golden
@@ -1,0 +1,25 @@
+# width=96 height=24
+|                                                                                                |
+| Task Catalog                                                                                   |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| New:                              Priority:                                                    |
+|                                                                                                |
+|                                   ▾ medium                                                     |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| [ Add ]  [ Clear all ]                                                                         |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| Tasks (4)                                                                                      |
+|                                                                                                |
+|   [medium] buy groceries                    Priority Count                                     |
+|   [high] write report                       ──────────────                                     |
+|   [low] review PR                           high         2                                     |
+|   [high] call alice                         medium       1                                     |
+|                                             low          1                                     |
+|                                                                                                |
+| catalog            Tab/↑↓ nav  Enter add/select  Ctrl+T theme  Ctrl+C quit          theme=dark |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/CatalogDemoAppSpec/list-row1-focused.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/CatalogDemoAppSpec/list-row1-focused.golden
@@ -1,0 +1,25 @@
+# width=96 height=24
+|                                                                                                |
+| Task Catalog                                                                                   |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| New:                              Priority:                                                    |
+|                                                                                                |
+| new task description…             ▾ medium                                                     |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| [ Add ]  [ Clear all ]                                                                         |
+|                                                                                                |
+|                                                                                                |
+|                                                                                                |
+| Tasks (4)                                                                                      |
+|                                                                                                |
+|   [medium] buy groceries                    Priority Count                                     |
+| ▸ [high] write report                       ──────────────                                     |
+|   [low] review PR                           high         2                                     |
+|   [high] call alice                         medium       1                                     |
+|                                             low          1                                     |
+|                                                                                                |
+| catalog            Tab/↑↓ nav  Enter add/select  Ctrl+T theme  Ctrl+C quit          theme=dark |

--- a/modules/termflow-sample/src/test/scala/termflow/apps/catalog/CatalogDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/catalog/CatalogDemoAppSpec.scala
@@ -1,0 +1,176 @@
+package termflow.apps.catalog
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.apps.catalog.CatalogDemoApp.*
+import termflow.testkit.GoldenSupport
+import termflow.testkit.TuiTestDriver
+import termflow.tui.KeyDecoder.InputKey
+
+class CatalogDemoAppSpec extends AnyFunSuite with GoldenSupport:
+
+  private val Width  = 96
+  private val Height = 24
+
+  private def driver(): TuiTestDriver[Model, Msg] =
+    val d = TuiTestDriver(App, width = Width, height = Height)
+    d.init()
+    d
+
+  private def typeKeys(d: TuiTestDriver[Model, Msg], s: String): Unit =
+    s.foreach(c => d.send(Msg.ConsoleInputKey(InputKey.CharKey(c))))
+
+  // --- initial state --------------------------------------------------------
+
+  test("initial state seeds 4 tasks, Medium priority, Task field focused"):
+    val d = driver()
+    assert(d.model.fm.isFocused(TaskFieldId))
+    assert(d.model.tasks.size == 4)
+    assert(d.model.priority.value.contains(Priority.Medium))
+    assert(d.model.darkTheme)
+
+  // --- focus cycle ---------------------------------------------------------
+
+  test("Tab cycles focus through Task → Priority → Add → Clear → List → Task"):
+    val d        = driver()
+    val expected = Vector(PriorityId, AddId, ClearId, ListId, TaskFieldId)
+    expected.foreach { id =>
+      d.send(Msg.NextFocus)
+      assert(d.model.fm.current.contains(id), s"expected $id, got ${d.model.fm.current}")
+    }
+
+  // --- TextField -----------------------------------------------------------
+
+  test("typing in the Task field fills its buffer"):
+    val d = driver()
+    typeKeys(d, "hello world")
+    assert(d.model.newTask.buffer == "hello world")
+
+  test("Enter in the Task field adds it with the current priority and clears the buffer"):
+    val d = driver()
+    typeKeys(d, "feed cat")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.newTask.buffer == "", "buffer should clear after add")
+    assert(d.model.tasks.items.contains(Task("feed cat", Priority.Medium)))
+
+  test("adding an empty-string task is ignored"):
+    val d      = driver()
+    val before = d.model.tasks.size
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.tasks.size == before)
+
+  test("'t' inside the Task field is a printable char, not a theme toggle"):
+    val d      = driver()
+    val before = d.model.darkTheme
+    typeKeys(d, "tomato")
+    assert(d.model.newTask.buffer == "tomato")
+    assert(d.model.darkTheme == before)
+
+  // --- Select dropdown -----------------------------------------------------
+
+  test("Space on the priority Select opens it; arrows navigate; Enter commits"):
+    val d = driver()
+    d.send(Msg.NextFocus) // -> Priority
+    assert(!d.model.priority.open)
+    d.send(Msg.ConsoleInputKey(InputKey.CharKey(' ')))
+    assert(d.model.priority.open)
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowDown))
+    assert(d.model.priority.value.contains(Priority.Low))
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(!d.model.priority.open)
+    assert(d.model.priority.value.contains(Priority.Low))
+
+  test("adding a task after changing priority records the new priority"):
+    val d = driver()
+    d.send(Msg.NextFocus)                         // -> Priority
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))   // open
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowUp)) // wait — already at Medium(1); Up goes to High(0)
+    // Actually default is selectIndex(1) = Medium. Up → High.
+    d.send(Msg.ConsoleInputKey(InputKey.Enter)) // commit -> High
+    assert(d.model.priority.value.contains(Priority.High))
+    d.send(Msg.PrevFocus) // -> Task field
+    typeKeys(d, "urgent")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.tasks.items.contains(Task("urgent", Priority.High)))
+
+  // --- buttons -------------------------------------------------------------
+
+  test("Enter on the Add button with buffer content adds the task"):
+    val d = driver()
+    typeKeys(d, "fix bug")
+    d.send(Msg.NextFocus) // -> Priority
+    d.send(Msg.NextFocus) // -> Add
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.tasks.items.exists(_.title == "fix bug"))
+
+  test("Enter on the Clear button empties the tasks list"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // -> Clear
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.tasks.isEmpty)
+
+  // --- ListView ------------------------------------------------------------
+
+  test("ArrowDown in the task list advances selection within the widget (not focus)"):
+    val d = driver()
+    (1 to 4).foreach(_ => d.send(Msg.NextFocus)) // -> List
+    val before = d.model.tasks.selected
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowDown))
+    assert(d.model.fm.isFocused(ListId), "focus should stay on the list")
+    assert(d.model.tasks.selected == before + 1)
+
+  test("Enter on the list removes the selected task"):
+    val d = driver()
+    (1 to 4).foreach(_ => d.send(Msg.NextFocus)) // -> List
+    val targeted = d.model.tasks.selectedItem.get
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(!d.model.tasks.items.contains(targeted))
+
+  // --- globals -------------------------------------------------------------
+
+  test("Ctrl+T toggles the theme from anywhere, including inside the Task field"):
+    val d      = driver()
+    val before = d.model.darkTheme
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('T')))
+    assert(d.model.darkTheme == !before)
+
+  test("Ctrl+C quits from anywhere"):
+    val d = driver()
+    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('C')))
+    assert(d.exited)
+
+  test("'q' on a button row quits (non-text shortcut)"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(Msg.NextFocus)) // -> Add
+    d.send(Msg.ConsoleInputKey(InputKey.CharKey('q')))
+    assert(d.exited)
+
+  // --- Keymap wiring --------------------------------------------------------
+
+  test("Globals bind Tab / Shift+Tab / Ctrl+T / Ctrl+C / Esc but NOT vertical arrows"):
+    val g = CatalogDemoApp.Globals
+    assert(g.lookup(InputKey.Ctrl('I')).contains(Msg.NextFocus))
+    assert(g.lookup(InputKey.BackTab).contains(Msg.PrevFocus))
+    assert(g.lookup(InputKey.Ctrl('T')).contains(Msg.ToggleTheme))
+    assert(g.lookup(InputKey.Ctrl('C')).contains(Msg.Quit))
+    assert(g.lookup(InputKey.Escape).contains(Msg.Quit))
+    // Arrows are NOT global — the list + open Select need them.
+    assert(g.lookup(InputKey.ArrowUp).isEmpty)
+    assert(g.lookup(InputKey.ArrowDown).isEmpty)
+
+  // --- golden snapshots ----------------------------------------------------
+
+  test("initial frame matches the dark-theme golden"):
+    val d = driver()
+    assertGoldenFrame(d.frame, "initial-dark")
+
+  test("after an Add cycle: type, Enter, shows updated summary"):
+    val d = driver()
+    typeKeys(d, "ship v1")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assertGoldenFrame(d.frame, "after-add")
+
+  test("after navigating to the List and selecting row 1"):
+    val d = driver()
+    (1 to 4).foreach(_ => d.send(Msg.NextFocus))
+    d.send(Msg.ConsoleInputKey(InputKey.ArrowDown))
+    assertGoldenFrame(d.frame, "list-row1-focused")


### PR DESCRIPTION
Capstone demo for the #91 widget series. Wires every stateful widget into one small task-manager app.

**Stacked on #108** (Table) → #107 → #106 → … Base is \`feature/91-table-widget\`.

## Summary

- **\`CatalogDemoApp\`** — task manager combining \`TextField\` + \`Select\` + \`ListView\` + \`Table\` + \`Button\`
- Demonstrates the complete widget stack working together with \`FocusManager\` + \`Keymap\` + \`Layout\`
- \`sbt catalogDemo\` alias, registered in \`SampleSmoke\`, documented in \`RUN_EXAMPLES.md\`
- 19 integration tests including three golden-frame snapshots

## Run it

\`\`\`bash
sbt catalogDemo
\`\`\`

What you'll see (dark theme, initial load with 4 seed tasks):

\`\`\`
 Task Catalog

 New:                              Priority:
                                   ▾ medium


 [ Add ]  [ Clear all ]


 Tasks (4)

   [medium] buy groceries                    Priority Count
   [high] write report                       ──────────────
   [low] review PR                           high         2
   [high] call alice                         medium       1
                                             low          1

 catalog            Tab/↑↓ nav  Enter add/select  Ctrl+T theme  Ctrl+C quit          theme=dark
\`\`\`

## Widget showcase

| Widget | Role | Key behaviour |
|---|---|---|
| \`TextField\` | Task title input | \`handleKeyOrSubmit(state, key)(AddTask)\` — Enter adds the task, Tab/↑↓ navigates focus |
| \`Select[Priority]\` | Priority dropdown (High/Medium/Low) | Space/Enter opens; ↑/↓ selects; Enter commits + closes |
| \`Button\` | Add, Clear all | focus cycles via Tab or ←/→; Enter/Space activates |
| \`ListView[Task]\` | Scrollable list of tasks | ↑/↓/Home/End navigate rows; Enter removes selected |
| \`Table[(Priority, Int)]\` | Live priority summary | non-selectable (\`selectable = false\`), updates as the list changes |

## Routing design

Unlike the form demo, arrows are **not** in the global keymap — the List and open Select need to consume them. Instead each focused element has bespoke routing:

| Focus | Key handling |
|---|---|
| Task field | \`↑\`/\`↓\` → focus nav; \`Enter\` → AddTask; other → TextField |
| Priority | delegate all (not in Globals) to \`Select.handleKey\` |
| Add / Clear button | \`Enter\`/\`Space\` → activate; arrows → focus nav; \`t\`/\`q\` → toggle/quit |
| Task list | delegate all to \`ListView.handleKey\`; \`Enter\` → RemoveSelected |

This is a real pattern users will want to crib — worth documenting by existence.

## Test plan

- [x] **19 CatalogDemoAppSpec tests**:
  - Initial state: 4 seed tasks, default priority = Medium, Task field focused
  - Tab cycles through all 5 focus targets
  - TextField: typing fills buffer, Enter adds with current priority + clears, empty-string is ignored, \`t\` is a printable
  - Select: Space opens, ArrowDown advances, Enter commits + closes
  - End-to-end: change priority + add → task records the new priority
  - Buttons: Enter on Add uses current buffer + priority, Enter on Clear empties the list
  - List: ArrowDown advances selection (focus stays on list), Enter removes selected
  - Globals: \`Ctrl+T\` toggles theme anywhere; \`Ctrl+C\` quits; \`q\` on a button quits; **binding-table spot check** that arrows are NOT in Globals
  - **3 golden-frame snapshots**: initial-dark (4-seed layout), after-add (add cycle result), list-row1-focused (focused list row highlighted)
- [x] \`sbt ciCheck\` green — **409 tests total** (317 termflow + 92 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly
- [x] \`SampleSmoke\` exercises the app's init + view path

## Out of scope

- Remembering tasks across sessions (no persistence; Devtools #99 is the natural place for that)
- Editing an existing task (re-add + remove works today)
- Column sorting in the summary table — Table widget doesn't support it yet