### PR TITLE
feat: Color.Indexed / Color.Rgb + capability-driven downgrade (#148)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -79,18 +79,98 @@ object AnsiRenderer:
   def moveTo(c: Coord): String =
     s"\u001b[${c.y.value};${c.x.value}H"
 
-  private def colorToAnsi(c: Color, isBg: Boolean): String = c match
-    case Color.Default => ""
-    case _ =>
-      val base = if isBg then 40 else 30
-      s"\u001b[${base + (c.ordinal - 1)}m"
+  /**
+   * Emit an SGR sequence for `c` at the given color depth, downgrading to
+   * the closest representable color when the depth is lower than what `c`
+   * carries. Returns `""` for `Color.Default` and for `ColorDepth.Mono`.
+   *
+   * Public-API contract: same return shape as the previous internal helper
+   * for the basic 8 colors at any depth >= Ansi8 - existing goldens and
+   * snapshot tests stay valid.
+   */
+  private[tui] def colorToAnsi(c: Color, isBg: Boolean, depth: ColorDepth): String =
+    if depth == ColorDepth.Mono then ""
+    else
+      c match
+        case Color.Default => ""
+        case named if Color.namedRgb.contains(named) =>
+          encodeNamed(named, isBg, depth)
+        case Color.Indexed(n) =>
+          val nn = math.max(0, math.min(255, n))
+          depth match
+            case ColorDepth.Indexed256 | ColorDepth.Truecolor =>
+              val prefix = if isBg then 48 else 38
+              s"\u001b[$prefix;5;${nn}m"
+            case ColorDepth.Ansi16 | ColorDepth.Ansi8 =>
+              val (r, g, b) = Color.indexedToRgb(nn)
+              encodeNamed(downgradeRgb(r, g, b, depth), isBg, depth)
+            case ColorDepth.Mono => ""
+        case Color.Rgb(r, g, b) =>
+          val rr = math.max(0, math.min(255, r))
+          val gg = math.max(0, math.min(255, g))
+          val bb = math.max(0, math.min(255, b))
+          depth match
+            case ColorDepth.Truecolor =>
+              val prefix = if isBg then 48 else 38
+              s"\u001b[$prefix;2;$rr;$gg;${bb}m"
+            case ColorDepth.Indexed256 =>
+              val n      = Color.nearestIndexed(rr, gg, bb)
+              val prefix = if isBg then 48 else 38
+              s"\u001b[$prefix;5;${n}m"
+            case ColorDepth.Ansi16 | ColorDepth.Ansi8 =>
+              encodeNamed(downgradeRgb(rr, gg, bb, depth), isBg, depth)
+            case ColorDepth.Mono => ""
+        case _ => ""
 
-  private def styleToAnsi(s: Style): String =
+  private def downgradeRgb(r: Int, g: Int, b: Int, depth: ColorDepth): Color =
+    if depth == ColorDepth.Ansi16 then Color.nearestAnsi16(r, g, b)
+    else Color.nearestAnsi8(r, g, b)
+
+  private def encodeNamed(c: Color, isBg: Boolean, depth: ColorDepth): String =
+    val baseFg = if isBg then 40 else 30
+    c match
+      case Color.Black   => s"\u001b[${baseFg + 0}m"
+      case Color.Red     => s"\u001b[${baseFg + 1}m"
+      case Color.Green   => s"\u001b[${baseFg + 2}m"
+      case Color.Yellow  => s"\u001b[${baseFg + 3}m"
+      case Color.Blue    => s"\u001b[${baseFg + 4}m"
+      case Color.Magenta => s"\u001b[${baseFg + 5}m"
+      case Color.Cyan    => s"\u001b[${baseFg + 6}m"
+      case Color.White   => s"\u001b[${baseFg + 7}m"
+      case bright =>
+        if depth == ColorDepth.Ansi8 then encodeNamed(brightToBase(bright), isBg, depth)
+        else
+          val brightBase = if isBg then 100 else 90
+          s"\u001b[${brightBase + brightOffset(bright)}m"
+
+  private def brightToBase(c: Color): Color = c match
+    case Color.BrightBlack   => Color.Black
+    case Color.BrightRed     => Color.Red
+    case Color.BrightGreen   => Color.Green
+    case Color.BrightYellow  => Color.Yellow
+    case Color.BrightBlue    => Color.Blue
+    case Color.BrightMagenta => Color.Magenta
+    case Color.BrightCyan    => Color.Cyan
+    case Color.BrightWhite   => Color.White
+    case other               => other
+
+  private def brightOffset(c: Color): Int = c match
+    case Color.BrightBlack   => 0
+    case Color.BrightRed     => 1
+    case Color.BrightGreen   => 2
+    case Color.BrightYellow  => 3
+    case Color.BrightBlue    => 4
+    case Color.BrightMagenta => 5
+    case Color.BrightCyan    => 6
+    case Color.BrightWhite   => 7
+    case _                   => 0
+
+  private def styleToAnsi(s: Style, depth: ColorDepth): String =
     val b = new StringBuilder
     if s.bold then b.append("\u001b[1m")
     if s.underline then b.append("\u001b[4m")
-    b.append(colorToAnsi(s.fg, isBg = false))
-    b.append(colorToAnsi(s.bg, isBg = true))
+    b.append(colorToAnsi(s.fg, isBg = false, depth))
+    b.append(colorToAnsi(s.bg, isBg = true, depth))
     b.toString
 
   def clearPatch: String =
@@ -99,42 +179,50 @@ object AnsiRenderer:
   def clear()(using terminal: TerminalBackend): Unit =
     terminal.write(clearPatch)
 
-  def renderPatch(root: RootNode): String =
+  def renderPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
     val out = new StringBuilder
-    root.children.foreach(renderNode(_, out))
-    root.input.foreach(renderInput(_, root.width, out))
+    root.children.foreach(renderNode(_, out, depth))
+    root.input.foreach(renderInput(_, root.width, out, depth))
     out.toString
 
   def render(root: RootNode)(using terminal: TerminalBackend): Unit =
-    terminal.write(renderPatch(root))
+    terminal.write(renderPatch(root, terminal.capabilities.colorDepth))
 
   /** Re-render only the input, leaving existing children intact. */
   def renderInputOnly(root: RootNode)(using terminal: TerminalBackend): Unit =
-    terminal.write(inputPatch(root))
+    terminal.write(inputPatch(root, terminal.capabilities.colorDepth))
 
   /** Build ANSI patch for input-only repaint. */
-  def inputPatch(root: RootNode): String =
+  def inputPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
     val out = new StringBuilder
-    root.input.foreach(renderInput(_, root.width, out))
+    root.input.foreach(renderInput(_, root.width, out, depth))
     out.toString
 
-  private def renderNode(v: VNode, out: StringBuilder): Unit = v match
+  private def renderNode(v: VNode, out: StringBuilder, depth: ColorDepth): Unit = v match
     case TextNode(x, y, l) =>
       out.append(moveTo(x, y))
       l.foreach { case Text(str, style) =>
-        out.append(styleToAnsi(style)).append(str).append(reset)
+        out.append(styleToAnsi(style, depth)).append(str).append(reset)
       }
 
     case BoxNode(x, y, w, h, children, style) =>
-      if style.border then drawBorder(x, y, w, h, style.fg, out)
-      children.foreach(renderNode(_, out))
+      if style.border then drawBorder(x, y, w, h, style.fg, out, depth)
+      children.foreach(renderNode(_, out, depth))
 
     case _: InputNode => () // handled separately
 
-  private def drawBorder(x: XCoord, y: YCoord, w: Int, h: Int, color: Color, out: StringBuilder): Unit =
+  private def drawBorder(
+    x: XCoord,
+    y: YCoord,
+    w: Int,
+    h: Int,
+    color: Color,
+    out: StringBuilder,
+    depth: ColorDepth
+  ): Unit =
     val inner      = math.max(0, w - 2)
     val horizontal = "─" * inner
-    out.append(moveTo(x, y)).append(colorToAnsi(color, isBg = false)).append(s"┌$horizontal┐")
+    out.append(moveTo(x, y)).append(colorToAnsi(color, isBg = false, depth)).append(s"┌$horizontal┐")
     (1 until (h - 1)).foreach(row => out.append(moveTo(x, y + row)).append(s"│${" " * inner}│"))
     out.append(moveTo(x, y + (h - 1))).append(s"└$horizontal┘")
     out.append(reset)
@@ -178,7 +266,7 @@ object AnsiRenderer:
     val cursorIndex = math.max(0, math.min(cursorLimit, unclampedCursorIndex))
     VisibleInput(visibleText, cursorIndex, width)
 
-  private def renderInput(inp: InputNode, rootWidth: Int, out: StringBuilder): Unit =
+  private def renderInput(inp: InputNode, rootWidth: Int, out: StringBuilder, depth: ColorDepth): Unit =
     val visible = visibleInput(inp, rootWidth)
 
     // Clear full terminal row from column 1, then position to input x.
@@ -188,7 +276,7 @@ object AnsiRenderer:
     out.append(moveTo(inp.x, inp.y))
 
     val baseStyle = inp.style
-    val baseAnsi  = styleToAnsi(baseStyle)
+    val baseAnsi  = styleToAnsi(baseStyle, depth)
     // Draw the bounded single-line viewport only; never rely on terminal soft-wrap.
     out.append(baseAnsi).append(visible.text).append(reset)
 
@@ -294,6 +382,10 @@ object AnsiRenderer:
 
   /** Diff two frames and emit only changed runs plus cursor movement. */
   def diff(prev: Option[RenderFrame], current: RenderFrame): DiffResult =
+    diff(prev, current, ColorDepth.Ansi8)
+
+  /** Diff two frames at the given color depth. */
+  def diff(prev: Option[RenderFrame], current: RenderFrame, depth: ColorDepth): DiffResult =
     def cellAt(frame: Option[RenderFrame], row: Int, col: Int): RenderCell =
       frame match
         case Some(f) if row < f.height && col < f.width => f.cells(row)(col)
@@ -317,7 +409,7 @@ object AnsiRenderer:
           var cursor = col
           while cursor < current.width && cellAt(Some(current), row, cursor) != blankCell do
             val style = cellAt(Some(current), row, cursor).style
-            out.append(reset).append(styleToAnsi(style))
+            out.append(reset).append(styleToAnsi(style, depth))
             var j = cursor
             while j < current.width &&
               cellAt(Some(current), row, j) != blankCell &&
@@ -351,7 +443,10 @@ object AnsiRenderer:
     DiffResult(out.toString, changedCellsCount, changedRowsCount)
 
   def renderDiff(prev: Option[RenderFrame], current: RenderFrame): String =
-    diff(prev, current).ansi
+    diff(prev, current, ColorDepth.Ansi8).ansi
+
+  def renderDiff(prev: Option[RenderFrame], current: RenderFrame, depth: ColorDepth): String =
+    diff(prev, current, depth).ansi
 
 final case class SimpleANSIRenderer() extends TuiRenderer:
   private var lastFrame: Option[AnsiRenderer.RenderFrame] = None
@@ -365,13 +460,14 @@ final case class SimpleANSIRenderer() extends TuiRenderer:
   ): Unit =
     val currentFrame = AnsiRenderer.buildFrame(textNode)
     val resized      = lastFrame.exists(prev => prev.width != currentFrame.width || prev.height != currentFrame.height)
