### PR TITLE
Forward inner Sub.Every / Sub.TerminalResize through Devtools.wrap (#114)

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/catalog/CatalogDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/catalog/CatalogDemoApp.scala
@@ -178,11 +178,11 @@ object CatalogDemoApp:
           sized.copy(tasks = sized.tasks.withItems(Vector.empty)).tui
 
         case RemoveSelected =>
-          sized.tasks.selectedItem match
-            case None => sized.tui
-            case Some(task) =>
-              val remaining = sized.tasks.items.filterNot(_ == task)
-              sized.copy(tasks = sized.tasks.withItems(remaining)).tui
+          val idx = sized.tasks.selected
+          if idx < 0 || idx >= sized.tasks.items.size then sized.tui
+          else
+            val remaining = sized.tasks.items.patch(idx, Nil, 1)
+            sized.copy(tasks = sized.tasks.withItems(remaining)).tui
 
         case ConsoleInputKey(key) =>
           Globals.lookup(key) match

--- a/modules/termflow-sample/src/test/scala/termflow/apps/catalog/CatalogDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/catalog/CatalogDemoAppSpec.scala
@@ -125,6 +125,17 @@ class CatalogDemoAppSpec extends AnyFunSuite with GoldenSupport:
     d.send(Msg.ConsoleInputKey(InputKey.Enter))
     assert(!d.model.tasks.items.contains(targeted))
 
+  test("Enter on the list removes only the selected row when duplicate tasks exist"):
+    val d = driver()
+    typeKeys(d, "buy groceries")
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    val duplicate = Task("buy groceries", Priority.Medium)
+    assert(d.model.tasks.items.count(_ == duplicate) == 2)
+
+    (1 to 4).foreach(_ => d.send(Msg.NextFocus)) // -> List, selected row 0
+    d.send(Msg.ConsoleInputKey(InputKey.Enter))
+    assert(d.model.tasks.items.count(_ == duplicate) == 1)
+
   // --- globals -------------------------------------------------------------
 
   test("Ctrl+T toggles the theme from anywhere, including inside the Task field"):

--- a/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
@@ -445,10 +445,19 @@ object Devtools:
    *   - `terminal.reader` is an empty `StringReader` so the inner's
    *     `Sub.InputKey` creates a `ConsoleKeyPressSource` that
    *     immediately hits end-of-stream and exits harmlessly.
-   *   - `registerSub` records the inner's subs but never calls
-   *     `start()` on them, so no inner sub (input, timer, or resize)
-   *     actually runs. Relies on the deferred-start contract from
-   *     PR #95 (`Sub.Every`) and PR #110 (`Sub.InputKey`).
+   *   - `registerSub` splits the inner's subs by kind:
+   *     - Any [[Sub.InputSub]] (e.g. the inner's `Sub.InputKey`) is
+   *       captured but never started — the wrapper feeds the inner its
+   *       own input stream so keystrokes can be intercepted for
+   *       time-travel. Relies on the deferred-start contract from
+   *       PR #110 so the reader thread stays dormant.
+   *     - All other subs (`Sub.Every` timers, `Sub.TerminalResize`
+   *       polls, custom event sources) are started immediately, and
+   *       an adapter is registered on the real ctx so they're
+   *       cancelled when the wrapped app exits. Their ticks flow
+   *       through the fake ctx's `publish` and arrive at the wrapper
+   *       as `WrapMsg.Inner(...)` — exactly the shape the outer loop
+   *       expects.
    *   - `publish` forwards inner commands to the real ctx, lifted to
    *     the outer `WrapMsg[Ms]` type.
    *
@@ -461,13 +470,11 @@ object Devtools:
    *   - Else (Inspect) → route to [[Panel.handleKey]]. On Enter, rewind
    *     the inner model from the selected frame and exit Inspect.
    *
-   * ## Known limitations (v1)
-   *
-   * Because the wrapper captures but never starts inner subs, any
-   * `Sub.Every` / `Sub.TerminalResize` registered by the inner stays
-   * dormant. Apps that rely on those (animated clocks, stress demos)
-   * will see their animations pause while wrapped. Selective
-   * forwarding of non-input subs is a future follow-up.
+   * While in Inspect mode the wrapper still receives inner timer and
+   * resize events (the subs keep firing), but discards them — the
+   * model is frozen so the user can scrub history without it
+   * advancing underneath them. Ticks resume flowing into `inner.update`
+   * as soon as the user returns to Live.
    *
    * @param inner       The inner TuiApp to wrap.
    * @param toInputMsg  How to turn a raw `InputKey` into the inner's
@@ -605,8 +612,33 @@ object Devtools:
         override def publish(cmd: Cmd[Ms]): Unit =
           real.publish(liftCmd(cmd))
         override def registerSub(sub: Sub[Ms]): Sub[Ms] =
-          // Capture but do not start — wrapper owns all input flow.
-          sub
+          sub match
+            case _: Sub.InputSub[?] =>
+              // Capture but do not start — wrapper owns input flow and
+              // feeds the inner from its own Sub.InputKey against the
+              // real ctx (see `init`).
+              sub
+            case other =>
+              // Non-input subs (Sub.Every timers, Sub.TerminalResize
+              // polls, custom sources) keep working while wrapped. The
+              // sub was constructed with `sink = fake`, so ticks land
+              // on `fake.publish` which forwards to `real.publish` via
+              // `liftCmd`. Start it eagerly and hand an adapter to the
+              // real ctx so it's cancelled when the wrapped app exits.
+              other.start()
+              real.registerSub(adaptInnerSubForCleanup(other))
+              other
+
+    /**
+     * Wrap a `Sub[Ms]` so the real ctx can take ownership of its
+     * cleanup lifecycle. We only need `cancel` / `isActive` from the
+     * real ctx's perspective — the inner has already been started via
+     * its own `start()`, so the adapter's `start` is a no-op.
+     */
+    private def adaptInnerSubForCleanup(inner: Sub[Ms]): Sub[WrapMsg[Ms]] =
+      new Sub[WrapMsg[Ms]]:
+        override def isActive: Boolean = inner.isActive
+        override def cancel(): Unit    = inner.cancel()
 
     /** Terminal that the inner sees: same dims, real writer, empty reader. */
     private def innerTerminal(real: TerminalBackend): TerminalBackend = new TerminalBackend:

--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -52,6 +52,23 @@ trait Sub[+Msg]:
   def start(): Unit = ()
 
 object Sub:
+
+  /**
+   * Marker for subscriptions whose primary job is delivering keyboard
+   * input to the app.
+   *
+   * Decorators that want to intercept the user's keystrokes (the most
+   * prominent example is [[Devtools.wrap]]) use this marker to tell
+   * input-sources apart from timer-/resize-style subs: the decorator
+   * swallows [[InputSub]]s so it can feed the inner app its own input
+   * stream, while still starting all other subs normally.
+   *
+   * Only [[InputKeyFromSource]] extends this today — apps rarely need
+   * to construct an `InputSub` by hand, but custom key sources may
+   * extend it to opt into the same treatment.
+   */
+  trait InputSub[+Msg] extends Sub[Msg]
+
   private def autoRegisterIfRuntimeCtx[Msg](sub: Sub[Msg], sink: EventSink[Msg]): Sub[Msg] =
     sink match
       case ctx: RuntimeCtx[?] =>
@@ -147,7 +164,7 @@ object Sub:
     onError: Throwable => Msg,
     sink: EventSink[Msg]
   ): Sub[Msg] =
-    val sub = new Sub[Msg]:
+    val sub = new InputSub[Msg]:
       private val lock                     = new Object
       @volatile private var active         = true
       @volatile private var thread: Thread = null

--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -6,6 +6,7 @@ import java.io.Reader
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import scala.util.Failure
+import scala.util.Try
 
 /**
  * A subscription represents a long-running background task that emits messages.
@@ -158,24 +159,28 @@ object Sub:
    * Most apps should prefer [[InputKey]], which uses the runtime context's
    * terminal reader.
    */
-  def InputKeyFromSource[Msg](
-    source: TerminalKeySource,
+  private def inputKeyFromSourceFactory[Msg](
+    sourceFactory: () => TerminalKeySource,
+    closeUnstarted: () => Unit,
     msg: InputKey => Msg,
     onError: Throwable => Msg,
     sink: EventSink[Msg]
   ): Sub[Msg] =
     val sub = new InputSub[Msg]:
-      private val lock                     = new Object
-      @volatile private var active         = true
-      @volatile private var thread: Thread = null
+      private val lock                                = new Object
+      @volatile private var active                    = true
+      @volatile private var source: TerminalKeySource = null
+      @volatile private var thread: Thread            = null
 
       override def start(): Unit =
         lock.synchronized {
           if thread == null && active then
+            val startedSource = sourceFactory()
+            source = startedSource
             thread = ThreadUtils.startThread(() =>
               try
                 while active do
-                  source.next() match
+                  startedSource.next() match
                     case InputRead.Key(key) =>
                       if active then sink.publish(Cmd.GCmd(msg(key)))
                     case InputRead.End =>
@@ -198,9 +203,11 @@ object Sub:
       override def cancel(): Unit =
         lock.synchronized {
           active = false
-          source.close() match
-            case Failure(_) => ()
-            case _          => ()
+          if source == null then closeUnstarted()
+          else
+            source.close() match
+              case Failure(_) => ()
+              case _          => ()
           if thread != null then
             thread.interrupt()
             try thread.join(200L)
@@ -210,6 +217,20 @@ object Sub:
             }
         }
     autoRegisterIfRuntimeCtx(sub, sink)
+
+  def InputKeyFromSource[Msg](
+    source: TerminalKeySource,
+    msg: InputKey => Msg,
+    onError: Throwable => Msg,
+    sink: EventSink[Msg]
+  ): Sub[Msg] =
+    inputKeyFromSourceFactory(
+      sourceFactory = () => source,
+      closeUnstarted = () => { val _ = source.close() },
+      msg = msg,
+      onError = onError,
+      sink = sink
+    )
 
   /**
    * Poll terminal dimensions at a fixed interval and publish a message when
@@ -228,36 +249,48 @@ object Sub:
     ctx: RuntimeCtx[Msg]
   ): Sub[Msg] =
     val sub = new Sub[Msg]:
-      @volatile private var active = true
-      private val scheduler        = Executors.newSingleThreadScheduledExecutor(ThreadUtils.newThreadFactory())
-      @volatile private var w0     = ctx.terminal.width
-      @volatile private var h0     = ctx.terminal.height
+      private val lock                                                               = new Object
+      @volatile private var active                                                   = true
+      @volatile private var scheduler: java.util.concurrent.ScheduledExecutorService = null
+      @volatile private var handle: java.util.concurrent.ScheduledFuture[?]          = null
+      @volatile private var w0                                                       = 0
+      @volatile private var h0                                                       = 0
 
-      private val handle =
-        scheduler.scheduleAtFixedRate(
-          () =>
-            if active then
-              val w = ctx.terminal.width
-              val h = ctx.terminal.height
-              if w != w0 || h != h0 then
-                w0 = w
-                h0 = h
-                ctx.publish(Cmd.GCmd(mkMsg(w, h))),
-          0L,
-          millis,
-          TimeUnit.MILLISECONDS
-        )
+      override def start(): Unit =
+        lock.synchronized {
+          if scheduler == null && active then
+            w0 = ctx.terminal.width
+            h0 = ctx.terminal.height
+            val s = Executors.newSingleThreadScheduledExecutor(ThreadUtils.newThreadFactory())
+            scheduler = s
+            handle = s.scheduleAtFixedRate(
+              () =>
+                if active then
+                  val w = ctx.terminal.width
+                  val h = ctx.terminal.height
+                  if w != w0 || h != h0 then
+                    w0 = w
+                    h0 = h
+                    ctx.publish(Cmd.GCmd(mkMsg(w, h))),
+              0L,
+              millis,
+              TimeUnit.MILLISECONDS
+            )
+        }
 
       override def isActive: Boolean = active
 
       override def cancel(): Unit =
-        active = false
-        handle.cancel(true)
-        scheduler.shutdownNow(): Unit
-        try scheduler.awaitTermination(200L, TimeUnit.MILLISECONDS): Unit
-        catch {
-          case _: InterruptedException =>
-            Thread.currentThread().interrupt()
+        lock.synchronized {
+          active = false
+          if handle != null then handle.cancel(true): Unit
+          if scheduler != null then
+            scheduler.shutdownNow(): Unit
+            try scheduler.awaitTermination(200L, TimeUnit.MILLISECONDS): Unit
+            catch {
+              case _: InterruptedException =>
+                Thread.currentThread().interrupt()
+            }
         }
     ctx.registerSub(sub)
 
@@ -273,7 +306,13 @@ object Sub:
     sink: EventSink[Msg],
     reader: Reader
   ): Sub[Msg] =
-    InputKeyFromSource(ConsoleKeyPressSource(reader), msg, onError, sink)
+    inputKeyFromSourceFactory(
+      sourceFactory = () => ConsoleKeyPressSource(reader),
+      closeUnstarted = () => { val _ = Try(reader.close()) },
+      msg = msg,
+      onError = onError,
+      sink = sink
+    )
 
   /**
    * Create a keyboard-input subscription using the terminal reader from the
@@ -288,7 +327,13 @@ object Sub:
    * }}}
    */
   def InputKey[Msg](msg: InputKey => Msg, onError: Throwable => Msg, ctx: RuntimeCtx[Msg]): Sub[Msg] =
-    InputKeyFromSource(ConsoleKeyPressSource(ctx.terminal.reader), msg, onError, ctx)
+    inputKeyFromSourceFactory(
+      sourceFactory = () => ConsoleKeyPressSource(ctx.terminal.reader),
+      closeUnstarted = () => { val _ = Try(ctx.terminal.reader.close()) },
+      msg = msg,
+      onError = onError,
+      sink = ctx
+    )
 
 /**
  * Sink that receives commands from subscriptions and other asynchronous

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/ListView.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/ListView.scala
@@ -1,7 +1,6 @@
 package termflow.tui.widgets
 
 import termflow.tui.*
-import termflow.tui.TuiPrelude.*
 
 /**
  * Scrollable list of items with a selection cursor.

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Select.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Select.scala
@@ -1,7 +1,6 @@
 package termflow.tui.widgets
 
 import termflow.tui.*
-import termflow.tui.TuiPrelude.*
 
 /**
  * Dropdown picker — a closed "current value" box that expands into a

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/StatusBar.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/StatusBar.scala
@@ -1,7 +1,6 @@
 package termflow.tui.widgets
 
 import termflow.tui.*
-import termflow.tui.TuiPrelude.*
 
 /**
  * Bottom-of-screen status bar with left / center / right sections.

--- a/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
+++ b/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriver.scala
@@ -39,6 +39,7 @@ final class TuiTestDriver[Model, Msg](
   private var _model: Model                              = uninitialized
   private var _initialized: Boolean                      = false
   private var _exited: Boolean                           = false
+  private val pending: mutable.Queue[Cmd[Msg]]           = mutable.Queue.empty
   private val observed: mutable.ArrayBuffer[Cmd[Msg]]    = mutable.ArrayBuffer.empty
   private val errors: mutable.ArrayBuffer[TermFlowError] = mutable.ArrayBuffer.empty
 
@@ -76,8 +77,9 @@ final class TuiTestDriver[Model, Msg](
     val initial = app.init(ctx)
     _model = initial.model
     _initialized = true
-    applyCmd(initial.cmd)
-    drainCtxQueue()
+    enqueueCtxQueue()
+    pending.enqueue(initial.cmd)
+    processPending()
 
   /**
    * Dispatch a message through `app.update` and apply the resulting `Cmd`.
@@ -89,32 +91,38 @@ final class TuiTestDriver[Model, Msg](
   def send(msg: Msg): Unit =
     if !_initialized then throw new IllegalStateException("TuiTestDriver.send() called before init()")
     if _exited then throw new IllegalStateException("TuiTestDriver.send() called after Cmd.Exit")
+    dispatch(msg)
+    processPending()
+
+  private def dispatch(msg: Msg): Unit =
     val next = app.update(_model, msg, ctx)
     _model = next.model
-    applyCmd(next.cmd)
-    drainCtxQueue()
+    enqueueCtxQueue()
+    pending.enqueue(next.cmd)
 
-  private def drainCtxQueue(): Unit =
-    var drained = ctx.drainCmds()
-    while drained.nonEmpty do
-      drained.foreach(applyCmd)
-      drained = ctx.drainCmds()
+  private def enqueueCtxQueue(): Unit =
+    ctx.drainCmds().foreach(pending.enqueue(_))
+
+  private def processPending(): Unit =
+    while pending.nonEmpty && !_exited do applyCmd(pending.dequeue())
 
   private def applyCmd(cmd: Cmd[Msg]): Unit =
     observed += cmd
     cmd match
       case Cmd.NoCmd     => ()
       case Cmd.Exit      => _exited = true
-      case Cmd.GCmd(msg) => send(msg)
+      case Cmd.GCmd(msg) => dispatch(msg)
       case Cmd.TermFlowErrorCmd(e) =>
         errors += e
       case fc: Cmd.FCmd[a, ?] =>
         // Mirror runtime: onEnqueue fires immediately (synchronously), then
         // resolve the future eagerly. Tests must supply Future.successful.
-        fc.onEnqueue.foreach(m => applyCmd(Cmd.GCmd(m).asInstanceOf[Cmd[Msg]]))
+        fc.onEnqueue match
+          case Some(m) => pending.enqueue(Cmd.GCmd(m).asInstanceOf[Cmd[Msg]])
+          case None    => pending.enqueue(Cmd.NoCmd)
         fc.task.value match
           case Some(Success(v)) =>
-            applyCmd(fc.toCmd(v).asInstanceOf[Cmd[Msg]])
+            pending.enqueue(fc.toCmd(v).asInstanceOf[Cmd[Msg]])
           case Some(Failure(e)) =>
             errors += TermFlowError.Unexpected(
               Option(e.getMessage).getOrElse(e.getClass.getSimpleName),

--- a/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriverSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/testkit/TuiTestDriverSpec.scala
@@ -16,6 +16,9 @@ class TuiTestDriverSpec extends AnyFunSuite:
       case Inc
       case Plus(delta: Int)
       case Chain(a: Msg, b: Msg)
+      case AppendDigit(digit: Int)
+      case PublishThenReturn(published: Msg, returned: Msg)
+      case PublishExitThenReturn(returned: Msg)
       case Async(value: Int)
       case AsyncUnresolved
       case ReportError(text: String)
@@ -29,6 +32,14 @@ class TuiTestDriverSpec extends AnyFunSuite:
         case Msg.Inc         => Tui(model + 1)
         case Msg.Plus(d)     => Tui(model + d)
         case Msg.Chain(a, _) => Tui(model, Cmd.GCmd(a))
+        case Msg.AppendDigit(digit) =>
+          Tui(model * 10 + digit)
+        case Msg.PublishThenReturn(published, returned) =>
+          ctx.publish(Cmd.GCmd(published))
+          Tui(model, Cmd.GCmd(returned))
+        case Msg.PublishExitThenReturn(returned) =>
+          ctx.publish(Cmd.Exit)
+          Tui(model, Cmd.GCmd(returned))
         case Msg.Async(v) =>
           Tui(
             model,
@@ -105,6 +116,17 @@ class TuiTestDriverSpec extends AnyFunSuite:
     val d = driver()
     d.send(TinyApp.Msg.Chain(TinyApp.Msg.Plus(3), TinyApp.Msg.Noop))
     assert(d.model == 3)
+
+  test("commands published during update are processed before the returned Cmd"):
+    val d = driver()
+    d.send(TinyApp.Msg.PublishThenReturn(TinyApp.Msg.AppendDigit(1), TinyApp.Msg.AppendDigit(2)))
+    assert(d.model == 12)
+
+  test("Cmd.Exit stops processing queued follow-up commands"):
+    val d = driver()
+    d.send(TinyApp.Msg.PublishExitThenReturn(TinyApp.Msg.AppendDigit(2)))
+    assert(d.exited)
+    assert(d.model == 0)
 
   test("Cmd.FCmd with Future.successful resolves eagerly"):
     val d = driver()

--- a/modules/termflow/src/test/scala/termflow/tui/DevtoolsWrapSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DevtoolsWrapSpec.scala
@@ -198,3 +198,99 @@ class DevtoolsWrapSpec extends AnyFunSuite:
     assert(d.model.history.at(2).isEmpty)
     // The latest retained frames span 3..5 inclusive.
     assert(d.model.history.frames.map(_.index) == Vector(3, 4, 5))
+
+  // --- inner sub forwarding -----------------------------------------------
+
+  /** Test-only sub whose start/cancel flip flags and whose `fire` publishes on demand. */
+  private class RecordingSub[Msg](sink: EventSink[Msg], onTick: () => Msg) extends Sub[Msg]:
+    var started: Boolean           = false
+    var cancelled: Boolean         = false
+    override def isActive: Boolean = started && !cancelled
+    override def cancel(): Unit    = cancelled = true
+    override def start(): Unit     = started = true
+    def fire(): Unit               = sink.publish(Cmd.GCmd(onTick()))
+
+  /** Test-only input sub whose `start` flips a flag. */
+  private class RecordingInputSub[Msg] extends Sub.InputSub[Msg]:
+    var started: Boolean           = false
+    override def isActive: Boolean = false
+    override def cancel(): Unit    = ()
+    override def start(): Unit     = started = true
+
+  private def timerInner(subRef: RecordingSub[InnerMsg] => Unit): TuiApp[Int, InnerMsg] =
+    new TuiApp[Int, InnerMsg]:
+      override def init(ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] =
+        val s = new RecordingSub[InnerMsg](ctx, () => InnerMsg.Inc)
+        ctx.registerSub(s)
+        subRef(s)
+        0.tui
+      override def update(m: Int, msg: InnerMsg, ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] =
+        msg match
+          case InnerMsg.Inc    => (m + 1).tui
+          case InnerMsg.Dec    => (m - 1).tui
+          case InnerMsg.Reset  => 0.tui
+          case InnerMsg.Key(_) => m.tui
+      override def view(m: Int): RootNode                     = RootNode(10, 1, List.empty, None)
+      override def toMsg(input: PromptLine): Result[InnerMsg] = Right(InnerMsg.Inc)
+
+  test("wrapper starts inner non-input subs (e.g. Sub.Every) during init"):
+    var captured: RecordingSub[InnerMsg] = null
+    val wrapped                          = Devtools.wrap(timerInner(s => captured = s), toInputMsg = InnerMsg.Key.apply)
+    val d                                = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    assert(captured != null)
+    assert(captured.started, "wrapper should call start() on inner non-input subs")
+    assert(!captured.cancelled)
+
+  test("inner non-input sub ticks flow through as WrapMsg.Inner while Live"):
+    var captured: RecordingSub[InnerMsg] = null
+    val wrapped                          = Devtools.wrap(timerInner(s => captured = s), toInputMsg = InnerMsg.Key.apply)
+    val d                                = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    assert(d.model.inner == 0)
+    captured.fire() // queues Cmd.GCmd(WrapMsg.Inner(Inc)) on the real ctx
+    // Force a drain via a no-op message (KeyError is ignored by update).
+    d.send(WrapMsg.KeyError(new RuntimeException("drain")))
+    assert(d.model.inner == 1, "timer tick should have advanced the inner model")
+    // And it was recorded into history just like any other transition.
+    assert(d.model.history.size == 2)
+    assert(d.model.history.latest.get.msg.contains(InnerMsg.Inc))
+
+  test("inner non-input sub ticks are discarded while in Inspect mode"):
+    var captured: RecordingSub[InnerMsg] = null
+    val wrapped                          = Devtools.wrap(timerInner(s => captured = s), toInputMsg = InnerMsg.Key.apply)
+    val d                                = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    d.send(WrapMsg.Inner(InnerMsg.Inc)) // model=1
+    d.send(WrapMsg.Toggle)              // enter Inspect
+    captured.fire()                     // queues an Inc — but mode is Inspect
+    d.send(WrapMsg.KeyError(new RuntimeException("drain")))
+    assert(d.model.inner == 1, "ticks during Inspect must not advance the model")
+    assert(d.model.history.size == 2, "no new history frame while Inspect paused")
+
+  test("real ctx cancellation propagates to the inner non-input sub"):
+    var captured: RecordingSub[InnerMsg] = null
+    val wrapped                          = Devtools.wrap(timerInner(s => captured = s), toInputMsg = InnerMsg.Key.apply)
+    val d                                = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    assert(!captured.cancelled)
+    d.ctx.cancelSubs()
+    assert(captured.cancelled, "cancelling via real ctx should cancel the adapted inner sub")
+
+  test("inner Sub.InputSub is captured but never started"):
+    val probe = new RecordingInputSub[InnerMsg]
+    val inputInner: TuiApp[Int, InnerMsg] = new TuiApp[Int, InnerMsg]:
+      override def init(ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] =
+        ctx.registerSub(probe)
+        0.tui
+      override def update(m: Int, msg: InnerMsg, ctx: RuntimeCtx[InnerMsg]): Tui[Int, InnerMsg] = m.tui
+      override def view(m: Int): RootNode                     = RootNode(10, 1, List.empty, None)
+      override def toMsg(input: PromptLine): Result[InnerMsg] = Right(InnerMsg.Inc)
+
+    val wrapped = Devtools.wrap(inputInner, toInputMsg = InnerMsg.Key.apply)
+    val d       = TuiTestDriver(wrapped, width = 20, height = 4)
+    d.init()
+    assert(!probe.started, "wrapper must NOT start an inner Sub.InputSub")
+    // And the real ctx should have exactly one registered sub: the wrapper's own
+    // Sub.InputKey. The inner's InputSub is captured-not-forwarded.
+    assert(d.ctx.registeredSubs.size == 1)

--- a/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
@@ -2,6 +2,10 @@ package termflow.tui
 
 import org.scalatest.funsuite.AnyFunSuite
 
+import java.io.Reader
+import java.io.StringReader
+import java.io.StringWriter
+import java.io.Writer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -183,15 +187,39 @@ class SubSpec extends AnyFunSuite:
   // --- Sub.start() / deferred-start contract --------------------------------
 
   /** Stub RuntimeCtx that records subs but never calls `start()`. */
-  private class CapturingCtx[Msg] extends RuntimeCtx[Msg]:
-    private val captured                              = new java.util.concurrent.ConcurrentLinkedQueue[Cmd[Msg]]()
-    private val subs                                  = new java.util.concurrent.ConcurrentLinkedQueue[Sub[Msg]]()
-    override def terminal: TerminalBackend            = throw new UnsupportedOperationException("not used in test")
+  private class CapturingCtx[Msg](terminalBackend: TerminalBackend = null) extends RuntimeCtx[Msg]:
+    private val captured = new java.util.concurrent.ConcurrentLinkedQueue[Cmd[Msg]]()
+    private val subs     = new java.util.concurrent.ConcurrentLinkedQueue[Sub[Msg]]()
+    override def terminal: TerminalBackend =
+      if terminalBackend == null then throw new UnsupportedOperationException("not used in test")
+      else terminalBackend
     override def config: TermFlowConfig               = throw new UnsupportedOperationException("not used in test")
     override def publish(cmd: Cmd[Msg]): Unit         = captured.add(cmd): Unit
     override def registerSub(sub: Sub[Msg]): Sub[Msg] = { subs.add(sub): Unit; sub }
     def messages: List[Cmd[Msg]]                      = captured.iterator().asScala.toList
     def registered: List[Sub[Msg]]                    = subs.iterator().asScala.toList
+
+  private class CountingReader(script: String = "") extends Reader:
+    private var idx           = 0
+    val reads: AtomicInteger  = new AtomicInteger(0)
+    val closes: AtomicInteger = new AtomicInteger(0)
+    override def read(cbuf: Array[Char], off: Int, len: Int): Int =
+      reads.incrementAndGet(): Unit
+      if idx >= script.length then -1
+      else
+        cbuf(off) = script.charAt(idx)
+        idx += 1
+        1
+    override def close(): Unit =
+      closes.incrementAndGet(): Unit
+
+  final private class MutableTerminal(var currentWidth: Int, var currentHeight: Int) extends TerminalBackend:
+    private val out             = new StringWriter()
+    override def reader: Reader = new StringReader("")
+    override def writer: Writer = out
+    override def width: Int     = currentWidth
+    override def height: Int    = currentHeight
+    override def close(): Unit  = ()
 
   test("Sub.Every does not tick when registered into a RuntimeCtx that omits start()"):
     val ctx = new CapturingCtx[String]
@@ -338,4 +366,48 @@ class SubSpec extends AnyFunSuite:
       assert(sink.awaitFirst(500))
       val msgs = sink.messages.collect { case Cmd.GCmd(v: String) => v }
       assert(msgs.exists(_.startsWith("key:")))
+    finally sub.cancel()
+
+  test("InputKeyWithReader does not construct reader threads until start()"):
+    val ctx    = new CapturingCtx[String]
+    val reader = new CountingReader("a")
+    val sub    = Sub.InputKeyWithReader[String](k => s"key:$k", e => s"err:$e", ctx, reader)
+    assert(ctx.registered == List(sub))
+    Thread.sleep(80)
+    assert(reader.reads.get() == 0, s"reader should be idle before start; saw ${reader.reads.get()} reads")
+
+    sub.start()
+    try
+      val deadline = System.currentTimeMillis() + 1000
+      while ctx.messages.isEmpty && System.currentTimeMillis() < deadline do Thread.sleep(10)
+      assert(reader.reads.get() > 0, "reader should be consumed after start()")
+      val msgs = ctx.messages.collect { case Cmd.GCmd(v: String) => v }
+      assert(msgs.exists(_.startsWith("key:")))
+    finally sub.cancel()
+
+  test("InputKeyWithReader closes its reader when cancelled before start()"):
+    val ctx    = new CapturingCtx[String]
+    val reader = new CountingReader("a")
+    val sub    = Sub.InputKeyWithReader[String](k => s"key:$k", e => s"err:$e", ctx, reader)
+
+    sub.cancel()
+    assert(reader.reads.get() == 0)
+    assert(reader.closes.get() == 1)
+
+  test("Sub.TerminalResize stays dormant until start()"):
+    val terminal = new MutableTerminal(80, 24)
+    val ctx      = new CapturingCtx[String](terminal)
+    val sub      = Sub.TerminalResize[String](20, (w, h) => s"$w:$h", ctx)
+    assert(ctx.registered == List(sub))
+
+    terminal.currentWidth = 81
+    Thread.sleep(80)
+    assert(ctx.messages.isEmpty, s"resize poll should be dormant before start; saw ${ctx.messages}")
+
+    sub.start()
+    try
+      terminal.currentWidth = 82
+      val deadline = System.currentTimeMillis() + 1000
+      while ctx.messages.isEmpty && System.currentTimeMillis() < deadline do Thread.sleep(10)
+      assert(ctx.messages.contains(Cmd.GCmd("82:24")), s"expected resize tick after start; saw ${ctx.messages}")
     finally sub.cancel()

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/ProgressBarSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/ProgressBarSpec.scala
@@ -2,7 +2,6 @@ package termflow.tui.widgets
 
 import org.scalatest.funsuite.AnyFunSuite
 import termflow.tui.*
-import termflow.tui.TuiPrelude.*
 
 class ProgressBarSpec extends AnyFunSuite:
 


### PR DESCRIPTION
## Summary

- Adds `Sub.InputSub[+Msg]` marker trait; `Sub.InputKeyFromSource` extends it.
- `Devtools.wrap` now splits inner sub registrations by kind: input subs stay captured-and-dormant, everything else is started eagerly and adapted onto the real ctx for cleanup.
- Ticks from started inner subs arrive at the outer loop as `WrapMsg.Inner(...)` — routed to `inner.update` in Live mode, discarded in Inspect.
- Follow-up fixes make the deferred-start contract apply to `Sub.InputKey` / `Sub.InputKeyWithReader` and `Sub.TerminalResize`, align `TuiTestDriver` command ordering with the runtime, remove duplicate catalog rows by selected index, and clean up stale unused imports.

## Why

PR #113 froze timers and resize polling while wrapped (documented as a "Known limitations (v1)" bullet at the time). Timer-driven apps (`DigitalClock`, stress demos) now animate correctly when wrapped.

The follow-up fixes close the remaining lifecycle gaps found during review: input readers and resize pollers now stay dormant in capturing/test contexts until `start()`, and test-driver command handling now matches runtime FIFO semantics more closely.

Closes #114.

Stacked on #113.

## Test plan

- [x] `sbt --batch scalafmtAll ciCheck` — 456 tests (363 termflow + 93 sample)
- [x] `./scripts/check_scala3_style.sh`
- [x] `sbt --batch coverageLib` — statement coverage 85.59%, branch coverage 77.41%
- [x] New tests in `DevtoolsWrapSpec`:
  - wrapper starts inner non-input subs during init
  - inner non-input sub ticks flow through as `WrapMsg.Inner` while Live
  - inner non-input sub ticks are discarded while in Inspect mode
  - real ctx cancellation propagates to the inner non-input sub
  - inner `Sub.InputSub` is captured but never started
- [x] New follow-up regression tests:
  - `InputKeyWithReader` does not consume the reader until `start()`
  - `InputKeyWithReader` closes cleanly when cancelled before `start()`
  - `Sub.TerminalResize` stays dormant until `start()`
  - `TuiTestDriver` processes queued commands in runtime FIFO order and stops after `Cmd.Exit`
  - catalog duplicate task removal deletes only the selected row