### PR TITLE
Add Devtools.Panel widget (Phase 2a of #99)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
@@ -14,15 +14,19 @@ package termflow.tui
  *   - [[Devtools.Frame]] — one transition: timestamp, optional `Msg`, resulting `Model`
  *   - Apps record manually in `update`; nothing in the runtime changes
  *
- * ## Phase 2 (deferred follow-up)
+ * ## Phase 2 (partial — see [[Devtools.Panel]])
  *
- * A `TuiApp` wrapper that:
- *   - records every transition automatically
- *   - exposes a hotkey-toggled overlay (history list + rewind controls)
- *   - intercepts replay messages and re-applies forward transitions
+ * [[Devtools.Panel]] ships a read-only viewer: takes a `History` plus a
+ * cursor index and renders a scrollable list of recent frames. Apps
+ * integrate by holding a cursor `Int` in their model and forwarding
+ * arrow keys / Enter to `Panel.handleKey`. Enter returns the selected
+ * frame's index so the app can rewind via [[Devtools.History.rewindTo]].
  *
- * Phase 2 needs more design work around overlay rendering and key
- * interception — see the follow-up issue filed alongside this PR.
+ * Still deferred (Phase 2b): a `Devtools.wrap` app decorator that
+ * records transitions and intercepts keys automatically. Prerequisite
+ * is `llm4s/termflow#110` — making `Sub.InputKey` lazy-start (same
+ * treatment as `Sub.Every` got in PR #95) so the wrapper can swap
+ * the inner app's input source for its own without racing for keys.
  *
  * ## Manual integration today
  *
@@ -190,3 +194,186 @@ object Devtools:
     /** Build an empty history with the given retention capacity. */
     def empty[Msg, Model](capacity: Int): History[Msg, Model] =
       History(capacity, Vector.empty, 0)
+
+  /**
+   * Widget for viewing and navigating a [[Devtools.History]].
+   *
+   * Panel is a thin read-only projection over a History: the caller
+   * holds a cursor index in their model, forwards navigation keys
+   * via [[Panel.handleKey]], and renders the panel via [[Panel.view]].
+   * On `Enter`, `handleKey` returns the selected frame's
+   * lifetime-unique index so the app can call
+   * [[Devtools.History.rewindTo]] to time-travel.
+   *
+   * ## Integration pattern
+   *
+   * {{{
+   * case class Model(
+   *   count: Int,
+   *   history: Devtools.History[Msg, Model],
+   *   devCursor: Int,
+   *   devFocused: Boolean
+   * )
+   *
+   * // In update:
+   * case Msg.Inc =>
+   *   val next = model.copy(count = model.count + 1)
+   *   next.copy(history = next.history.record(msg, next)).tui
+   *
+   * case Msg.DevKey(k) =>
+   *   val (cursor, maybeIdx) = Devtools.Panel.handleKey(model.devCursor, model.history, k)
+   *   maybeIdx match
+   *     case None      => model.copy(devCursor = cursor).tui
+   *     case Some(idx) =>
+   *       // Rewind: restore the selected frame's model.
+   *       val frame = model.history.at(idx).get
+   *       frame.model.copy(history = model.history.rewindTo(idx).get,
+   *                        devCursor = cursor).tui
+   *
+   * // In view:
+   * Devtools.Panel.view(
+   *   history  = model.history,
+   *   cursor   = model.devCursor,
+   *   width    = 60,
+   *   visibleRows = 10,
+   *   focused  = model.devFocused
+   * )
+   * }}}
+   *
+   * The Panel itself doesn't own state — the caller parks the cursor
+   * `Int` wherever makes sense (directly in the model, inside a wrapper
+   * struct, etc). Stateless rendering keeps composition simple.
+   *
+   * ## Row format
+   *
+   * Each frame is rendered as:
+   * {{{
+   * #  4 · +120ms · Msg.Inc
+   * }}}
+   *
+   * The model snapshot is deliberately elided (models can be large);
+   * callers who want full details can print `history.toReport` on
+   * the side or use `history.at(cursor)` to drill in.
+   */
+  object Panel:
+
+    /**
+     * Process one keystroke. Returns the next cursor index and, if the
+     * key was `Enter` (or `Space`) on a valid frame, the selected
+     * frame's lifetime-unique `index` for the caller to rewind to.
+     *
+     * The cursor is a zero-based position into `history.frames` — not
+     * the frame's own `index`. That's so it keeps pointing at a row
+     * as frames scroll off the back of the ring buffer.
+     *
+     * Behaviour:
+     *   - `ArrowUp` / `ArrowDown` move the cursor within the retained range
+     *   - `Home` / `End`          jump to first / last retained frame
+     *   - `Enter` / `Space`       return the selected frame's `Frame.index`
+     *   - other keys              no change
+     *
+     * Empty-history operation is a no-op — cursor stays where it is and
+     * Enter returns `None`.
+     */
+    def handleKey[Msg, Model](
+      cursor: Int,
+      history: History[Msg, Model],
+      key: KeyDecoder.InputKey
+    ): (Int, Option[Int]) =
+      import KeyDecoder.InputKey.*
+      val size = history.size
+      if size == 0 then (cursor, None)
+      else
+        val clamped = math.max(0, math.min(size - 1, cursor))
+        key match
+          case ArrowUp   => (math.max(0, clamped - 1), None)
+          case ArrowDown => (math.min(size - 1, clamped + 1), None)
+          case Home      => (0, None)
+          case End       => (size - 1, None)
+          case Enter | CharKey(' ') =>
+            val frame = history.frames(clamped)
+            (clamped, Some(frame.index))
+          case _ => (clamped, None)
+
+    /**
+     * Render the panel as a [[BoxNode]] with a title row, a divider,
+     * and `visibleRows` body rows drawn from the tail of `history`.
+     *
+     * Sizing mirrors [[termflow.tui.widgets.Table]]: total height is
+     * `2 + visibleRows` cells (title + divider + viewport). Rows that
+     * don't have a frame render as blanks so the panel has a stable
+     * height regardless of how full the history is.
+     *
+     * Focus gates the cursor: only a focused panel shows the `▸ `
+     * marker + inverse-video row.
+     *
+     * @param history     The recording to display.
+     * @param cursor      Zero-based index into the visible frames list.
+     * @param at          Top-left cell. Defaults to `(1, 1)`.
+     * @param width       Total width in cells (minimum 10).
+     * @param visibleRows Viewport height in cells.
+     * @param focused     Whether the panel currently has focus.
+     * @param title       Title-row text.
+     */
+    def view[Msg, Model](
+      history: History[Msg, Model],
+      cursor: Int,
+      at: Coord = Coord(XCoord(1), YCoord(1)),
+      width: Int = 60,
+      visibleRows: Int = 10,
+      focused: Boolean = false,
+      title: String = "Devtools History"
+    )(using theme: Theme): VNode =
+      import termflow.tui.TuiPrelude.*
+      val w       = math.max(10, width)
+      val rowsH   = math.max(1, visibleRows)
+      val frames  = history.frames
+      val size    = frames.size
+      val clamped = math.max(0, math.min(math.max(0, size - 1), cursor))
+
+      val headerLabel = s"$title (${size}/${history.capacity})".take(w).padTo(w, ' ')
+      val headerStyle = Style(fg = theme.primary, bold = true)
+      val headerRow   = TextNode(at.x, at.y, List(Text(headerLabel, headerStyle)))
+      val divider     = TextNode(at.x, at.y + 1, List(Text("─" * w, Style(fg = theme.primary))))
+
+      // Scroll so the cursor stays in-view (simple window-follow logic).
+      val scrollOffset =
+        if size <= rowsH then 0
+        else if clamped < rowsH then 0
+        else math.min(size - rowsH, clamped - rowsH + 1)
+
+      val baseTs = frames.headOption.map(_.timestampMillis).getOrElse(0L)
+
+      val bodyRows = (0 until rowsH).map { r =>
+        val idx  = scrollOffset + r
+        val rowY = at.y + 2 + r
+        if idx >= size then TextNode(at.x, rowY, List(Text(" " * w, Style())))
+        else
+          val f          = frames(idx)
+          val rel        = f.timestampMillis - baseTs
+          val msgText    = f.msg.fold("(initial)")(_.toString)
+          val line       = f"#${f.index}%4d · +${rel}%5dms · ${msgText}"
+          val truncated  = line.take(w - 2).padTo(w - 2, ' ')
+          val isSelected = idx == clamped
+          val showCursor = isSelected && focused
+          val prefix     = if showCursor then "▸ " else "  "
+          val style =
+            if showCursor then Style(fg = theme.background, bg = theme.primary)
+            else Style(fg = theme.foreground)
+          TextNode(at.x, rowY, List(Text(prefix, style), Text(truncated, style)))
+      }.toList
+
+      BoxNode(
+        at.x,
+        at.y,
+        w,
+        2 + rowsH,
+        children = headerRow :: divider :: bodyRows,
+        style = Style()
+      )
+
+    /** Total rendered height in cells (title + divider + viewport). */
+    def height(visibleRows: Int): Int = 2 + math.max(1, visibleRows)
+
+    /** Minimum panel width. */
+    def width(lineWidth: Int): Int = math.max(10, lineWidth)

--- a/modules/termflow/src/test/scala/termflow/tui/DevtoolsPanelSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DevtoolsPanelSpec.scala
@@ -1,0 +1,173 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.KeyDecoder.InputKey
+
+class DevtoolsPanelSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  enum DemoMsg:
+    case Inc, Dec, Reset
+
+  private def buildHistory(n: Int): Devtools.History[DemoMsg, Int] =
+    (1 to n).foldLeft(
+      Devtools.History.empty[DemoMsg, Int](capacity = 32).snapshot(0, atMillis = 1000L)
+    )((h, i) => h.record(DemoMsg.Inc, i, atMillis = 1000L + i * 50L))
+
+  // --- handleKey -----------------------------------------------------------
+
+  test("handleKey on an empty history is a no-op"):
+    val h        = Devtools.History.empty[DemoMsg, Int](8)
+    val (c, idx) = Devtools.Panel.handleKey(0, h, InputKey.ArrowDown)
+    assert(c == 0 && idx.isEmpty)
+
+  test("ArrowDown advances cursor, clamped to history.size - 1"):
+    val h       = buildHistory(3) // frames: snapshot + 3 records -> size 4
+    val (c1, _) = Devtools.Panel.handleKey(0, h, InputKey.ArrowDown)
+    assert(c1 == 1)
+    val (c4, _) = (1 to 10).foldLeft((c1, Option.empty[Int])) { case ((acc, _), _) =>
+      Devtools.Panel.handleKey(acc, h, InputKey.ArrowDown)
+    }
+    assert(c4 == h.size - 1, s"clamped at last row; size=${h.size}")
+
+  test("ArrowUp retreats cursor, clamped to 0"):
+    val h = buildHistory(3)
+    val (c0, _) = (1 to 5).foldLeft((3, Option.empty[Int])) { case ((acc, _), _) =>
+      Devtools.Panel.handleKey(acc, h, InputKey.ArrowUp)
+    }
+    assert(c0 == 0)
+
+  test("Home / End jump to endpoints"):
+    val h       = buildHistory(5)
+    val (c0, _) = Devtools.Panel.handleKey(3, h, InputKey.Home)
+    assert(c0 == 0)
+    val (cN, _) = Devtools.Panel.handleKey(0, h, InputKey.End)
+    assert(cN == h.size - 1)
+
+  test("Enter returns the selected frame's lifetime-unique index"):
+    val h        = buildHistory(3) // Frames indexed 0,1,2,3
+    val (_, idx) = Devtools.Panel.handleKey(cursor = 2, h, InputKey.Enter)
+    assert(idx.contains(h.frames(2).index))
+
+  test("Space returns the selected frame's index (same as Enter)"):
+    val h        = buildHistory(3)
+    val (_, idx) = Devtools.Panel.handleKey(cursor = 1, h, InputKey.CharKey(' '))
+    assert(idx.contains(h.frames(1).index))
+
+  test("Enter on an empty history returns None"):
+    val h        = Devtools.History.empty[DemoMsg, Int](8)
+    val (c, idx) = Devtools.Panel.handleKey(0, h, InputKey.Enter)
+    assert(c == 0 && idx.isEmpty)
+
+  test("cursor passed in out-of-range is clamped for both navigation and Enter"):
+    val h       = buildHistory(2) // size 3
+    val (c1, _) = Devtools.Panel.handleKey(cursor = 99, h, InputKey.ArrowUp)
+    // Clamped to (size - 1) = 2 first, then up to 1.
+    assert(c1 == 1)
+    val (c2, _) = Devtools.Panel.handleKey(cursor = -5, h, InputKey.ArrowDown)
+    // Clamped to 0 first, then down to 1.
+    assert(c2 == 1)
+
+  test("unknown keys return the (clamped) cursor unchanged and no msg"):
+    val h        = buildHistory(3)
+    val (c, idx) = Devtools.Panel.handleKey(cursor = 1, h, InputKey.F1)
+    assert(c == 1 && idx.isEmpty)
+
+  // --- rewind integration pattern ------------------------------------------
+
+  test("Enter + rewindTo pattern restores the selected frame's model"):
+    // Simulate the integration path an app would follow: user picks a
+    // frame, app calls history.rewindTo with the returned index.
+    val h           = buildHistory(4) // frames: snapshot(0) + Inc(1..4)
+    val cursor      = 2               // points at Frame(index=2, msg=Inc, model=2)
+    val (_, picked) = Devtools.Panel.handleKey(cursor, h, InputKey.Enter)
+    assert(picked.contains(2))
+    val rewound = h.rewindTo(picked.get).get
+    assert(rewound.size == 3)
+    assert(rewound.latest.get.model == 2)
+    // Continuing from here gives a fresh index.
+    val next = rewound.record(DemoMsg.Reset, 0, atMillis = 9999L)
+    assert(next.latest.get.index == 3)
+
+  // --- helpers -------------------------------------------------------------
+
+  test("height is 2 + visibleRows with a clamp of visibleRows >= 1"):
+    assert(Devtools.Panel.height(5) == 7)
+    assert(Devtools.Panel.height(0) == 3) // clamped to 1
+    assert(Devtools.Panel.height(-2) == 3)
+
+  test("width clamps to a minimum of 10"):
+    assert(Devtools.Panel.width(40) == 40)
+    assert(Devtools.Panel.width(5) == 10)
+    assert(Devtools.Panel.width(-1) == 10)
+
+  // --- rendering -----------------------------------------------------------
+
+  private def render(v: VNode, width: Int, height: Int): (Array[Array[Char]], Array[Array[Style]]) =
+    val frame = AnsiRenderer.buildFrame(RootNode(width, height, List(v), None))
+    val chars = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).ch)
+    val style = Array.tabulate(height, width)((r, c) => frame.cells(r)(c).style)
+    (chars, style)
+
+  test("view draws title, divider, and frame rows in order"):
+    val h       = buildHistory(2)
+    val v       = Devtools.Panel.view(h, cursor = 0, width = 40, visibleRows = 3, focused = false)
+    val (cs, _) = render(v, 40, Devtools.Panel.height(3))
+    // Row 0: title header (starts with the supplied title).
+    assert(cs(0).mkString.startsWith("Devtools History"))
+    assert(cs(0).mkString.contains(s"3/32")) // 3 frames in a capacity-32 history
+    // Row 1: divider.
+    assert(cs(1).forall(_ == '─'))
+    // Rows 2..4: frame rows — first is the initial snapshot.
+    assert(cs(2).mkString.contains("(initial)"))
+    // Subsequent rows show the Inc msg and relative timestamps.
+    assert(cs(3).mkString.contains("Inc"))
+    assert(cs(4).mkString.contains("Inc"))
+
+  test("focused render highlights the cursor row in inverse video"):
+    val h            = buildHistory(3)
+    val v            = Devtools.Panel.view(h, cursor = 1, width = 40, visibleRows = 4, focused = true)
+    val (cs, styles) = render(v, 40, Devtools.Panel.height(4))
+    // Row 3 in frame space (body rows start at y=2; cursor=1 means second body row = y=3).
+    val cursorRow = 3
+    assert(cs(cursorRow).mkString.startsWith("▸ "))
+    (0 until 40).foreach(c =>
+      assert(styles(cursorRow)(c).bg == Theme.dark.primary, s"cursor row col $c expected inverse bg")
+    )
+    // Other body rows stay default.
+    assert(styles(2)(0).bg == Color.Default)
+    assert(styles(4)(0).bg == Color.Default)
+
+  test("unfocused render omits the cursor marker"):
+    val h       = buildHistory(3)
+    val v       = Devtools.Panel.view(h, cursor = 1, width = 40, visibleRows = 4, focused = false)
+    val (cs, _) = render(v, 40, Devtools.Panel.height(4))
+    // No ▸ anywhere.
+    assert(!cs.exists(_.contains('▸')))
+
+  test("empty history renders the title + blank body"):
+    val h       = Devtools.History.empty[DemoMsg, Int](8)
+    val v       = Devtools.Panel.view(h, cursor = 0, width = 40, visibleRows = 3, focused = true)
+    val (cs, _) = render(v, 40, Devtools.Panel.height(3))
+    // Title row shows "(retained/capacity)" — retained is 0.
+    assert(cs(0).mkString.contains("0/8"))
+    // Body rows should all be blank (40 spaces each).
+    (2 until 5).foreach(r => assert(cs(r).mkString == " " * 40))
+
+  test("viewport scrolls when cursor is past the visible window"):
+    // 10 frames (size 11 incl. snapshot), visibleRows = 4, cursor at last.
+    val h       = buildHistory(10)
+    val v       = Devtools.Panel.view(h, cursor = h.size - 1, width = 30, visibleRows = 4, focused = true)
+    val (cs, _) = render(v, 30, Devtools.Panel.height(4))
+    // The last row of the viewport should be the focused frame with the ▸ marker.
+    val lastBodyRow = cs(5).mkString
+    assert(lastBodyRow.startsWith("▸ "))
+    // The first body row should NOT be the initial snapshot (it scrolled away).
+    assert(!cs(2).mkString.contains("(initial)"))
+
+  test("view composes inside Layout.column with the expected measure"):
+    val h = buildHistory(3)
+    val v = Devtools.Panel.view(h, cursor = 0, width = 40, visibleRows = 5)
+    val c = Layout.column(gap = 0)(v)
+    assert(c.measure == (40, Devtools.Panel.height(5)))