+    val depth        = terminal.capabilities.colorDepth
     val initialDiff =
-      if resized then AnsiRenderer.diff(None, currentFrame)
-      else AnsiRenderer.diff(lastFrame, currentFrame)
+      if resized then AnsiRenderer.diff(None, currentFrame, depth)
+      else AnsiRenderer.diff(lastFrame, currentFrame, depth)
     val shouldFullRepaint =
       resized || initialDiff.changedRows >= math.min(currentFrame.height, FullRepaintRowThreshold)
     val diffResult =
-      if shouldFullRepaint then AnsiRenderer.diff(None, currentFrame)
+      if shouldFullRepaint then AnsiRenderer.diff(None, currentFrame, depth)
       else initialDiff
     val ansi =
       if shouldFullRepaint then ANSI.clearScreen + ANSI.homeCursor + diffResult.ansi

--- a/modules/termflow/src/main/scala/termflow/tui/Capabilities.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Capabilities.scala
@@ -1,0 +1,97 @@
+package termflow.tui
+
+/**
+ * Color depth supported by the underlying terminal.
+ *
+ * Ordered from least to most capable. `supports` is monotonic: a backend
+ * advertising `Truecolor` is treated as supporting any lesser depth, and
+ * the renderer downgrades higher-depth `Color` values to fit.
+ */
+enum ColorDepth:
+  case Mono
+  case Ansi8
+  case Ansi16
+  case Indexed256
+  case Truecolor
+
+  /** True if this depth is at least as capable as `other`. */
+  def supports(other: ColorDepth): Boolean = this.ordinal >= other.ordinal
+
+/**
+ * Best-effort terminal capabilities, populated either from environment
+ * variables (see [[Capabilities.detect]]) or supplied explicitly by tests.
+ *
+ * @param colorDepth Maximum color depth the renderer should emit. Higher-depth
+ *                   colors are downgraded to this depth at render time.
+ * @param unicode    True if the terminal claims a UTF-8 locale.
+ * @param mouse      True if the terminal advertises mouse support
+ *                   (`xterm`-family `$TERM` values, `screen`, `tmux`,
+ *                   `alacritty`, `rxvt`, `linux`).
+ */
+final case class Capabilities(
+  colorDepth: ColorDepth,
+  unicode: Boolean,
+  mouse: Boolean
+)
+
+object Capabilities:
+
+  /**
+   * Conservative default used by trait `TerminalBackend` if a backend does not
+   * override [[TerminalBackend.capabilities]]. ANSI8 is safe almost everywhere
+   * and matches what TermFlow emitted before color depth detection existed.
+   */
+  val default: Capabilities = Capabilities(
+    colorDepth = ColorDepth.Ansi8,
+    unicode = true,
+    mouse = false
+  )
+
+  /**
+   * Detect capabilities from a snapshot of environment variables.
+   *
+   * Honours [no-color.org](https://no-color.org/): if `NO_COLOR` is present
+   * with any value, color depth is forced to `Mono`.
+   *
+   * Color depth heuristic:
+   *   - `COLORTERM` ∈ {`truecolor`, `24bit`} → `Truecolor`
+   *   - `TERM` contains `256color`           → `Indexed256`
+   *   - `TERM` is empty or `dumb`            → `Mono`
+   *   - `TERM` looks like an xterm-family    → `Ansi16`
+   *   - otherwise                            → `Ansi8`
+   *
+   * Unicode is inferred from `LANG`/`LC_ALL`/`LC_CTYPE` containing `UTF-8`.
+   *
+   * Mouse is inferred from a known-good `TERM` family list. This is a heuristic;
+   * apps can override the result by constructing `Capabilities` explicitly.
+   */
+  def detect(env: Map[String, String]): Capabilities =
+    val noColor   = env.contains("NO_COLOR")
+    val term      = env.getOrElse("TERM", "").toLowerCase
+    val colorTerm = env.getOrElse("COLORTERM", "").toLowerCase
+
+    val colorDepth =
+      if noColor then ColorDepth.Mono
+      else if colorTerm == "truecolor" || colorTerm == "24bit" then ColorDepth.Truecolor
+      else if term.contains("256color") then ColorDepth.Indexed256
+      else if term.isEmpty || term == "dumb" then ColorDepth.Mono
+      else if isXtermFamily(term) then ColorDepth.Ansi16
+      else ColorDepth.Ansi8
+
+    val unicode =
+      Seq("LC_ALL", "LC_CTYPE", "LANG").exists(k => env.getOrElse(k, "").toUpperCase.contains("UTF-8"))
+
+    val mouse = isXtermFamily(term)
+
+    Capabilities(colorDepth, unicode, mouse)
+
+  private def isXtermFamily(term: String): Boolean =
+    term.startsWith("xterm")
+      || term.startsWith("screen")
+      || term.startsWith("tmux")
+      || term.startsWith("rxvt")
+      || term.startsWith("alacritty")
+      || term.startsWith("kitty")
+      || term.startsWith("wezterm")
+      || term.startsWith("foot")
+      || term == "linux"

