### PR TITLE
Defer Sub.InputKey producer thread to start()

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -31,15 +31,20 @@ trait Sub[+Msg]:
   /**
    * Begin any background activity (timers, reader threads, …).
    *
-   * The default is a no-op for back-compat with existing `Sub` implementations
-   * that start their work eagerly in their constructor. New deferred-start
-   * factories — currently only [[Sub.Every]] — override this so the cost of
-   * "starting a sub" can be controlled by the registering context:
+   * The default is a no-op for back-compat with `Sub` implementations that
+   * start their work eagerly in their constructor. Deferred-start factories
+   * — [[Sub.Every]] (timer scheduler) and [[Sub.InputKeyFromSource]]
+   * (keyboard reader thread) — override this so the registering context
+   * decides when the work actually begins:
    *
    *   - `LocalCmdBus.registerSub` calls `start()` immediately after recording
    *     the sub, preserving existing production behaviour.
    *   - `TestRuntimeCtx.registerSub` deliberately does **not** call `start()`,
-   *     so timer-driven subs stay dormant inside the testkit.
+   *     so both timer- and input-driven subs stay dormant inside the testkit.
+   *   - Wrapper decorators (e.g. a future `Devtools.wrap`) can intercept the
+   *     inner app's `registerSub`, swap its input source for their own, and
+   *     skip calling `start()` on the original — all without racing for
+   *     keystrokes.
    *
    * Calling `start()` more than once must be safe — the contract is "start if
    * not already started".
@@ -124,6 +129,15 @@ object Sub:
    * Each decoded [[KeyDecoder.InputKey]] is wrapped with `msg` and published
    * to `sink`. Read failures are surfaced via `onError`.
    *
+   * The producer thread is constructed lazily by [[Sub.start]] rather than
+   * in this factory so `TestRuntimeCtx` can keep input subs dormant during
+   * snapshot tests, and wrapper decorators can intercept the inner app's
+   * input subscription by swapping it for their own before `start()`
+   * is called. Production callers (`LocalCmdBus.registerSub` and bare
+   * `EventSink` sinks routed through [[autoRegisterIfRuntimeCtx]]) get
+   * `start()` invoked synchronously right after construction, so the
+   * observable behaviour is identical to the eager version.
+   *
    * Most apps should prefer [[InputKey]], which uses the runtime context's
    * terminal reader.
    */
@@ -134,40 +148,49 @@ object Sub:
     sink: EventSink[Msg]
   ): Sub[Msg] =
     val sub = new Sub[Msg]:
-      @volatile private var active = true
+      private val lock                     = new Object
+      @volatile private var active         = true
+      @volatile private var thread: Thread = null
 
