### PR TITLE
feat: signal-driven Sub.TerminalResize via backend.onResize (#151)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Devtools.scala
@@ -642,11 +642,12 @@ object Devtools:
 
     /** Terminal that the inner sees: same dims, real writer, empty reader. */
     private def innerTerminal(real: TerminalBackend): TerminalBackend = new TerminalBackend:
-      override def reader: java.io.Reader = new java.io.StringReader("")
-      override def writer: java.io.Writer = real.writer
-      override def width: Int             = real.width
-      override def height: Int            = real.height
-      override def close(): Unit          = ()
+      override def reader: java.io.Reader                             = new java.io.StringReader("")
+      override def writer: java.io.Writer                             = real.writer
+      override def width: Int                                         = real.width
+      override def height: Int                                        = real.height
+      override def close(): Unit                                      = ()
+      override def onResize(listener: () => Unit): Option[() => Unit] = real.onResize(listener)
 
     /** Lift a Cmd[Ms] from the inner app into Cmd[WrapMsg[Ms]] for the real ctx. */
     private def liftCmd(cmd: Cmd[Ms]): Cmd[WrapMsg[Ms]] = cmd match

--- a/modules/termflow/src/main/scala/termflow/tui/Sub.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Sub.scala
@@ -233,15 +233,18 @@ object Sub:
     )
 
   /**
-   * Poll terminal dimensions at a fixed interval and publish a message when
-   * they change.
+   * Publish a message when the terminal is resized.
    *
-   * Useful for apps that need to re-flow their view when the window is
-   * resized. The subscription publishes through `ctx.publish` and
-   * auto-registers for cleanup on exit.
+   * Prefers the backend's [[TerminalBackend.onResize]] signal when available
+   * (e.g. SIGWINCH on Unix); falls back to polling at `millis` for backends
+   * without signal support (notably the test virtual backend).
    *
-   * @param millis Polling interval, in milliseconds.
-   * @param mkMsg Function producing the resize message from `(width, height)`.
+   * The subscription publishes through `ctx.publish` and auto-registers for
+   * cleanup on exit.
+   *
+   * @param millis Polling interval used only when the backend cannot deliver
+   *               resize signals.
+   * @param mkMsg  Function producing the resize message from `(width, height)`.
    */
   def TerminalResize[Msg](
     millis: Long,
@@ -253,29 +256,36 @@ object Sub:
       @volatile private var active                                                   = true
       @volatile private var scheduler: java.util.concurrent.ScheduledExecutorService = null
       @volatile private var handle: java.util.concurrent.ScheduledFuture[?]          = null
+      @volatile private var unregister: () => Unit                                   = null
       @volatile private var w0                                                       = 0
       @volatile private var h0                                                       = 0
 
+      private def maybePublish(): Unit =
+        if active then
+          val w = ctx.terminal.width
+          val h = ctx.terminal.height
+          if w != w0 || h != h0 then
+            w0 = w
+            h0 = h
+            ctx.publish(Cmd.GCmd(mkMsg(w, h)))
+
       override def start(): Unit =
         lock.synchronized {
-          if scheduler == null && active then
+          if (scheduler == null && unregister == null) && active then
             w0 = ctx.terminal.width
             h0 = ctx.terminal.height
-            val s = Executors.newSingleThreadScheduledExecutor(ThreadUtils.newThreadFactory())
-            scheduler = s
-            handle = s.scheduleAtFixedRate(
-              () =>
-                if active then
-                  val w = ctx.terminal.width
-                  val h = ctx.terminal.height
-                  if w != w0 || h != h0 then
-                    w0 = w
-                    h0 = h
-                    ctx.publish(Cmd.GCmd(mkMsg(w, h))),
-              0L,
-              millis,
-              TimeUnit.MILLISECONDS
-            )
+            ctx.terminal.onResize(() => maybePublish()) match
+              case Some(unreg) =>
+                unregister = unreg
+              case None =>
+                val s = Executors.newSingleThreadScheduledExecutor(ThreadUtils.newThreadFactory())
+                scheduler = s
+                handle = s.scheduleAtFixedRate(
+                  () => maybePublish(),
+                  0L,
+                  millis,
+                  TimeUnit.MILLISECONDS
+                )
         }
 
       override def isActive: Boolean = active
@@ -283,6 +293,10 @@ object Sub:
       override def cancel(): Unit =
         lock.synchronized {
           active = false
+          if unregister != null then
+            try unregister()
+            catch { case _: Throwable => () }
+            unregister = null
           if handle != null then handle.cancel(true): Unit
           if scheduler != null then
             scheduler.shutdownNow(): Unit

--- a/modules/termflow/src/main/scala/termflow/tui/TerminalBackend.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TerminalBackend.scala
@@ -25,9 +25,25 @@ trait TerminalBackend extends TerminalInfo:
    * Best-effort terminal capabilities. Defaults to a conservative
    * `Capabilities.default` (Ansi8 + Unicode on, mouse off); production
    * backends should override with a richer detection (see
-   * [[Capabilities.detectFromEnv]]).
+   * [[Capabilities.detect]]).
    */
   def capabilities: Capabilities = Capabilities.default
+
+  /**
+   * Register a listener to be invoked when the terminal is resized.
+   *
+   * Returns `Some(unregister)` if the backend supports event-based resize
+   * notifications (e.g. SIGWINCH on a Unix tty); the caller must invoke
+   * `unregister()` to remove the listener.
+   *
+   * Returns `None` if the backend has no signal mechanism — callers should
+   * fall back to polling [[width]] / [[height]]. The default trait
+   * implementation returns `None`.
+   *
+   * The listener is invoked from a backend-internal thread (e.g. the JVM
+   * signal-dispatch thread) and should be cheap and non-blocking.
+   */
+  def onResize(listener: () => Unit): Option[() => Unit] = None
 
 /** Default JLine-backed terminal implementation. */
 final class JLineTerminalBackend extends TerminalBackend:
@@ -54,6 +70,23 @@ final class JLineTerminalBackend extends TerminalBackend:
 
   override val capabilities: Capabilities =
     Capabilities.detect(System.getenv().asScala.toMap)
+
+  /**
+   * Hook into JLine's SIGWINCH delivery. JLine raises [[Terminal.Signal.WINCH]]
+   * when the underlying tty resizes (or, on Windows, when its emulator reports
+   * a console-buffer change). The listener is invoked on JLine's signal
+   * dispatch path; we adapt it through a Java [[Terminal.SignalHandler]] and
+   * return the previous handler so callers can restore it on unregister.
+   */
+  override def onResize(listener: () => Unit): Option[() => Unit] =
+    val handler = new Terminal.SignalHandler:
+      override def handle(signal: Terminal.Signal): Unit =
+        try listener()
+        catch { case _: Throwable => () }
+    val previous = terminal.handle(Terminal.Signal.WINCH, handler)
+    Some { () =>
+      terminal.handle(Terminal.Signal.WINCH, previous); ()
+    }
 
   override def close(): Unit =
     terminal.close()

--- a/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/SubSpec.scala
@@ -221,6 +221,29 @@ class SubSpec extends AnyFunSuite:
     override def height: Int    = currentHeight
     override def close(): Unit  = ()
 
+  /**
+   * Test backend that supports onResize. Captures the listener so the test
+   * can fire it manually, and records unregister calls.
+   */
+  final private class SignalingTerminal(var currentWidth: Int, var currentHeight: Int) extends TerminalBackend:
+    private val out                                      = new StringWriter()
+    @volatile var registeredListener: Option[() => Unit] = None
+    val unregisterCalls                                  = new java.util.concurrent.atomic.AtomicInteger(0)
+    override def reader: Reader                          = new StringReader("")
+    override def writer: Writer                          = out
+    override def width: Int                              = currentWidth
+    override def height: Int                             = currentHeight
+    override def close(): Unit                           = ()
+    override def onResize(listener: () => Unit): Option[() => Unit] =
+      registeredListener = Some(listener)
+      Some(() =>
+        unregisterCalls.incrementAndGet(): Unit
+        registeredListener = None
+      )
+
+    /** Simulate a SIGWINCH-equivalent delivery from the OS. */
+    def fireResize(): Unit = registeredListener.foreach(_.apply())
+
   test("Sub.Every does not tick when registered into a RuntimeCtx that omits start()"):
     val ctx = new CapturingCtx[String]
     val sub = Sub.Every(20, () => "tick", ctx)
@@ -410,4 +433,45 @@ class SubSpec extends AnyFunSuite:
       val deadline = System.currentTimeMillis() + 1000
       while ctx.messages.isEmpty && System.currentTimeMillis() < deadline do Thread.sleep(10)
       assert(ctx.messages.contains(Cmd.GCmd("82:24")), s"expected resize tick after start; saw ${ctx.messages}")
+    finally sub.cancel()
+
+  test("Sub.TerminalResize uses backend.onResize when supported (no polling)"):
+    val terminal = new SignalingTerminal(80, 24)
+    val ctx      = new CapturingCtx[String](terminal)
+    val sub      = Sub.TerminalResize[String](20, (w, h) => s"$w:$h", ctx)
+
+    sub.start()
+    try
+      assert(terminal.registeredListener.isDefined, "expected backend listener to be registered after start()")
+
+      // Mutate dimensions, fire the signal — should publish exactly once.
+      terminal.currentWidth = 100
+      terminal.fireResize()
+      assert(ctx.messages == List(Cmd.GCmd("100:24")))
+
+      // Identical-size signal should be a no-op (no spurious message).
+      terminal.fireResize()
+      assert(ctx.messages == List(Cmd.GCmd("100:24")))
+
+      // Another change still publishes.
+      terminal.currentHeight = 30
+      terminal.fireResize()
+      assert(ctx.messages == List(Cmd.GCmd("100:24"), Cmd.GCmd("100:30")))
+    finally sub.cancel()
+
+    assert(terminal.unregisterCalls.get() == 1, "cancel() must invoke the unregister hook exactly once")
+    assert(terminal.registeredListener.isEmpty, "listener should be cleared after cancel()")
+
+  test("Sub.TerminalResize does not start a polling scheduler when signal path is taken"):
+    // Indirectly observed: with the signal path active, no message is published
+    // by polling alone (we never fire the signal). Wait long enough that the
+    // polling would have ticked under the fallback path.
+    val terminal = new SignalingTerminal(80, 24)
+    val ctx      = new CapturingCtx[String](terminal)
+    val sub      = Sub.TerminalResize[String](20, (w, h) => s"$w:$h", ctx)
+    sub.start()
+    try
+      terminal.currentWidth = 90
+      Thread.sleep(150)
+      assert(ctx.messages.isEmpty, s"expected no polling-driven publish on signal-capable backend; saw ${ctx.messages}")
     finally sub.cancel()


### PR DESCRIPTION
Closes #151. Stage 1 §4.5 from `docs/ROADMAP.md`.

## Summary
- New `TerminalBackend.onResize(listener) -> Option[unregister]` hook with a default `None` impl.
- `JLineTerminalBackend` overrides it to register a `Terminal.SignalHandler` against `Terminal.Signal.WINCH`. The previous handler is restored on unregister so layered consumers compose cleanly.
- `Sub.TerminalResize` tries the signal path first; only when the backend returns `None` does it fall back to its existing polling scheduler. `cancel()` tears down whichever side was wired.

## Why this matters
Previously every TermFlow app spun up a dedicated scheduled-executor thread that woke up every 50ms (default) to call `terminal.getWidth`/`getHeight` just to notice the rare event of a window resize. That's wasteful, has visible latency on resize, and duplicates work the OS is already happy to deliver via SIGWINCH on Unix (and JLine maps the equivalent on Windows). The signal path is essentially free until the user actually resizes.

## Backwards compatibility
- The public `Sub.TerminalResize(millis, mkMsg, ctx)` signature is unchanged. The `millis` parameter is kept as the polling interval **for backends without signal support** (notably the virtual backend used in tests and the `Devtools.wrap` inner-terminal proxy).
- Anonymous test-only `TerminalBackend` instances continue to work — they inherit the default `None` `onResize` and get the polling fallback.

## Tests
- New `"uses backend.onResize when supported (no polling)"`: a `SignalingTerminal` test backend captures the listener, fires it manually, and the test asserts that (a) only size-change events publish, (b) identical-size signals are no-ops, (c) `cancel()` invokes the unregister hook exactly once.
- New `"does not start a polling scheduler when signal path is taken"`: guards against the scheduler firing accidentally — wait > poll-interval after start with no `fireResize()` call, expect zero messages.
- Existing `"Sub.TerminalResize stays dormant until start()"` (polling path on `MutableTerminal`) is unchanged and still passes.
- All 491 existing tests still green; `sbt ciCheck` clean.

## Test plan
- [ ] Verify the three `Sub.TerminalResize*` tests pass in CI.
- [ ] Manual smoke: run `sbt "termflowSample/runMain termflow.run.TermFlowMain"`, resize the terminal window, confirm the layout reflows immediately (no 50ms perceptible delay).
- [ ] Confirm `Devtools.wrap` still observes resize ticks correctly (its inner-terminal proxy passes through `onResize`? — flagged as a follow-up if not).

## Follow-up
- `Devtools.wrap`'s inner-terminal proxy at `Devtools.scala:644` may need `onResize` forwarding to keep the signal path live for wrapped apps. Not changed in this PR; will verify and patch in a small follow-up if needed.