### PR TITLE
Add Devtools.wrap app decorator (Phase 2b — closes #99)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
@@ -1,5 +1,7 @@
 package termflow.tui
 
+import termflow.tui.Tui.tui
+
 /**
  * In-memory recording primitives for time-travel debugging of TermFlow apps.
  *
@@ -14,19 +16,21 @@ package termflow.tui
  *   - [[Devtools.Frame]] — one transition: timestamp, optional `Msg`, resulting `Model`
  *   - Apps record manually in `update`; nothing in the runtime changes
  *
- * ## Phase 2 (partial — see [[Devtools.Panel]])
+ * ## Phase 2 — Panel viewer + app decorator
  *
- * [[Devtools.Panel]] ships a read-only viewer: takes a `History` plus a
+ * [[Devtools.Panel]] is a read-only viewer: takes a `History` plus a
  * cursor index and renders a scrollable list of recent frames. Apps
  * integrate by holding a cursor `Int` in their model and forwarding
  * arrow keys / Enter to `Panel.handleKey`. Enter returns the selected
  * frame's index so the app can rewind via [[Devtools.History.rewindTo]].
  *
- * Still deferred (Phase 2b): a `Devtools.wrap` app decorator that
- * records transitions and intercepts keys automatically. Prerequisite
- * is `llm4s/termflow#110` — making `Sub.InputKey` lazy-start (same
- * treatment as `Sub.Every` got in PR #95) so the wrapper can swap
- * the inner app's input source for its own without racing for keys.
+ * [[Devtools.wrap]] takes any [[TuiApp]] and returns a wrapped `TuiApp`
+ * that records every inner transition automatically, toggles between
+ * Live and Inspect modes on a hotkey, and rewinds to the selected frame
+ * on Enter. Relies on the deferred-start contract from PR #95 / #110:
+ * the inner app's `Sub.*` registrations are captured but not started,
+ * and the wrapper runs its own `Sub.InputKey` against the real
+ * terminal. See [[Devtools.wrap]]'s ScalaDoc for the integration call.
  *
  * ## Manual integration today
  *
@@ -324,7 +328,6 @@ object Devtools:
       focused: Boolean = false,
       title: String = "Devtools History"
     )(using theme: Theme): VNode =
-      import termflow.tui.TuiPrelude.*
       val w       = math.max(10, width)
       val rowsH   = math.max(1, visibleRows)
       val frames  = history.frames
@@ -377,3 +380,260 @@ object Devtools:
 
     /** Minimum panel width. */
     def width(lineWidth: Int): Int = math.max(10, lineWidth)
+
+  // -------------------------------------------------------------------------
+  // Phase 2b — Devtools.wrap app decorator
+  // -------------------------------------------------------------------------
+
+  /** Mode flag for a [[wrap]]ped app. */
+  enum WrapMode:
+
+    /** Inner app runs normally; keys are forwarded via `toInputMsg`. */
+    case Live
+
+    /** Inner app is paused; the Devtools.Panel is rendered as a modal viewer. */
+    case Inspect
+
+  /**
+   * Outer model for a [[wrap]]ped app. Holds the inner model plus the
+   * recording, the current mode, and the Inspect cursor.
+   */
+  final case class Wrapped[M, +Ms](
+    inner: M,
+    history: History[Ms, M],
+    mode: WrapMode,
+    cursor: Int,
+    terminalWidth: Int,
+    terminalHeight: Int
+  )
+
+  /** Outer message ADT for a [[wrap]]ped app. */
+  enum WrapMsg[+Ms]:
+
+    /** Toggle Live <-> Inspect. Fired by the configured hotkey. */
+    case Toggle
+
+    /** Wrap an inner app message so it flows through the outer update. */
+    case Inner[Ms](msg: Ms) extends WrapMsg[Ms]
+
+    /** Raw key event from the wrapper's own `Sub.InputKey`. */
+    case Key(k: KeyDecoder.InputKey)
+
+    /** Input-source error forwarded from the wrapper's `Sub.InputKey`. */
+    case KeyError(e: Throwable)
+
+  /**
+   * Wrap a [[TuiApp]] with devtools. Records every `inner.update`
+   * transition into a [[History]], listens for a hotkey to toggle
+   * between Live and Inspect modes, and lets the user rewind to any
+   * recorded frame by pressing `Enter` in Inspect.
+   *
+   * {{{
+   * object Counter:
+   *   enum Msg:
+   *     case Inc, Dec, Key(k: KeyDecoder.InputKey)
+   *   val App: TuiApp[Int, Msg] = ...
+   *
+   *   @main def run(): Unit =
+   *     TuiRuntime.run(Devtools.wrap(App, toInputMsg = Msg.Key.apply))
+   * }}}
+   *
+   * ## How the wrapper intercepts input
+   *
+   * The wrapper's `init` calls `inner.init` with a fake [[RuntimeCtx]]:
+   *
+   *   - `terminal.reader` is an empty `StringReader` so the inner's
+   *     `Sub.InputKey` creates a `ConsoleKeyPressSource` that
+   *     immediately hits end-of-stream and exits harmlessly.
+   *   - `registerSub` records the inner's subs but never calls
+   *     `start()` on them, so no inner sub (input, timer, or resize)
+   *     actually runs. Relies on the deferred-start contract from
+   *     PR #95 (`Sub.Every`) and PR #110 (`Sub.InputKey`).
+   *   - `publish` forwards inner commands to the real ctx, lifted to
+   *     the outer `WrapMsg[Ms]` type.
+   *
+   * The wrapper then registers its own `Sub.InputKey` against the
+   * real ctx. Keys arrive as `WrapMsg.Key(k)`:
+   *
+   *   - If `k == toggleKey` → flip mode.
+   *   - Else if mode is Live → dispatch `WrapMsg.Inner(toInputMsg(k))`
+   *     and let the inner update run normally.
+   *   - Else (Inspect) → route to [[Panel.handleKey]]. On Enter, rewind
+   *     the inner model from the selected frame and exit Inspect.
+   *
+   * ## Known limitations (v1)
+   *
+   * Because the wrapper captures but never starts inner subs, any
+   * `Sub.Every` / `Sub.TerminalResize` registered by the inner stays
+   * dormant. Apps that rely on those (animated clocks, stress demos)
+   * will see their animations pause while wrapped. Selective
+   * forwarding of non-input subs is a future follow-up.
+   *
+   * @param inner       The inner TuiApp to wrap.
+   * @param toInputMsg  How to turn a raw `InputKey` into the inner's
+   *                    own message ADT. Typically `Msg.Key.apply` or
+   *                    similar constructor.
+   * @param capacity    Max retained history frames (default 500).
+   * @param toggleKey   Which key toggles Live <-> Inspect
+   *                    (default `Ctrl+G`, which decodes cleanly
+   *                    through `KeyDecoder`).
+   * @param devTheme    Theme used for the Inspect-mode UI (independent
+   *                    of whatever theme the inner app uses).
+   */
+  def wrap[M, Ms](
+    inner: TuiApp[M, Ms],
+    toInputMsg: KeyDecoder.InputKey => Ms,
+    capacity: Int = 500,
+    toggleKey: KeyDecoder.InputKey = KeyDecoder.InputKey.Ctrl('G'),
+    devTheme: Theme = Theme.dark
+  ): TuiApp[Wrapped[M, Ms], WrapMsg[Ms]] = new TuiApp[Wrapped[M, Ms], WrapMsg[Ms]]:
+
+    override def init(ctx: RuntimeCtx[WrapMsg[Ms]]): Tui[Wrapped[M, Ms], WrapMsg[Ms]] =
+      val fake    = innerCtx(ctx)
+      val initial = inner.init(fake)
+      // Wrapper's own input source, running against the REAL ctx.
+      Sub.InputKey[WrapMsg[Ms]](WrapMsg.Key.apply, WrapMsg.KeyError.apply, ctx)
+      val history = History.empty[Ms, M](capacity).snapshot(initial.model)
+      Tui(
+        Wrapped(
+          inner = initial.model,
+          history = history,
+          mode = WrapMode.Live,
+          cursor = 0,
+          terminalWidth = ctx.terminal.width,
+          terminalHeight = ctx.terminal.height
+        ),
+        liftCmd(initial.cmd)
+      )
+
+    override def update(
+      m: Wrapped[M, Ms],
+      msg: WrapMsg[Ms],
+      ctx: RuntimeCtx[WrapMsg[Ms]]
+    ): Tui[Wrapped[M, Ms], WrapMsg[Ms]] =
+      val sized = m.copy(terminalWidth = ctx.terminal.width, terminalHeight = ctx.terminal.height)
+      msg match
+        case WrapMsg.Toggle =>
+          val nextMode = sized.mode match
+            case WrapMode.Live    => WrapMode.Inspect
+            case WrapMode.Inspect => WrapMode.Live
+          // Park the cursor on the most recent frame when entering Inspect.
+          val nextCursor =
+            if nextMode == WrapMode.Inspect then math.max(0, sized.history.size - 1)
+            else sized.cursor
+          sized.copy(mode = nextMode, cursor = nextCursor).tui
+
+        case WrapMsg.Inner(innerMsg) =>
+          if sized.mode == WrapMode.Inspect then sized.tui
+          else
+            val fake        = innerCtx(ctx)
+            val nextInner   = inner.update(sized.inner, innerMsg, fake)
+            val nextHistory = sized.history.record(innerMsg, nextInner.model)
+            Tui(
+              sized.copy(inner = nextInner.model, history = nextHistory),
+              liftCmd(nextInner.cmd)
+            )
+
+        case WrapMsg.Key(k) =>
+          if k == toggleKey then update(sized, WrapMsg.Toggle, ctx)
+          else
+            sized.mode match
+              case WrapMode.Live =>
+                update(sized, WrapMsg.Inner(toInputMsg(k)), ctx)
+              case WrapMode.Inspect =>
+                val (cursor, maybeIdx) = Panel.handleKey(sized.cursor, sized.history, k)
+                maybeIdx match
+                  case None => sized.copy(cursor = cursor).tui
+                  case Some(idx) =>
+                    val frame   = sized.history.at(idx).get
+                    val rewound = sized.history.rewindTo(idx).get
+                    sized
+                      .copy(
+                        inner = frame.model,
+                        history = rewound,
+                        mode = WrapMode.Live,
+                        cursor = math.max(0, math.min(rewound.size - 1, cursor))
+                      )
+                      .tui
+
+        case WrapMsg.KeyError(_) =>
+          sized.tui
+
+    override def view(m: Wrapped[M, Ms]): RootNode =
+      m.mode match
+        case WrapMode.Live =>
+          // Transparent pass-through — same frame the inner would draw.
+          inner.view(m.inner)
+
+        case WrapMode.Inspect =>
+          given Theme = devTheme
+          import TuiPrelude.*
+          val w          = math.max(40, m.terminalWidth)
+          val h          = math.max(12, m.terminalHeight)
+          val panelWidth = math.max(20, w - 4)
+          val panelRows  = math.max(3, h - 6)
+          val title = TextNode(
+            2.x,
+            1.y,
+            List(
+              Text(
+                "Devtools — ↑↓ select · Enter rewind · " +
+                  formatToggleLabel(toggleKey) + " resume",
+                Style(fg = devTheme.primary, bold = true, underline = true)
+              )
+            )
+          )
+          val panel = Panel.view(
+            history = m.history,
+            cursor = m.cursor,
+            at = Coord(2.x, 3.y),
+            width = panelWidth,
+            visibleRows = panelRows,
+            focused = true,
+            title = "History"
+          )
+          RootNode(w, h, List(title, panel), None)
+
+    override def toMsg(input: TuiPrelude.PromptLine): TuiPrelude.Result[WrapMsg[Ms]] =
+      inner.toMsg(input).map(WrapMsg.Inner(_))
+
+    /** Fake RuntimeCtx that the inner app sees. See class ScalaDoc. */
+    private def innerCtx(real: RuntimeCtx[WrapMsg[Ms]]): RuntimeCtx[Ms] =
+      new RuntimeCtx[Ms]:
+        override def terminal: TerminalBackend = innerTerminal(real.terminal)
+        override def config: TermFlowConfig    = real.config
+        override def publish(cmd: Cmd[Ms]): Unit =
+          real.publish(liftCmd(cmd))
+        override def registerSub(sub: Sub[Ms]): Sub[Ms] =
+          // Capture but do not start — wrapper owns all input flow.
+          sub
+
+    /** Terminal that the inner sees: same dims, real writer, empty reader. */
+    private def innerTerminal(real: TerminalBackend): TerminalBackend = new TerminalBackend:
+      override def reader: java.io.Reader = new java.io.StringReader("")
+      override def writer: java.io.Writer = real.writer
+      override def width: Int             = real.width
+      override def height: Int            = real.height
+      override def close(): Unit          = ()
+
+    /** Lift a Cmd[Ms] from the inner app into Cmd[WrapMsg[Ms]] for the real ctx. */
+    private def liftCmd(cmd: Cmd[Ms]): Cmd[WrapMsg[Ms]] = cmd match
+      case Cmd.NoCmd                     => Cmd.NoCmd
+      case Cmd.Exit                      => Cmd.Exit
+      case Cmd.GCmd(innerMsg)            => Cmd.GCmd(WrapMsg.Inner(innerMsg))
+      case Cmd.TermFlowErrorCmd(err)     => Cmd.TermFlowErrorCmd(err)
+      case fc: Cmd.FCmd[a, ?] @unchecked =>
+        // Erasure-safe: Cmd.FCmd's second type parameter is always the
+        // enclosing Cmd[Ms]'s Msg type. The @unchecked suppresses the
+        // structural-type test warning since JVM can't see the Ms.
+        Cmd.FCmd[a, WrapMsg[Ms]](
+          task = fc.task,
+          toCmd = (res: a) => liftCmd(fc.toCmd(res).asInstanceOf[Cmd[Ms]]),
+          onEnqueue = fc.onEnqueue.map(m => WrapMsg.Inner(m.asInstanceOf[Ms]))
+        )
+
+    /** Pretty-print a toggle key for the Inspect banner. */
+    private def formatToggleLabel(key: KeyDecoder.InputKey): String = key match
+      case KeyDecoder.InputKey.Ctrl(c) => s"Ctrl+$c"
+      case KeyDecoder.InputKey.Escape  => "Esc"
+      case other                       => other.toString

--- a/modules/termflow/src/test/scala/termflow/tui/DevtoolsWrapSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DevtoolsWrapSpec.scala
@@ -1,0 +1,200 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.testkit.TuiTestDriver
+import termflow.tui.Devtools.*
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.Tui.tui
+import termflow.tui.TuiPrelude.*
+
+class DevtoolsWrapSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  // A minimal inner app to wrap.
+  enum InnerMsg:
+    case Inc, Dec, Reset
+    case Key(k: InputKey)
+
+  private def innerApp: TuiApp[Int, InnerMsg] = new TuiApp[Int, InnerMsg]:
+    override def init(ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] =
+      // Inner registers a Sub.InputKey — the wrapper should capture + not start it.
+      Sub.InputKey[InnerMsg](InnerMsg.Key.apply, _ => InnerMsg.Reset, ctx)
+      0.tui
+
+    override def update(model: Int, msg: InnerMsg, ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] =
+      msg match
+        case InnerMsg.Inc    => (model + 1).tui
+        case InnerMsg.Dec    => (model - 1).tui
+        case InnerMsg.Reset  => 0.tui
+        case InnerMsg.Key(_) => model.tui // ignore raw keys for this test
+
+    override def view(model: Int): RootNode =
+      RootNode(
+        width = 20,
+        height = 1,
+        children = List(TextNode(1.x, 1.y, List(Text(s"count=$model", Style())))),
+        input = None
+      )
+
+    override def toMsg(input: PromptLine): Result[InnerMsg] = Right(InnerMsg.Inc)
+
+  private def driver(): TuiTestDriver[Wrapped[Int, InnerMsg], WrapMsg[InnerMsg]] =
+    val wrapped = Devtools.wrap(innerApp, toInputMsg = InnerMsg.Key.apply, capacity = 20)
+    val d       = TuiTestDriver(wrapped, width = 40, height = 12)
+    d.init()
+    d
+
+  // --- initial state -------------------------------------------------------
+
+  test("init starts in Live mode with a single initial snapshot"):
+    val d = driver()
+    assert(d.model.mode == WrapMode.Live)
+    assert(d.model.inner == 0)
+    assert(d.model.history.size == 1)
+    assert(d.model.history.frames.head.msg.isEmpty, "initial frame has msg=None")
+    assert(d.model.history.frames.head.model == 0)
+
+  // --- recording in Live mode ---------------------------------------------
+
+  test("inner transitions in Live mode are recorded into history"):
+    val d = driver()
+    d.send(WrapMsg.Inner(InnerMsg.Inc))
+    d.send(WrapMsg.Inner(InnerMsg.Inc))
+    d.send(WrapMsg.Inner(InnerMsg.Dec))
+    assert(d.model.inner == 1)
+    assert(d.model.history.size == 4, "1 snapshot + 3 recorded transitions")
+    assert(d.model.history.latest.get.model == 1)
+    assert(d.model.history.latest.get.msg.contains(InnerMsg.Dec))
+
+  test("inner transitions while in Inspect mode are ignored"):
+    val d = driver()
+    d.send(WrapMsg.Toggle)
+    assert(d.model.mode == WrapMode.Inspect)
+    d.send(WrapMsg.Inner(InnerMsg.Inc))
+    assert(d.model.inner == 0, "inner update should be paused")
+    // History size unchanged (still just the initial snapshot).
+    assert(d.model.history.size == 1)
+
+  // --- Key routing --------------------------------------------------------
+
+  test("Live mode forwards Key messages to inner via toInputMsg"):
+    val d = driver()
+    d.send(WrapMsg.Key(InputKey.CharKey('x')))
+    // The wrapped Key turns into InnerMsg.Key('x'), which inner.update
+    // handles by ignoring — but the transition was recorded.
+    assert(d.model.history.size == 2)
+    val last = d.model.history.latest.get
+    assert(last.msg.contains(InnerMsg.Key(InputKey.CharKey('x'))))
+
+  test("Toggle hotkey Ctrl+G flips Live <-> Inspect"):
+    val d = driver()
+    d.send(WrapMsg.Key(InputKey.Ctrl('G')))
+    assert(d.model.mode == WrapMode.Inspect)
+    d.send(WrapMsg.Key(InputKey.Ctrl('G')))
+    assert(d.model.mode == WrapMode.Live)
+
+  test("Entering Inspect parks the cursor on the most recent frame"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(WrapMsg.Inner(InnerMsg.Inc)))
+    d.send(WrapMsg.Toggle)
+    assert(d.model.mode == WrapMode.Inspect)
+    assert(d.model.cursor == 3, s"history size is 4, cursor should park at 3; saw ${d.model.cursor}")
+
+  // --- Inspect mode navigation --------------------------------------------
+
+  test("ArrowUp in Inspect moves cursor backward"):
+    val d = driver()
+    (1 to 3).foreach(_ => d.send(WrapMsg.Inner(InnerMsg.Inc)))
+    d.send(WrapMsg.Toggle) // cursor parks at 3
+    d.send(WrapMsg.Key(InputKey.ArrowUp))
+    assert(d.model.cursor == 2)
+
+  test("Enter in Inspect rewinds inner model to the selected frame's model"):
+    val d = driver()
+    d.send(WrapMsg.Inner(InnerMsg.Inc)) // 1
+    d.send(WrapMsg.Inner(InnerMsg.Inc)) // 2
+    d.send(WrapMsg.Inner(InnerMsg.Inc)) // 3
+    assert(d.model.inner == 3)
+    d.send(WrapMsg.Toggle)
+    // Move cursor back to frame at index 1 (the Inc that produced model=1).
+    d.send(WrapMsg.Key(InputKey.ArrowUp)) // cursor=2
+    d.send(WrapMsg.Key(InputKey.ArrowUp)) // cursor=1
+    d.send(WrapMsg.Key(InputKey.Enter))
+    assert(d.model.mode == WrapMode.Live, "rewind returns to Live")
+    assert(d.model.inner == 1, "inner model restored from the selected frame")
+    assert(d.model.history.size == 2, "history truncated to index 1 (size 2)")
+    assert(d.model.history.latest.get.model == 1)
+
+  test("Post-rewind transitions continue with fresh history indices"):
+    val d = driver()
+    d.send(WrapMsg.Inner(InnerMsg.Inc)) // 1
+    d.send(WrapMsg.Inner(InnerMsg.Inc)) // 2
+    d.send(WrapMsg.Toggle)
+    d.send(WrapMsg.Key(InputKey.ArrowUp)) // cursor=1
+    d.send(WrapMsg.Key(InputKey.Enter))   // rewind to 1
+    assert(d.model.inner == 1)
+    // A new transition after rewind should be recorded with nextIndex = 2.
+    d.send(WrapMsg.Inner(InnerMsg.Dec)) // 0
+    assert(d.model.history.latest.get.index == 2)
+    assert(d.model.history.latest.get.model == 0)
+
+  // --- view pass-through / takeover ---------------------------------------
+
+  test("Live mode view is identical to inner.view"):
+    val d = driver()
+    d.send(WrapMsg.Inner(InnerMsg.Inc))
+    val frame      = d.frame
+    val innerRoot  = innerApp.view(1)
+    val innerFrame = AnsiRenderer.buildFrame(innerRoot)
+    assert(frame.width == innerFrame.width)
+    assert(frame.height == innerFrame.height)
+    val row0Frame = (0 until frame.width).map(c => frame.cells(0)(c).ch).mkString
+    val row0Inner = (0 until innerFrame.width).map(c => innerFrame.cells(0)(c).ch).mkString
+    assert(row0Frame == row0Inner)
+
+  test("Inspect mode view shows the Devtools Panel instead of the inner view"):
+    val d = driver()
+    d.send(WrapMsg.Inner(InnerMsg.Inc))
+    d.send(WrapMsg.Toggle)
+    val frame = d.frame
+    // Top row carries the Devtools title line.
+    val row0 = (0 until frame.width).map(c => frame.cells(0)(c).ch).mkString
+    assert(row0.contains("Devtools"))
+    assert(row0.contains("Enter rewind"))
+    assert(row0.contains("Ctrl+G"))
+    // The count=N string from inner.view should NOT appear.
+    val allChars = (0 until frame.height)
+      .flatMap(r => (0 until frame.width).map(c => frame.cells(r)(c).ch))
+      .mkString
+    assert(!allChars.contains("count="), "inner view must be hidden in Inspect mode")
+
+  // --- startup cmd propagation --------------------------------------------
+
+  test("inner startup Cmd propagates through the wrapper"):
+    // Use an inner app whose init returns Cmd.Exit — the wrapper should
+    // propagate that as the outer startup cmd.
+    val exitingInner: TuiApp[Int, InnerMsg] = new TuiApp[Int, InnerMsg]:
+      override def init(ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg]                          = Tui(0, Cmd.Exit)
+      override def update(m: Int, msg: InnerMsg, ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] = m.tui
+      override def view(m: Int): RootNode                     = RootNode(1, 1, List.empty, None)
+      override def toMsg(input: PromptLine): Result[InnerMsg] = Right(InnerMsg.Inc)
+    val wrapped = Devtools.wrap(exitingInner, toInputMsg = InnerMsg.Key.apply)
+    val d       = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    assert(d.exited, "Cmd.Exit from inner init should terminate the wrapped app")
+
+  // --- capacity ------------------------------------------------------------
+
+  test("history capacity is honoured — older frames are evicted"):
+    val wrapped = Devtools.wrap(innerApp, toInputMsg = InnerMsg.Key.apply, capacity = 3)
+    val d       = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    // Initial snapshot + 5 Inc transitions = 6 frames, retained = 3.
+    (1 to 5).foreach(_ => d.send(WrapMsg.Inner(InnerMsg.Inc)))
+    assert(d.model.history.size == 3)
+    // Oldest frames were evicted; at(0) / at(1) / at(2) now None.
+    assert(d.model.history.at(0).isEmpty)
+    assert(d.model.history.at(2).isEmpty)
+    // The latest retained frames span 3..5 inclusive.
+    assert(d.model.history.frames.map(_.index) == Vector(3, 4, 5))


### PR DESCRIPTION
Closes #99. Final piece of the time-travel debugging work.

**Stacked on #112** (lazy Sub.InputKey) → #111 (Devtools.Panel) → #109 → … Base is \`feature/110-lazy-input-key\`.

## Summary

\`Devtools.wrap(inner, toInputMsg)\` takes any \`TuiApp\` and returns a wrapped one that:

1. Records every inner transition into a \`Devtools.History\` automatically (no app-side integration needed)
2. Listens for a hotkey (default \`Ctrl+G\`, configurable) to toggle Live ↔ Inspect modes
3. In **Live** mode: passes \`inner.view\` through untouched; forwards keys to the inner via the user-supplied \`toInputMsg\` callback
4. In **Inspect** mode: takes over the screen with [\`Devtools.Panel\`](../blob/main/modules/termflow/src/main/scala/termflow/tui/Devtools.scala) as a modal viewer; arrows navigate the history; Enter rewinds the inner model from the selected frame and returns to Live

No app-side integration required beyond supplying \`toInputMsg\` (how to lift a raw \`InputKey\` into the inner's \`Msg\` type — typically one-line).

## Call site

\`\`\`scala
object Counter:
  enum Msg:
    case Inc, Dec
    case Key(k: KeyDecoder.InputKey)
  val App: TuiApp[Int, Msg] = ...

  @main def run(): Unit =
    TuiRuntime.run(Devtools.wrap(App, toInputMsg = Msg.Key.apply))
\`\`\`

## How key interception works (relies on #95 + #110)

The wrapper's \`init\` builds a fake \`RuntimeCtx\` for the inner:

- \`terminal.reader\` is a \`StringReader("")\`, so any inner \`ConsoleKeyPressSource\` hits EOF and stops harmlessly
- \`registerSub\` captures the inner's subs but deliberately **does not** call \`start()\` on them — every inner \`Sub.*\` stays dormant
- \`publish\` forwards inner \`Cmd[Ms]\` to the real ctx, lifted to \`Cmd[WrapMsg[Ms]]\` by \`liftCmd\`

The wrapper then registers its **own** \`Sub.InputKey\` against the real ctx. Keys flow in as \`WrapMsg.Key(k)\`; the routing table:

| Key | Live mode | Inspect mode |
|---|---|---|
| \`toggleKey\` (\`Ctrl+G\`) | → Toggle (enter Inspect) | → Toggle (back to Live) |
| other key | → \`WrapMsg.Inner(toInputMsg(k))\` — runs through \`inner.update\`, transition recorded | → \`Devtools.Panel.handleKey\`; Enter rewinds |

## Rewind semantics

When the user hits Enter on a selected frame in Inspect:

1. \`Panel.handleKey\` returns \`Some(frame.index)\`
2. Wrapper reads the frame's model and replaces the current inner model with it
3. \`History.rewindTo(index)\` truncates all "future" frames and resets \`nextIndex = index + 1\`
4. Mode flips back to Live; cursor clamps

Subsequent transitions are recorded with fresh, monotonically-increasing indices — the timeline branches from the rewind point.

## Known limitations (documented in the ScalaDoc)

Because the fake ctx captures-but-never-starts every inner sub, inner \`Sub.Every\` timers and \`Sub.TerminalResize\` polls are dormant while wrapped. Apps with animated clocks or resize-driven reflows will see those pause. Selective starting of non-input subs is a future follow-up (would need a marker trait on \`Sub.InputKey\` variants or similar type discrimination). Input-driven apps (counters, forms, most apps built from this stack's widget library) work transparently.

## Test plan

- [x] **13 DevtoolsWrapSpec tests**:
  - init seeds history with an initial snapshot; starts in Live mode with the inner's model
  - Live-mode transitions are recorded; Inspect-mode \`WrapMsg.Inner\` is dropped (inner paused)
  - \`WrapMsg.Key\` forwards via \`toInputMsg\` and records the transition (including the raw-key flow)
  - \`Ctrl+G\` toggles mode; entering Inspect parks the cursor on the most recent frame
  - \`ArrowUp\` moves cursor in Inspect; \`Enter\` rewinds inner model, truncates history, and returns to Live
  - Post-rewind transitions continue with fresh history indices (timeline branching)
  - Live-mode view is byte-identical to \`inner.view\`; Inspect-mode view shows the Devtools banner + Panel and **hides** the inner (verified via a substring assertion that \`count=\` never appears)
  - \`Cmd.Exit\` from \`inner.init\` propagates through the wrapper (liftCmd handles Exit)
  - Capacity is honoured — older frames are evicted at the boundary
- [x] \`sbt ciCheck\` green — **445 tests total** (353 termflow + 92 sample)
- [x] \`sbt termflow/doc\` regenerates cleanly

## What this closes out

With this PR, the full ambition described in the original **#99** ticket is delivered:

- ✅ Records every dispatched Msg alongside a Model snapshot
- ✅ Bounded ring buffer with configurable capacity
- ✅ Hotkey-toggled overlay (full-screen takeover in v1 — richer overlaying could come later)
- ✅ Rewind to any retained frame
- ✅ Opt-in at the call site (\`Devtools.wrap\`); zero production overhead for apps that don't wrap

Filed as out-of-scope / future work in the ScalaDoc:
- Replay forward through pre-rewind frames (would need the wrapper to retain the "future" branch)
- Selective sub forwarding (timers resume while wrapped)
- File export beyond \`history.toReport\` (app-side concern today)
- Remote devtools over a socket