### PR DESCRIPTION
Phase 2a of #99. Phase 2b (the full \`Devtools.wrap\` app decorator) stays deferred until \`llm4s/termflow#110\` lands — details below.

**Stacked on #109** (catalog demo) → #108 → #107 → #106 → … Base is \`feature/91-catalog-demo\`.

## Summary

- **\`Devtools.Panel\`** — read-only viewer: takes a \`Devtools.History\` plus a cursor \`Int\` and renders a scrollable list of recent frames
- \`Panel.handleKey\` navigates the cursor and, on \`Enter\`, returns the selected frame's lifetime-unique \`Frame.index\` for the caller to rewind to
- 18 tests including a full \`Enter → rewindTo\` integration covering the end-to-end rewind path

## Why split from the full wrapper

The original #99 describes a \`Devtools.wrap(innerApp)\` app decorator that records and intercepts keys automatically. Working through the design, the key-interception step is blocked by \`Sub.InputKey\` spawning its producer thread eagerly (before \`registerSub\` runs) — the same kind of race \`Sub.Every\` had before PR #95 fixed it.

Rather than dragging a complex core refactor into this PR, I filed **#110** as the explicit prerequisite and delivered the user-facing viewer half now. Apps that want devtools today can integrate \`Panel\` manually; once #110 lands, the wrapper becomes a small additional PR.

## Integration pattern (manual, but simple)

\`\`\`scala
case class Model(
  count: Int,
  history: Devtools.History[Msg, Model],
  devCursor: Int,
  devFocused: Boolean
)

// In update: record every transition
case Msg.Inc =>
  val next = model.copy(count = model.count + 1)
  next.copy(history = next.history.record(msg, next)).tui

// Route keys to the panel when it has focus
case Msg.DevKey(k) =>
  val (cursor, maybeIdx) = Devtools.Panel.handleKey(model.devCursor, model.history, k)
  maybeIdx match
    case None      => model.copy(devCursor = cursor).tui
    case Some(idx) =>
      // Rewind: restore the selected frame's model.
      val frame = model.history.at(idx).get
      frame.model.copy(history = model.history.rewindTo(idx).get,
                       devCursor = cursor).tui

// In view
Devtools.Panel.view(
  history     = model.history,
  cursor      = model.devCursor,
  width       = 60,
  visibleRows = 10,
  focused     = model.devFocused
)
\`\`\`

Panel doesn't own state — the cursor lives wherever the app wants. Stateless rendering keeps composition predictable and puts the app in full control of how rewind actually applies.

## Row format

Each frame renders as:

\`\`\`
#  4 · +120ms · Msg.Inc
\`\`\`

Lifetime index + relative timestamp + msg \`toString\`. Model snapshots are elided (can be large); callers wanting detail use \`history.at(idx)\` or \`history.toReport\`.

## Test plan

- [x] **18 DevtoolsPanelSpec tests**:
  - handleKey: empty no-op, ArrowUp/Down clamping, Home/End, Enter/Space return \`Frame.index\`, out-of-range cursor clamping, unknown-key passthrough
  - **Full Enter → rewindTo integration**: drives handleKey to pick a frame, passes the returned index to \`History.rewindTo\`, verifies the history shrinks and a subsequent record gets a fresh \`nextIndex\`
  - Helpers \`height\` / \`width\` with bounds
  - Rendering: title row shows "(retained/capacity)", divider, frame rows (\`(initial)\` for snapshots, msg string for records), focused inverse-video cursor row, unfocused no marker, empty body blanks, viewport scroll when cursor exceeds the window, \`Layout.column\` composition at expected measure
- [x] \`sbt ciCheck\` green — **427 tests total** (335 termflow + 92 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## What's left for #99

The Phase 2b wrapper decorator. **#110** filed as the blocking prerequisite. Once that lands:

\`\`\`scala
def wrap[M, Ms](
  inner: TuiApp[M, Ms],
  toInputMsg: KeyDecoder.InputKey => Ms,
  capacity: Int = 500
): TuiApp[WrapperModel[M, Ms], WrapperMsg[Ms]]
\`\`\`

becomes a straightforward decorator: intercept the inner's \`registerSub\` for its \`Sub.InputKey\` and **don't** call \`start()\` on it; register the wrapper's own input source; route keys by mode. The Panel from this PR is exactly the view the wrapper's Inspect mode would use.

## Out of scope (per #99, still)

- Full Redux-devtools-style persistence across restarts
- Editing messages inline
- Remote devtools over a socket