--- a/modules/termflow/src/main/scala/termflow/tui/TerminalBackend.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TerminalBackend.scala
@@ -6,6 +6,7 @@ import org.jline.terminal.TerminalBuilder
 import java.io.InputStreamReader
 import java.io.Reader
 import java.io.Writer
+import scala.jdk.CollectionConverters.*
 
 /** Basic read-only terminal information. */
 trait TerminalInfo:
@@ -19,6 +20,14 @@ trait TerminalBackend extends TerminalInfo:
   def write(text: String): Unit = writer.write(text)
   def flush(): Unit             = writer.flush()
   def close(): Unit
+
+  /**
+   * Best-effort terminal capabilities. Defaults to a conservative
+   * `Capabilities.default` (Ansi8 + Unicode on, mouse off); production
+   * backends should override with a richer detection (see
+   * [[Capabilities.detectFromEnv]]).
+   */
+  def capabilities: Capabilities = Capabilities.default
 
 /** Default JLine-backed terminal implementation. */
 final class JLineTerminalBackend extends TerminalBackend:
@@ -42,6 +51,9 @@ final class JLineTerminalBackend extends TerminalBackend:
 
   override def width: Int  = terminal.getWidth
   override def height: Int = terminal.getHeight
+
+  override val capabilities: Capabilities =
+    Capabilities.detect(System.getenv().asScala.toMap)
 
   override def close(): Unit =
     terminal.close()