-      private val thread = ThreadUtils.startThread(() =>
-        try
-          while active do
-            source.next() match
-              case InputRead.Key(key) =>
-                if active then sink.publish(Cmd.GCmd(msg(key)))
-              case InputRead.End =>
-                active = false
-              case InputRead.Failed(_: InterruptedException) =>
-                active = false
-              case InputRead.Failed(err) =>
-                if active then sink.publish(Cmd.GCmd(onError(err)))
-        catch {
-          case _: InterruptedException =>
-            ()
-          case e: Throwable =>
-            if active then sink.publish(Cmd.GCmd(onError(e)))
+      override def start(): Unit =
+        lock.synchronized {
+          if thread == null && active then
+            thread = ThreadUtils.startThread(() =>
+              try
+                while active do
+                  source.next() match
+                    case InputRead.Key(key) =>
+                      if active then sink.publish(Cmd.GCmd(msg(key)))
+                    case InputRead.End =>
+                      active = false
+                    case InputRead.Failed(_: InterruptedException) =>
+                      active = false
+                    case InputRead.Failed(err) =>
+                      if active then sink.publish(Cmd.GCmd(onError(err)))
+              catch {
+                case _: InterruptedException =>
+                  ()
+                case e: Throwable =>
+                  if active then sink.publish(Cmd.GCmd(onError(e)))
+              }
+            )
         }
-      )
 
       override def isActive: Boolean = active
 
       override def cancel(): Unit =
-        active = false
-        source.close() match
-          case Failure(_) => ()
-          case _          => ()
-        thread.interrupt()
-        try thread.join(200L)
-        catch {
-          case _: InterruptedException =>
-            Thread.currentThread().interrupt()
+        lock.synchronized {
+          active = false
+          source.close() match
+            case Failure(_) => ()
+            case _          => ()
+          if thread != null then
+            thread.interrupt()
+            try thread.join(200L)
+            catch {
+              case _: InterruptedException =>
+                Thread.currentThread().interrupt()
+            }
         }
     autoRegisterIfRuntimeCtx(sub, sink)
 

--- a/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
+++ b/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
@@ -65,13 +65,11 @@ final class TuiTestDriver[Model, Msg](
    *
    * Subscriptions the app registers via `Sub.*` factories pass through
    * [[TestRuntimeCtx.registerSub]], which deliberately does not invoke
-   * `Sub.start()`. Combined with `Sub.Every`'s deferred-start design (see
-   * `llm4s/termflow#92`), this means timer-driven subscriptions stay
-   * dormant in tests — no race-prone ticks land in the model.
-   *
-   * Subscriptions that still start eagerly in their own constructor (e.g.
-   * `Sub.InputKey` with the testkit's empty `StringReader`) terminate
-   * harmlessly on the test backend.
+   * `Sub.start()`. Combined with the deferred-start design shared by
+   * `Sub.Every` (see `llm4s/termflow#92`) and `Sub.InputKey` (see
+   * `llm4s/termflow#110`), this means every framework-provided sub stays
+   * dormant in tests — no race-prone timer ticks or input threads land in
+   * the model.
    */
   def init(): Unit =
     if _initialized then throw new IllegalStateException("TuiTestDriver.init() called twice")

--- a/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
@@ -247,3 +247,95 @@ class SubSpec extends AnyFunSuite:
     assert(sub.isActive)
     sub.start()
     assert(sub.isActive)
+
+  // --- Sub.InputKey deferred-start contract (issue #110) -------------------
+
+  /**
+   * Stub `TerminalKeySource` that hands out a scripted sequence of
+   * `InputRead`s and records how many times it's been polled. Blocks on
+   * `latch` after exhausting its script so the consumer thread stays
+   * parked (simulating a live terminal that has no more keys yet).
+   */
+  private class ScriptedSource(script: List[InputRead]) extends TerminalKeySource:
+    private val queue = new java.util.concurrent.ConcurrentLinkedQueue[InputRead](script.asJava)
+    val polls         = new AtomicInteger(0)
+    private val done  = new CountDownLatch(1)
+    override def next(): InputRead =
+      polls.incrementAndGet(): Unit
+      Option(queue.poll()) match
+        case Some(r) => r
+        case None =>
+          try done.await(5, TimeUnit.SECONDS): Unit
+          catch { case _: InterruptedException => () }
+          InputRead.End
+    override def close(): Try[Unit] =
+      done.countDown()
+      Success(())
+
+  test("InputKeyFromSource does not read when registered into a RuntimeCtx that omits start()"):
+    val ctx = new CapturingCtx[String]
+    val source = new ScriptedSource(
+      List(InputRead.Key(KeyDecoder.InputKey.CharKey('a')))
+    )
+    val sub = Sub.InputKeyFromSource[String](source, k => s"key:$k", e => s"err:$e", ctx)
+    assert(ctx.registered == List(sub))
+    // Wait well past any plausible race window — if the thread were running
+    // it would have called `next` at least once.
+    Thread.sleep(80)
+    assert(source.polls.get() == 0, s"expected zero polls; saw ${source.polls.get()}")
+    assert(ctx.messages.isEmpty, s"expected no published messages; saw ${ctx.messages}")
+    sub.cancel()
+
+  test("InputKeyFromSource starts consuming once start() is called explicitly"):
+    val ctx = new CapturingCtx[String]
+    val source = new ScriptedSource(
+      List(InputRead.Key(KeyDecoder.InputKey.CharKey('z')))
+    )
+    val sub = Sub.InputKeyFromSource[String](source, k => s"key:$k", e => s"err:$e", ctx)
+    assert(ctx.messages.isEmpty)
+    sub.start()
+    try
+      // Wait for the 'z' to be published.
+      val deadline = System.currentTimeMillis() + 1000
+      while ctx.messages.isEmpty && System.currentTimeMillis() < deadline do Thread.sleep(10)
+      val msgs = ctx.messages.collect { case Cmd.GCmd(v: String) => v }
+      assert(msgs.exists(_.startsWith("key:")), s"expected key message; saw ${ctx.messages}")
+    finally sub.cancel()
+
+  test("InputKeyFromSource.start() is idempotent — multiple calls do not spawn extra threads"):
+    val ctx    = new CapturingCtx[String]
+    val source = new ScriptedSource(List(InputRead.Key(KeyDecoder.InputKey.CharKey('x'))))
+    val sub    = Sub.InputKeyFromSource[String](source, k => s"key:$k", e => s"err:$e", ctx)
+    sub.start()
+    sub.start()
+    sub.start()
+    // Wait for the single 'x' to arrive.
+    val deadline = System.currentTimeMillis() + 1000
+    while ctx.messages.isEmpty && System.currentTimeMillis() < deadline do Thread.sleep(10)
+    sub.cancel()
+    assert(!sub.isActive)
+
+  test("InputKeyFromSource cancel before start does not leave a dangling thread"):
+    val ctx    = new CapturingCtx[String]
+    val source = new ScriptedSource(List(InputRead.Key(KeyDecoder.InputKey.CharKey('a'))))
+    val sub    = Sub.InputKeyFromSource[String](source, k => s"key:$k", e => s"err:$e", ctx)
+    sub.cancel()
+    // A subsequent start() must NOT spin up a thread for a cancelled sub.
+    sub.start()
+    Thread.sleep(50)
+    assert(source.polls.get() == 0, "cancelled sub must not poll after start()")
+    assert(!sub.isActive)
+
+  test("InputKeyFromSource with a bare EventSink (non-RuntimeCtx) still starts eagerly"):
+    // Back-compat: when caller passes a plain EventSink, the factory must
+    // start the sub itself so existing code keeps working.
+    val sink = new TestSink[String]
+    val source = new ScriptedSource(
+      List(InputRead.Key(KeyDecoder.InputKey.CharKey('a')))
+    )
+    val sub = Sub.InputKeyFromSource[String](source, k => s"key:$k", e => s"err:$e", sink)
+    try
+      assert(sink.awaitFirst(500))
+      val msgs = sink.messages.collect { case Cmd.GCmd(v: String) => v }
+      assert(msgs.exists(_.startsWith("key:")))
+    finally sub.cancel()


### PR DESCRIPTION
Closes #110. Unblocks Phase 2b of #99 (the \`Devtools.wrap\` app decorator).

**Stacked on #111** (Devtools.Panel) → #109 → #108 → … Base is \`feature/99-devtools-panel\`.

## Summary

Mirrors the \`Sub.Every\` treatment from PR #95. \`Sub.InputKeyFromSource\` now constructs its reader + decoder thread inside an override of \`Sub.start()\` instead of in its anonymous-class body. \`Sub.InputKey\` and \`Sub.InputKeyWithReader\` delegate to the same factory so they inherit the behaviour without direct changes.

**Production behaviour unchanged.** \`LocalCmdBus.registerSub\` calls \`start()\` immediately after recording; \`autoRegisterIfRuntimeCtx\` does the same for bare \`EventSink\` sinks. The only observable change is in the testkit and in future wrapper decorators.

## Why this matters

Two concerns drove the change:

### 1. Testkit determinism

\`TestRuntimeCtx.registerSub\` deliberately omits \`start()\` so subs stay dormant during snapshot tests. Before this PR, \`Sub.InputKey\` was a **hole** in that contract — the reader thread started eagerly, then terminated "harmlessly" only because the testkit's \`StringReader\` was empty. With this change the thread doesn't start at all. The \`TuiTestDriver.init\` ScalaDoc is updated to reflect the new, complete story.

### 2. Devtools.wrap app decorator

The \`Devtools.wrap\` decorator from #99 needs to intercept the inner app's \`Sub.InputKey\` registration and swap its input source for the wrapper's own. That's only safe if the inner sub hasn't already started a thread racing for keystrokes. After #110, the wrapper can capture the inner's sub at \`registerSub\` time and simply not call \`start()\` on it — no race, no cleanup dance.

## Implementation shape

\`\`\`scala
def InputKeyFromSource[Msg](source, msg, onError, sink): Sub[Msg] =
  val sub = new Sub[Msg]:
    private val lock                     = new Object
    @volatile private var active         = true
    @volatile private var thread: Thread = null

    override def start(): Unit = lock.synchronized {
      if thread == null && active then
        thread = ThreadUtils.startThread(() => /* reader loop */)
    }

    override def cancel(): Unit = lock.synchronized {
      active = false
      source.close()
      if thread != null then
        thread.interrupt()
        thread.join(200L)
    }
  autoRegisterIfRuntimeCtx(sub, sink)
\`\`\`

Guarded by a lock + null check so:
- **double start** is safe (no duplicate threads)
- **cancel-before-start** leaves \`active = false\` so any later \`start()\` is a no-op (covered by a dedicated test)
- **cancel-after-start** correctly interrupts + joins the thread

## Compatibility matrix

| Caller | Before | After |
|---|---|---|
| \`LocalCmdBus.registerSub(Sub.InputKey)\` | thread starts eagerly | thread starts via \`registerSub → start()\` (same moment) |
| Bare \`EventSink\` (non-RuntimeCtx) | eager start | \`autoRegisterIfRuntimeCtx\` calls \`start()\` explicitly — same moment |
| \`TestRuntimeCtx.registerSub(Sub.InputKey)\` | thread started then exited on empty reader (was an incidental bug) | thread never starts (now correct) |
| Future \`Devtools.wrap\` | would race | can cleanly swap input source |

## Test plan

- [x] **5 new SubSpec tests** covering the deferred-start contract:
  - \`InputKeyFromSource\` doesn't read when registered into a \`CapturingCtx\` that omits \`start()\` — zero polls after 80 ms
  - Explicit \`start()\` kicks off consumption (key messages land on the sink)
  - \`start()\` is idempotent — multiple calls don't spawn extra threads; cancel still tears everything down cleanly
  - **Cancel-before-start** leaves the sub inactive and a subsequent \`start()\` is a no-op
  - Bare \`EventSink\` (non-RuntimeCtx) still starts eagerly via \`autoRegisterIfRuntimeCtx\` — back-compat preserved
- [x] All existing InputKey tests still pass (no behaviour change in the main path)
- [x] \`sbt ciCheck\` green — **432 tests total** (340 termflow + 92 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## What's unblocked

Phase 2b of #99 — the \`Devtools.wrap\` app decorator — becomes a small follow-up:

\`\`\`scala
def wrap[M, Ms](
  inner: TuiApp[M, Ms],
  toInputMsg: KeyDecoder.InputKey => Ms,
  capacity: Int = 500
): TuiApp[WrapperModel[M, Ms], WrapperMsg[Ms]]
\`\`\`

Using this PR's machinery: wrapper builds a fake \`RuntimeCtx\` whose \`registerSub\` captures but **doesn't** call \`start()\` on the inner's input sub, then registers its own input source against the real ctx. Keys route by mode (Live → forward via \`toInputMsg\`; Inspect → drive \`Devtools.Panel\` locally).