### PR TITLE
docs: Maven Central badge + sbt usage snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # termflow
 
+[![Maven Central](https://img.shields.io/maven-central/v/org.llm4s/termflow_3.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.llm4s/termflow_3)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://mit-license.org/)
+
 `termflow` is a small, functional terminal UI (TUI) framework for Scala.
 
 It’s designed for building interactive CLIs with a simple architecture:
@@ -36,6 +39,12 @@ We intend to regularly port applicable fixes and critical updates from `main` to
 - `modules/termflow-sample`: demo apps (not published)
 
 ## Quick Start
+
+Add to your build (Scala 3):
+
+```scala
+libraryDependencies += "org.llm4s" %% "termflow" % "0.2.0"
+```
 
 Run a sample app:
 
@@ -74,7 +83,45 @@ debug key sequences and line editing behaviour.
 
 ## Versioning
 
-This repo uses `sbt-dynver` for versioning:
+Versioning is fully driven by git tags via `sbt-dynver`; nothing is hand-edited
+in `build.sbt` or a `version.sbt` file.
 
-- tags like `v0.1.0` produce release versions (`0.1.0`)
-- untagged commits use snapshot versions derived from git metadata
+- A clean checkout of a `vX.Y.Z` tag → version `X.Y.Z` (release).
+- Any commit past the latest tag → `X.Y.Z+<N>-<sha>-SNAPSHOT` (snapshot).
+- No tags reachable → `0.0.0-UNKNOWN` (CI fallback only).
+
+We follow [early SemVer](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html)
+(`versionScheme := "early-semver"`): in `0.y.z`, a minor bump (`0.1.x → 0.2.0`)
+may include breaking changes; patch bumps stay binary-compatible.
+
+### Cutting a release
+
+Releases are published to Maven Central by the `Release` GitHub workflow,
+which fires on any pushed tag matching `v[0-9]*`:
+
+```bash
+git tag v0.2.1
+git push origin v0.2.1
+```
+
+The workflow runs `sbt ci-release`, which:
+
+1. Re-runs CI checks.
+2. Imports the GPG key from `PGP_SECRET` and signs all artifacts.
+3. Stages to the Sonatype Central Portal using `SONATYPE_USERNAME` / `SONATYPE_PASSWORD`
+   (these are the **portal user token** values, not your Sonatype account login).
+4. Releases the staged bundle automatically — no manual “close & release” step.
+
+Artifacts land at `https://repo1.maven.org/maven2/org/llm4s/termflow_3/`
+within a few minutes of the workflow finishing.
+
+### Snapshots
+
+Untagged commits on `main` are not auto-published. If you need a snapshot to
+test downstream, either tag it (`v0.2.1-RC1`) or run `sbt publishLocal` and
+depend on the locally-installed coordinate.
+
+> Note: the legacy `search.maven.org` Solr index is not updated for projects
+> publishing through the new Sonatype Central Portal. Use
+> [central.sonatype.com](https://central.sonatype.com/artifact/org.llm4s/termflow_3)
+> or the raw repo URL above to verify a release.


### PR DESCRIPTION
## Summary
- Add Maven Central + License badges to the top of `README.md`. The Maven badge reads `org.llm4s:termflow_3` metadata from `repo1.maven.org`, so it auto-updates on each release.
- Add an `sbt` `libraryDependencies` snippet under **Quick Start** so consumers can copy a working coordinate.
- Expand the **Versioning** section to document the tag-driven `sbt-dynver` + `sbt ci-release` flow, list required CI secrets, and note that the deprecated `search.maven.org` Solr index does **not** reflect publishes via the Sonatype Central Portal — readers should use `central.sonatype.com` or the raw `repo1.maven.org` URL instead.

Motivated by confusion about whether termflow was actually on Maven Central. It is — versions 0.0.3 through 0.2.0 are live — but the legacy search index never picked them up, so the README needed to point readers at the right places and show how to depend on the library.

## Test plan
- [ ] Verify the Maven Central badge renders the current release version on the GitHub PR preview.
- [ ] Verify the `central.sonatype.com` link in the badge resolves to the artifact page.
- [ ] Confirm the `libraryDependencies` line resolves: `sbt "set libraryDependencies += \"org.llm4s\" %% \"termflow\" % \"0.2.0\"" update` in a scratch project.