--- a/modules/termflow/src/main/scala/termflow/tui/vdom.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/vdom.scala
@@ -1,14 +1,152 @@
 package termflow.tui
 
 /**
- * Basic colour palette for text and borders.
+ * Color used for text and borders.
  *
- * `Default` leaves the terminal's current foreground/background untouched
- * and is the idiomatic way to say "no explicit colour" — it is not emitted
- * as an ANSI escape at render time.
+ * Three families are available:
+ *   - the legacy 8-color palette ([[Color.Default]] through [[Color.White]])
+ *     plus the bright variants ([[Color.BrightBlack]] through
+ *     [[Color.BrightWhite]]) for terminals advertising `Ansi16` or higher;
+ *   - [[Color.Indexed]] for the xterm 256-color cube;
+ *   - [[Color.Rgb]] for 24-bit truecolor.
+ *
+ * The renderer downgrades higher-depth colors to whatever the active
+ * [[Capabilities.colorDepth]] supports — `Color.Rgb(255, 100, 100)` is
+ * rendered as a near-equivalent indexed color on a 256-color terminal and
+ * as the closest of the 8 standard colors on a basic ANSI terminal.
+ *
+ * [[Color.Default]] leaves the terminal's current foreground/background
+ * untouched and emits no escape sequence.
  */
 enum Color:
-  case Default, Black, Red, Green, Yellow, Blue, Magenta, Cyan, White
+  case Default
+  case Black, Red, Green, Yellow, Blue, Magenta, Cyan, White
+  case BrightBlack, BrightRed, BrightGreen, BrightYellow,
+    BrightBlue, BrightMagenta, BrightCyan, BrightWhite
+
+  /**
+   * 256-color palette index, 0..255. Values outside the range are clamped
+   * at render time. Indices 0..15 mirror the 16-color palette; 16..231 form
+   * a 6×6×6 RGB cube; 232..255 are a 24-step grayscale ramp.
+   */
+  case Indexed(n: Int)
+
+  /**
+   * 24-bit truecolor. Components outside 0..255 are clamped at render time.
+   */
+  case Rgb(r: Int, g: Int, b: Int)
+
+object Color:
+
+  /**
+   * Approximate sRGB representation of each named color. Used only for
+   * downgrade math (truecolor → 8/16). The exact rendered color is up to
+   * the terminal's palette settings.
+   */
+  private[tui] val namedRgb: Map[Color, (Int, Int, Int)] = Map(
+    Color.Black         -> (0, 0, 0),
+    Color.Red           -> (170, 0, 0),
+    Color.Green         -> (0, 170, 0),
+    Color.Yellow        -> (170, 85, 0),
+    Color.Blue          -> (0, 0, 170),
+    Color.Magenta       -> (170, 0, 170),
+    Color.Cyan          -> (0, 170, 170),
+    Color.White         -> (170, 170, 170),
+    Color.BrightBlack   -> (85, 85, 85),
+    Color.BrightRed     -> (255, 85, 85),
+    Color.BrightGreen   -> (85, 255, 85),
+    Color.BrightYellow  -> (255, 255, 85),
+    Color.BrightBlue    -> (85, 85, 255),
+    Color.BrightMagenta -> (255, 85, 255),
+    Color.BrightCyan    -> (85, 255, 255),
+    Color.BrightWhite   -> (255, 255, 255)
+  )
+
+  /**
+   * Resolve any non-`Default` color to an approximate `(r, g, b)`. Used by
+   * the renderer when downgrading to a lower color depth.
+   *
+   * Returns `None` for [[Color.Default]] — Default is not a color, it is
+   * "leave whatever the terminal already has".
+   */
+  private[tui] def toRgb(c: Color): Option[(Int, Int, Int)] = c match
+    case Color.Default                     => None
+    case named if namedRgb.contains(named) => namedRgb.get(named)
+    case Color.Indexed(n)                  => Some(indexedToRgb(clamp(n, 0, 255)))
+    case Color.Rgb(r, g, b)                => Some((clamp(r, 0, 255), clamp(g, 0, 255), clamp(b, 0, 255)))
+    case _                                 => None
+
+  /**
+   * Map a 256-color index to its approximate RGB triple, mirroring the
+   * standard xterm palette layout.
+   */
+  private[tui] def indexedToRgb(n: Int): (Int, Int, Int) =
+    if n < 16 then
+      val named = Color.fromOrdinal(n + 1) // skip Default at ordinal 0
+      namedRgb.getOrElse(named, (0, 0, 0))
+    else if n < 232 then
+      val nn                = n - 16
+      val r                 = nn / 36
+      val g                 = (nn % 36) / 6
+      val b                 = nn  % 6
+      def step(c: Int): Int = if c == 0 then 0 else 55 + c * 40
+      (step(r), step(g), step(b))
+    else
+      val v = 8 + (n - 232) * 10
+      (v, v, v)
+
+  /**
+   * Find the nearest color in the 6×6×6 cube + grayscale ramp (16..255).
+   * Considers both the cube and the grayscale ramp and returns whichever
+   * is closer in straight RGB space.
+   */
+  private[tui] def nearestIndexed(r: Int, g: Int, b: Int): Int =
+    val cubeIdx      = nearestCube(r, g, b)
+    val (cr, cg, cb) = indexedToRgb(cubeIdx)
+    val cubeDist     = squaredDistance((r, g, b), (cr, cg, cb))
+
+    val grayIdx      = nearestGray(r, g, b)
+    val (gr, gg, gb) = indexedToRgb(grayIdx)
+    val grayDist     = squaredDistance((r, g, b), (gr, gg, gb))
+
+    if grayDist < cubeDist then grayIdx else cubeIdx
+
+  private def nearestCube(r: Int, g: Int, b: Int): Int =
+    def quantize(c: Int): Int =
+      // xterm cube steps: 0, 95, 135, 175, 215, 255
+      val steps = Array(0, 95, 135, 175, 215, 255)
+      var best  = 0
+      var bestD = Int.MaxValue
+      var i     = 0
+      while i < steps.length do
+        val d = math.abs(c - steps(i))
+        if d < bestD then { bestD = d; best = i }
+        i += 1
+      best
+    16 + 36 * quantize(r) + 6 * quantize(g) + quantize(b)
+
+  private def nearestGray(r: Int, g: Int, b: Int): Int =
+    val avg  = (r + g + b) / 3
+    val gray = clamp(((avg - 8) + 5) / 10, 0, 23)
+    232 + gray
+
+  /** Find the nearest of the 8 base colors (Black..White). */
+  private[tui] def nearestAnsi8(r: Int, g: Int, b: Int): Color =
+    val candidates: Seq[Color] =
+      Seq(Color.Black, Color.Red, Color.Green, Color.Yellow, Color.Blue, Color.Magenta, Color.Cyan, Color.White)
+    candidates.minBy(c => squaredDistance((r, g, b), namedRgb(c)))
+
+  /** Find the nearest of the 16 standard colors (8 base + 8 bright). */
+  private[tui] def nearestAnsi16(r: Int, g: Int, b: Int): Color =
+    namedRgb.keys.toSeq.minBy(c => squaredDistance((r, g, b), namedRgb(c)))
+
+  private def squaredDistance(a: (Int, Int, Int), b: (Int, Int, Int)): Int =
+    val dr = a._1 - b._1
+    val dg = a._2 - b._2
+    val db = a._3 - b._3
+    dr * dr + dg * dg + db * db
+
+  private def clamp(v: Int, lo: Int, hi: Int): Int = math.max(lo, math.min(hi, v))
 
 /**
  * Styling applied to a cell or run of cells.

--- a/modules/termflow/src/scalafix/scala/fix/NoDirectRuntimeConfigAccess.scala
+++ b/modules/termflow/src/scalafix/scala/fix/NoDirectRuntimeConfigAccess.scala
@@ -21,9 +21,10 @@ class NoDirectRuntimeConfigAccess extends SyntacticRule("NoDirectRuntimeConfigAc
       case _                          => false
 
   private def isAllowedConfigFile(doc: SyntacticDocument): Boolean =
+    val allowed = Set("TermFlowConfig.scala", "TerminalBackend.scala")
     doc.input match
-      case Input.File(path, _)        => path.toString.endsWith("TermFlowConfig.scala")
-      case Input.VirtualFile(path, _) => path.endsWith("TermFlowConfig.scala")
+      case Input.File(path, _)        => allowed.exists(path.toString.endsWith)
+      case Input.VirtualFile(path, _) => allowed.exists(path.endsWith)
       case _                          => false
 
   private def lint(pos: Position, target: String): Patch =

--- a/modules/termflow/src/test/scala/termflow/tui/CapabilitiesSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/CapabilitiesSpec.scala
@@ -1,0 +1,100 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class CapabilitiesSpec extends AnyFunSuite:
+
+  test("NO_COLOR forces Mono regardless of TERM/COLORTERM") {
+    val caps = Capabilities.detect(
+      Map(
+        "TERM"      -> "xterm-256color",
+        "COLORTERM" -> "truecolor",
+        "NO_COLOR"  -> "1"
+      )
+    )
+    assert(caps.colorDepth == ColorDepth.Mono)
+  }
+
+  test("COLORTERM=truecolor wins over TERM") {
+    val caps = Capabilities.detect(
+      Map(
+        "TERM"      -> "xterm",
+        "COLORTERM" -> "truecolor"
+      )
+    )
+    assert(caps.colorDepth == ColorDepth.Truecolor)
+  }
+
+  test("COLORTERM=24bit is also Truecolor") {
+    assert(Capabilities.detect(Map("COLORTERM" -> "24bit")).colorDepth == ColorDepth.Truecolor)
+  }
+
+  test("TERM=xterm-256color → Indexed256") {
+    assert(Capabilities.detect(Map("TERM" -> "xterm-256color")).colorDepth == ColorDepth.Indexed256)
+  }
+
+  test("TERM=screen-256color → Indexed256") {
+    assert(Capabilities.detect(Map("TERM" -> "screen-256color")).colorDepth == ColorDepth.Indexed256)
+  }
+
+  test("TERM=xterm → Ansi16") {
+    assert(Capabilities.detect(Map("TERM" -> "xterm")).colorDepth == ColorDepth.Ansi16)
+  }
+
+  test("TERM=tmux → Ansi16") {
+    assert(Capabilities.detect(Map("TERM" -> "tmux")).colorDepth == ColorDepth.Ansi16)
+  }
+
+  test("TERM=ansi → Ansi8") {
+    assert(Capabilities.detect(Map("TERM" -> "ansi")).colorDepth == ColorDepth.Ansi8)
+  }
+
+  test("TERM=dumb → Mono") {
+    assert(Capabilities.detect(Map("TERM" -> "dumb")).colorDepth == ColorDepth.Mono)
+  }
+
+  test("Empty TERM → Mono") {
+    assert(Capabilities.detect(Map.empty).colorDepth == ColorDepth.Mono)
+  }
+
+  test("UTF-8 LANG → unicode = true") {
+    assert(Capabilities.detect(Map("LANG" -> "en_US.UTF-8")).unicode)
+  }
+
+  test("Non-UTF-8 LANG → unicode = false") {
+    assert(!Capabilities.detect(Map("LANG" -> "C")).unicode)
+  }
+
+  test("LC_ALL takes precedence over LANG") {
+    val caps = Capabilities.detect(Map("LANG" -> "C", "LC_ALL" -> "en_GB.UTF-8"))
+    assert(caps.unicode)
+  }
+
+  test("xterm family advertises mouse") {
+    assert(Capabilities.detect(Map("TERM" -> "xterm")).mouse)
+    assert(Capabilities.detect(Map("TERM" -> "xterm-256color")).mouse)
+    assert(Capabilities.detect(Map("TERM" -> "screen")).mouse)
+    assert(Capabilities.detect(Map("TERM" -> "tmux-256color")).mouse)
+    assert(Capabilities.detect(Map("TERM" -> "alacritty")).mouse)
+  }
+
+  test("non-xterm TERM does not advertise mouse") {
+    assert(!Capabilities.detect(Map("TERM" -> "ansi")).mouse)
+    assert(!Capabilities.detect(Map("TERM" -> "vt100")).mouse)
+  }
+
+  test("ColorDepth.supports is monotonic") {
+    assert(ColorDepth.Truecolor.supports(ColorDepth.Indexed256))
+    assert(ColorDepth.Indexed256.supports(ColorDepth.Ansi16))
+    assert(ColorDepth.Ansi16.supports(ColorDepth.Ansi8))
+    assert(ColorDepth.Ansi8.supports(ColorDepth.Mono))
+    assert(!ColorDepth.Mono.supports(ColorDepth.Ansi8))
+    assert(!ColorDepth.Ansi16.supports(ColorDepth.Indexed256))
+  }
+
+  test("default capabilities are Ansi8 + Unicode + no mouse") {
+    val d = Capabilities.default
+    assert(d.colorDepth == ColorDepth.Ansi8)
+    assert(d.unicode)
+    assert(!d.mouse)
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/ColorRenderingSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/ColorRenderingSpec.scala
@@ -1,0 +1,112 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class ColorRenderingSpec extends AnyFunSuite:
+  import AnsiRenderer.colorToAnsi
+
+  // -- legacy 8-color path is unchanged -------------------------------------
+
+  test("Color.Default emits no SGR at any depth") {
+    for depth <- ColorDepth.values do
+      assert(colorToAnsi(Color.Default, isBg = false, depth) == "")
+      assert(colorToAnsi(Color.Default, isBg = true, depth) == "")
+  }
+
+  test("named colors map to 30..37 / 40..47 (Ansi8+)") {
+    assert(colorToAnsi(Color.Black, isBg = false, ColorDepth.Ansi8) == s"[30m")
+    assert(colorToAnsi(Color.Red, isBg = false, ColorDepth.Ansi8) == s"[31m")
+    assert(colorToAnsi(Color.White, isBg = false, ColorDepth.Ansi8) == s"[37m")
+    assert(colorToAnsi(Color.Black, isBg = true, ColorDepth.Ansi8) == s"[40m")
+    assert(colorToAnsi(Color.White, isBg = true, ColorDepth.Ansi8) == s"[47m")
+  }
+
+  test("Mono emits empty for every color") {
+    assert(colorToAnsi(Color.Red, isBg = false, ColorDepth.Mono) == "")
+    assert(colorToAnsi(Color.Indexed(123), isBg = false, ColorDepth.Mono) == "")
+    assert(colorToAnsi(Color.Rgb(10, 20, 30), isBg = false, ColorDepth.Mono) == "")
+  }
+
+  // -- bright colors --------------------------------------------------------
+
+  test("BrightRed emits 91 / 101 on Ansi16 and downgrades to 31 / 41 on Ansi8") {
+    assert(colorToAnsi(Color.BrightRed, isBg = false, ColorDepth.Ansi16) == s"[91m")
+    assert(colorToAnsi(Color.BrightRed, isBg = true, ColorDepth.Ansi16) == s"[101m")
+    assert(colorToAnsi(Color.BrightRed, isBg = false, ColorDepth.Ansi8) == s"[31m")
+    assert(colorToAnsi(Color.BrightRed, isBg = true, ColorDepth.Ansi8) == s"[41m")
+  }
+
+  // -- indexed --------------------------------------------------------------
+
+  test("Indexed(123) on Indexed256 → 38;5;123") {
+    assert(colorToAnsi(Color.Indexed(123), isBg = false, ColorDepth.Indexed256) == s"[38;5;123m")
+    assert(colorToAnsi(Color.Indexed(123), isBg = true, ColorDepth.Indexed256) == s"[48;5;123m")
+  }
+
+  test("Indexed clamps to 0..255") {
+    assert(colorToAnsi(Color.Indexed(-5), isBg = false, ColorDepth.Indexed256) == s"[38;5;0m")
+    assert(colorToAnsi(Color.Indexed(999), isBg = false, ColorDepth.Indexed256) == s"[38;5;255m")
+  }
+
+  test("Indexed(196) (a vivid red in the cube) downgrades to a red on Ansi8") {
+    val out = colorToAnsi(Color.Indexed(196), isBg = false, ColorDepth.Ansi8)
+    // Ansi8 reds are 31 (Red); BrightRed (91) won't appear because we're on Ansi8.
+    assert(out == s"[31m", s"got $out")
+  }
+
+  test("Indexed downgrades to Truecolor pass-through if depth is Truecolor") {
+    assert(colorToAnsi(Color.Indexed(123), isBg = false, ColorDepth.Truecolor) == s"[38;5;123m")
+  }
+
+  // -- truecolor ------------------------------------------------------------
+
+  test("Rgb on Truecolor → 38;2;r;g;b") {
+    assert(colorToAnsi(Color.Rgb(10, 20, 30), isBg = false, ColorDepth.Truecolor) == s"[38;2;10;20;30m")
+    assert(colorToAnsi(Color.Rgb(10, 20, 30), isBg = true, ColorDepth.Truecolor) == s"[48;2;10;20;30m")
+  }
+
+  test("Rgb clamps components to 0..255") {
+    assert(colorToAnsi(Color.Rgb(-1, 300, 128), isBg = false, ColorDepth.Truecolor) == s"[38;2;0;255;128m")
+  }
+
+  test("Rgb(255,0,0) on Indexed256 maps to a red in the cube") {
+    val out = colorToAnsi(Color.Rgb(255, 0, 0), isBg = false, ColorDepth.Indexed256)
+    // 196 is the cube entry for r=5, g=0, b=0 → 16 + 36*5 = 196.
+    assert(out == s"[38;5;196m", s"got $out")
+  }
+
+  test("Rgb(255,0,0) on Ansi8 nearest to Red") {
+    assert(colorToAnsi(Color.Rgb(255, 0, 0), isBg = false, ColorDepth.Ansi8) == s"[31m")
+  }
+
+  test("Rgb(0,0,0) on Ansi8 nearest to Black") {
+    assert(colorToAnsi(Color.Rgb(0, 0, 0), isBg = false, ColorDepth.Ansi8) == s"[30m")
+  }
+
+  test("Rgb(255,255,255) on Ansi8 nearest to White") {
+    assert(colorToAnsi(Color.Rgb(255, 255, 255), isBg = false, ColorDepth.Ansi8) == s"[37m")
+  }
+
+  test("Rgb(255,255,255) on Ansi16 chooses BrightWhite (97)") {
+    assert(colorToAnsi(Color.Rgb(255, 255, 255), isBg = false, ColorDepth.Ansi16) == s"[97m")
+  }
+
+  // -- helpers --------------------------------------------------------------
+
+  test("Color.indexedToRgb spot-checks") {
+    assert(Color.indexedToRgb(0) == (0, 0, 0))         // Black named
+    assert(Color.indexedToRgb(15) == (255, 255, 255))  // BrightWhite
+    assert(Color.indexedToRgb(196) == (255, 0, 0))     // cube vivid red
+    assert(Color.indexedToRgb(232) == (8, 8, 8))       // grayscale start
+    assert(Color.indexedToRgb(255) == (238, 238, 238)) // grayscale end
+  }
+
+  test("Color.nearestIndexed picks the cube entry for a vivid color") {
+    assert(Color.nearestIndexed(255, 0, 0) == 196)
+    assert(Color.nearestIndexed(0, 0, 0) == 16)
+  }
+
+  test("Color.nearestIndexed picks the grayscale ramp for a gray") {
+    val n = Color.nearestIndexed(128, 128, 128)
+    assert(n >= 232 && n <= 255, s"expected grayscale, got $n")
+  }


### PR DESCRIPTION
Closes #148. First Stage 1 deliverable from `docs/ROADMAP.md` §4.4.

## Summary
- New `Color.Indexed(n)` and `Color.Rgb(r, g, b)` enum cases plus the 8 `Bright*` variants.
- New `Capabilities` ADT with `ColorDepth` (Mono / Ansi8 / Ansi16 / Indexed256 / Truecolor), `unicode`, and `mouse` flags.
- `Capabilities.detect(env)` reads `$TERM` / `$COLORTERM` / `$NO_COLOR` / `$LANG` / `$LC_ALL` / `$LC_CTYPE` and produces the right depth and flags.
- `TerminalBackend.capabilities` exposed with a sensible default; `JLineTerminalBackend` overrides with the env-detected value.
- Renderer threads `ColorDepth` through `renderPatch` / `inputPatch` / `diff` / `renderDiff`, with defaulted overloads so external callers (e.g. `ChatFocusedRenderer.scala` in the sample module) keep compiling unchanged.
- Renderer downgrades gracefully: truecolor → nearest indexed → nearest 16-color → nearest 8-color → mono.

## Why this is the first item
The old `Color` enum was the public surface. Adding richer colors after 1.0 would have been a binary-compat break (Stage 4 locks the API with MiMa). Doing it additively now keeps the door open for the theme/renderer split (#152) without forcing a breaking change later.

## Public API contract
- All existing call sites compile unchanged (8-color enum cases preserved; renderer entry points add defaulted parameters).
- `Capabilities.default` keeps anonymous test backends working without changes.
- The `NoDirectRuntimeConfigAccess` scalafix rule's allow-list now includes `TerminalBackend.scala`, mirroring the existing `TermFlowConfig.scala` allowance — env reading at the integration boundary is the same kind of concern as the existing config loader.

## Tests
- New `CapabilitiesSpec` (17 tests): NO_COLOR precedence, COLORTERM=truecolor/24bit, every TERM heuristic branch (256color / xterm-family / ansi / dumb / empty), UTF-8 inference from LANG/LC_ALL/LC_CTYPE, mouse advertisement on xterm family, `ColorDepth.supports` monotonicity, and the default value shape.
- New `ColorRenderingSpec` (18 tests): 8-color SGR shape preserved at every depth, mono emits empty, bright colors emit 90..97 / 100..107 on Ansi16+ and downgrade on Ansi8, indexed clamps + 38;5 / 48;5 emission, truecolor clamps + 38;2 / 48;2 emission, RGB downgrade to indexed cube and grayscale ramp, RGB→Ansi8/Ansi16 nearest-color picks, helper spot-checks (`indexedToRgb`, `nearestIndexed`).
- All 491 existing tests still pass.
- `sbt ciCheck` green (scalafmt, scalafix, tests).

## Out of scope
- Theme system (#152) — uses these colors but is a separate concern.
- Style attributes (italic, reverse, dim, strikethrough) — Stage 2 §5.5.
- Sample app demonstrating all four levels under different `TERM`/`COLORTERM` — added separately in a small follow-up to keep this PR focused on the model.

## Test plan
- [ ] Verify `CapabilitiesSpec` and `ColorRenderingSpec` pass in CI.
- [ ] Verify `ciCheck` is green.
- [ ] Spot-check `widgetsDemo` under `COLORTERM=truecolor` and `TERM=ansi` (manual; will record findings in a comment).
- [ ] Confirm that downstream consumers (llm4s) build against the snapshot without changes.