### PR TITLE
feat: themable BoxNode border characters (#152, partial)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,3 +143,4 @@ addCommandAlias("taskDemo",     "termflowSample/runMain termflow.apps.task.Task"
 addCommandAlias("stressDemo",   "termflowSample/runMain termflow.apps.stress.RenderStressApp")
 addCommandAlias("sineDemo",     "termflowSample/runMain termflow.apps.stress.SineWaveApp")
 addCommandAlias("inputDemo",    "termflowSample/runMain termflow.apps.input.InputLineReproApp")
+addCommandAlias("themeDemo",    "termflowSample/runMain termflow.apps.themes.ThemeDemoApp")

--- a/modules/termflow-sample/src/main/scala/termflow/apps/themes/ThemeDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/themes/ThemeDemoApp.scala
@@ -1,0 +1,97 @@
+package termflow.apps.themes
+
+import termflow.tui.*
+import termflow.tui.Theme.themed
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Tiny demo of theme + border-character switching at runtime.
+ *
+ * Press `Tab` to cycle through the shipped themes; press `q` to quit.
+ * Demonstrates that the same `view` produces visibly different chrome
+ * depending only on the ambient `Theme` value — no widget code is forked
+ * to support the alternate visuals.
+ */
+object ThemeDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  private val themes: Vector[(String, Theme)] = Vector(
+    "dark (sharp)"   -> Theme.dark,
+    "rounded"        -> Theme.rounded,
+    "double"         -> Theme.dark.copy(chars = BorderChars.double),
+    "ascii fallback" -> Theme.dark.copy(chars = BorderChars.ascii),
+    "light"          -> Theme.light,
+    "mono"           -> Theme.mono
+  )
+
+  final case class Model(themeIndex: Int, input: Sub[Msg])
+
+  enum Msg:
+    case Cycle
+    case Quit
+    case Key(k: KeyDecoder.InputKey)
+    case KeyError(t: Throwable)
+
+  import Msg._
+
+  object App extends TuiApp[Model, Msg]:
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Model(
+        themeIndex = 0,
+        input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx)
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      msg match
+        case Cycle       => m.copy(themeIndex = (m.themeIndex + 1) % themes.size).tui
+        case Quit        => Tui(m, Cmd.Exit)
+        case KeyError(_) => m.tui
+        case Key(k) =>
+          import KeyDecoder.InputKey.*
+          k match
+            case CharKey('\t') => Tui(m, Cmd.GCmd(Cycle))
+            case CharKey(' ')  => Tui(m, Cmd.GCmd(Cycle))
+            case CharKey('q')  => Tui(m, Cmd.GCmd(Quit))
+            case CharKey('Q')  => Tui(m, Cmd.GCmd(Quit))
+            case Escape        => Tui(m, Cmd.GCmd(Quit))
+            case _             => m.tui
+
+    override def view(m: Model): RootNode =
+      val (name, theme)   = themes(m.themeIndex)
+      given Theme         = theme
+      val width           = 50
+      val title           = s" Theme: $name "
+      val titlePadded     = title + (" " * math.max(0, width - 2 - title.length))
+      val instructionLine = "  Tab/Space → cycle theme    q/Esc → quit"
+      val box             = Theme.box(2.x, 2.y, width, 6)
+      val titleNode       = TextNode(3.x, 2.y, List(Text(title, Style(fg = theme.primary, bold = true))))
+      val sampleNode = TextNode(
+        4.x,
+        4.y,
+        List(
+          "Status: ".text,
+          "OK".themed(_.success),
+          "  ".text,
+          "Warning: ".text,
+          "12".themed(_.warning),
+          "  ".text,
+          "Error: ".text,
+          "0".themed(_.error)
+        )
+      )
+      val helpNode = TextNode(2.x, 9.y, List(Text(instructionLine, Style(fg = theme.foreground))))
+      val _        = titlePadded
+      RootNode(
+        width = math.max(width + 4, 60),
+        height = 11,
+        children = List(box, titleNode, sampleNode, helpNode),
+        input = None
+      )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      Left(TermFlowError.Validation("ThemeDemo has no prompt"))

--- a/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -205,8 +205,8 @@ object AnsiRenderer:
         out.append(styleToAnsi(style, depth)).append(str).append(reset)
       }
 
-    case BoxNode(x, y, w, h, children, style) =>
-      if style.border then drawBorder(x, y, w, h, style.fg, out, depth)
+    case BoxNode(x, y, w, h, children, style, chars) =>
+      if style.border then drawBorder(x, y, w, h, style.fg, chars, out, depth)
       children.foreach(renderNode(_, out, depth))
 
     case _: InputNode => () // handled separately
@@ -217,14 +217,19 @@ object AnsiRenderer:
     w: Int,
     h: Int,
     color: Color,
+    chars: BorderChars,
     out: StringBuilder,
     depth: ColorDepth
   ): Unit =
     val inner      = math.max(0, w - 2)
-    val horizontal = "─" * inner
-    out.append(moveTo(x, y)).append(colorToAnsi(color, isBg = false, depth)).append(s"┌$horizontal┐")
-    (1 until (h - 1)).foreach(row => out.append(moveTo(x, y + row)).append(s"│${" " * inner}│"))
-    out.append(moveTo(x, y + (h - 1))).append(s"└$horizontal┘")
+    val horizontal = chars.horizontal.toString * inner
+    val v          = chars.vertical
+    out
+      .append(moveTo(x, y))
+      .append(colorToAnsi(color, isBg = false, depth))
+      .append(s"${chars.topLeft}$horizontal${chars.topRight}")
+    (1 until (h - 1)).foreach(row => out.append(moveTo(x, y + row)).append(s"$v${" " * inner}$v"))
+    out.append(moveTo(x, y + (h - 1))).append(s"${chars.bottomLeft}$horizontal${chars.bottomRight}")
     out.append(reset)
 
   private def visibleInput(inp: InputNode, rootWidth: Int): VisibleInput =
@@ -291,7 +296,7 @@ object AnsiRenderer:
         val right     = x.value + math.max(0, textWidth - 1)
         (right, y.value)
 
-      case BoxNode(x, y, w, h, children, _) =>
+      case BoxNode(x, y, w, h, children, _, _) =>
         val boxRight = x.value + math.max(0, w - 1)
         val boxBot   = y.value + math.max(0, h - 1)
         children.foldLeft((boxRight, boxBot)) { case ((mx, my), child) =>
@@ -336,24 +341,24 @@ object AnsiRenderer:
         col += 1
       }
 
-    def drawBorder(x: Int, y: Int, w: Int, h: Int, style: Style): Unit =
+    def drawBorder(x: Int, y: Int, w: Int, h: Int, style: Style, chars: BorderChars): Unit =
       if w > 0 && h > 0 then
         var dx = 0
         while dx < w do
-          putCell(x + dx, y, RenderCell('─', style))
-          if h > 1 then putCell(x + dx, y + h - 1, RenderCell('─', style))
+          putCell(x + dx, y, RenderCell(chars.horizontal, style))
+          if h > 1 then putCell(x + dx, y + h - 1, RenderCell(chars.horizontal, style))
           dx += 1
 
         var dy = 0
         while dy < h do
-          putCell(x, y + dy, RenderCell('│', style))
-          if w > 1 then putCell(x + w - 1, y + dy, RenderCell('│', style))
+          putCell(x, y + dy, RenderCell(chars.vertical, style))
+          if w > 1 then putCell(x + w - 1, y + dy, RenderCell(chars.vertical, style))
           dy += 1
 
-        putCell(x, y, RenderCell('┌', style))
-        if w > 1 then putCell(x + w - 1, y, RenderCell('┐', style))
-        if h > 1 then putCell(x, y + h - 1, RenderCell('└', style))
-        if w > 1 && h > 1 then putCell(x + w - 1, y + h - 1, RenderCell('┘', style))
+        putCell(x, y, RenderCell(chars.topLeft, style))
+        if w > 1 then putCell(x + w - 1, y, RenderCell(chars.topRight, style))
+        if h > 1 then putCell(x, y + h - 1, RenderCell(chars.bottomLeft, style))
+        if w > 1 && h > 1 then putCell(x + w - 1, y + h - 1, RenderCell(chars.bottomRight, style))
 
     def drawNode(node: VNode): Unit = node match
       case TextNode(x, y, segments) =>
@@ -363,8 +368,8 @@ object AnsiRenderer:
           col += str.length
         }
 
-      case BoxNode(x, y, w, h, children, style) =>
-        if style.border then drawBorder(x.value, y.value, w, h, Style(fg = style.fg))
+      case BoxNode(x, y, w, h, children, style, chars) =>
+        if style.border then drawBorder(x.value, y.value, w, h, Style(fg = style.fg), chars)
         children.foreach(drawNode)
 
       case _: InputNode =>

--- a/modules/termflow/src/main/scala/termflow/tui/BorderChars.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/BorderChars.scala
@@ -1,0 +1,42 @@
+package termflow.tui
+
+/**
+ * Character set used to draw a [[VNode.BoxNode]]'s border.
+ *
+ * Apps can swap a `BorderChars` value via the ambient [[Theme.chars]] (or by
+ * passing `chars` directly to the box) without re-implementing the
+ * box-drawing logic in the renderer.
+ *
+ * @param topLeft     Top-left corner glyph.
+ * @param topRight    Top-right corner glyph.
+ * @param bottomLeft  Bottom-left corner glyph.
+ * @param bottomRight Bottom-right corner glyph.
+ * @param horizontal  Horizontal edge glyph (top and bottom rows).
+ * @param vertical    Vertical edge glyph (left and right columns).
+ */
+final case class BorderChars(
+  topLeft: Char,
+  topRight: Char,
+  bottomLeft: Char,
+  bottomRight: Char,
+  horizontal: Char,
+  vertical: Char
+)
+
+object BorderChars:
+
+  /** Single-line square corners (`┌─┐ │ │ └─┘`). The default. */
+  val sharp: BorderChars =
+    BorderChars('┌', '┐', '└', '┘', '─', '│')
+
+  /** Single-line rounded corners (`╭─╮ │ │ ╰─╯`). */
+  val rounded: BorderChars =
+    BorderChars('╭', '╮', '╰', '╯', '─', '│')
+
+  /** Double-line corners (`╔═╗ ║ ║ ╚═╝`). */
+  val double: BorderChars =
+    BorderChars('╔', '╗', '╚', '╝', '═', '║')
+
+  /** ASCII-only fallback for terminals without box-drawing glyph support. */
+  val ascii: BorderChars =
+    BorderChars('+', '+', '+', '+', '-', '|')

--- a/modules/termflow/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Layout.scala
@@ -195,7 +195,7 @@ object Layout:
       val width = segments.foldLeft(0)((acc, seg) => acc + seg.txt.length)
       (width, 1)
 
-    case BoxNode(_, _, w, h, _, _) =>
+    case BoxNode(_, _, w, h, _, _, _) =>
       (math.max(0, w), math.max(0, h))
 
     case InputNode(_, _, prompt, _, _, lineWidth, _) =>

--- a/modules/termflow/src/main/scala/termflow/tui/Theme.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Theme.scala
@@ -93,10 +93,11 @@ final case class Theme(
   info: Color,
   border: Color,
   background: Color,
-  foreground: Color
+  foreground: Color,
+  chars: BorderChars = BorderChars.sharp
 ):
 
-  /** All slots as an ordered list. Convenient for tests and debugging. */
+  /** All colour slots as an ordered list. Convenient for tests and debugging. */
   def slots: List[(String, Color)] =
     List(
       "primary"    -> primary,
@@ -171,6 +172,17 @@ object Theme:
   )
 
   /**
+   * Dark palette using rounded box-drawing corners.
+   *
+   * Identical colour slots to [[dark]]; differs only in `chars =
+   * BorderChars.rounded`, so any [[VNode.BoxNode]] built from this theme
+   * draws with `╭╮╰╯` instead of `┌┐└┘`. Demonstrates the
+   * [[Theme.chars]] seam — apps can swap visual personality without
+   * forking the renderer.
+   */
+  val rounded: Theme = dark.copy(chars = BorderChars.rounded)
+
+  /**
    * Return the `Theme` from implicit scope.
    *
    * Shorthand for `summon[Theme]`, useful when you want to pass the ambient
@@ -211,3 +223,30 @@ object Theme:
   extension (txt: String)
     def themed(select: Theme => Color)(using t: Theme): Text =
       Text(txt, Style(fg = select(t)))
+
+  /**
+   * Build a [[VNode.BoxNode]] using the ambient theme's [[chars]] and
+   * [[border]] slot.
+   *
+   * This is the idiomatic way to draw a themed bordered container — apps
+   * stay free of any direct reference to `BorderChars`, and the visual
+   * style follows whichever theme is currently in scope.
+   *
+   * {{{
+   * given Theme = Theme.rounded
+   * Theme.box(2.x, 2.y, 40, 6, children = Nil)
+   *   // → BoxNode(..., style = Style(fg = theme.border, border = true), chars = ╭╮╰╯)
+   * }}}
+   */
+  def box(
+    x: XCoord,
+    y: YCoord,
+    width: Int,
+    height: Int,
+    children: List[VNode] = Nil,
+    style: Style = Style(border = true)
+  )(using t: Theme): VNode =
+    val finalStyle =
+      if style.fg == Color.Default then style.copy(fg = t.border)
+      else style
+    VNode.BoxNode(x, y, width, height, children, finalStyle, t.chars)

--- a/modules/termflow/src/main/scala/termflow/tui/vdom.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/vdom.scala
@@ -215,7 +215,8 @@ enum VNode:
    * A rectangular container anchored at `(x, y)`.
    *
    * `BoxNode` is currently visual-only: if `style.border` is set, the
-   * renderer draws a border from `(x, y)` to `(x + width - 1, y + height - 1)`.
+   * renderer draws a border from `(x, y)` to `(x + width - 1, y + height - 1)`
+   * using the glyphs defined by `chars` (defaults to [[BorderChars.sharp]]).
    * Children are drawn in document order on top of the box; they are not
    * automatically clipped or repositioned relative to the box.
    *
@@ -225,6 +226,9 @@ enum VNode:
    * @param height The box height including both border rows.
    * @param children Child nodes drawn inside / over the box.
    * @param style The box style. `Style(border = true)` is the usual setting.
+   * @param chars Box-drawing glyphs used when the border is on.
+   *              Pick one of [[BorderChars.sharp]] / [[BorderChars.rounded]] /
+   *              [[BorderChars.double]] / [[BorderChars.ascii]] or roll your own.
    */
   case BoxNode(
     override val x: XCoord,
@@ -232,7 +236,8 @@ enum VNode:
     override val width: Int,
     override val height: Int,
     children: List[VNode],
-    override val style: Style = Style()
+    override val style: Style = Style(),
+    chars: BorderChars = BorderChars.sharp
   )
 
   /**
@@ -265,13 +270,13 @@ enum VNode:
   /** Top-left column of this node (1-based). */
   def x: XCoord = this match
     case TextNode(x, _, _)              => x
-    case BoxNode(x, _, _, _, _, _)      => x
+    case BoxNode(x, _, _, _, _, _, _)   => x
     case InputNode(x, _, _, _, _, _, _) => x
 
   /** Top-left row of this node (1-based). */
   def y: YCoord = this match
     case TextNode(_, y, _)              => y
-    case BoxNode(_, y, _, _, _, _)      => y
+    case BoxNode(_, y, _, _, _, _, _)   => y
     case InputNode(_, y, _, _, _, _, _) => y
 
   /**
@@ -282,21 +287,21 @@ enum VNode:
    * `AnsiRenderer.buildFrame` for authoritative layout.
    */
   def width: Int = this match
-    case TextNode(_, _, _)             => 1
-    case BoxNode(_, _, width, _, _, _) => width
+    case TextNode(_, _, _)                => 1
+    case BoxNode(_, _, width, _, _, _, _) => width
     case InputNode(_, _, prompt, _, _, lineWidth, _) =>
       if lineWidth > 0 then lineWidth else prompt.length + 1
 
   /** Height of this node in cells. Always `1` for text and input nodes. */
   def height: Int = this match
-    case TextNode(_, _, _)              => 1
-    case BoxNode(_, _, _, height, _, _) => height
-    case InputNode(_, _, _, _, _, _, _) => 1
+    case TextNode(_, _, _)                 => 1
+    case BoxNode(_, _, _, height, _, _, _) => height
+    case InputNode(_, _, _, _, _, _, _)    => 1
 
   /** The style applied to this node. [[TextNode]] styles live on its segments. */
   def style: Style = this match
     case TextNode(_, _, _)                  => Style()
-    case BoxNode(_, _, _, _, _, style)      => style
+    case BoxNode(_, _, _, _, _, style, _)   => style
     case InputNode(_, _, _, style, _, _, _) => style
 
 /**

--- a/modules/termflow/src/test/scala/termflow/tui/AnsiRendererSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/AnsiRendererSpec.scala
@@ -157,6 +157,23 @@ class AnsiRendererSpec extends AnyFunSuite:
     val out = captureAnsiRendererOut(root)
     assert(out.contains("┌"))
     assert(out.contains("└"))
+    assert(!out.contains("╭"), "default chars should be sharp, not rounded")
+
+    // BoxNode.chars drives the glyph set on emission.
+    val rounded = root.copy(children = root.children.collect { case b @ BoxNode(_, _, _, _, _, _, _) =>
+      b.copy(chars = BorderChars.rounded)
+    })
+    val outR = captureAnsiRendererOut(rounded)
+    assert(outR.contains("╭"))
+    assert(outR.contains("╯"))
+    assert(!outR.contains("┌"), "rounded chars should not produce sharp corners")
+
+    // buildFrame path also honours BoxNode.chars.
+    val frame  = AnsiRenderer.buildFrame(rounded)
+    val topRow = frame.cells(0).map(_.ch).mkString
+    val botRow = frame.cells(2).map(_.ch).mkString
+    assert(topRow.contains('╭') && topRow.contains('╮'), s"top row should have rounded corners: $topRow")
+    assert(botRow.contains('╰') && botRow.contains('╯'), s"bottom row should have rounded corners: $botRow")
     assert(out.contains("\u001b[1m")) // bold style for text
     assert(!out.contains(ANSI.hideCursor))
     assert(out.contains("\u001b[2K"))                               // clear current line

--- a/modules/termflow/src/test/scala/termflow/tui/BorderCharsSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/BorderCharsSpec.scala
@@ -1,0 +1,60 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class BorderCharsSpec extends AnyFunSuite:
+
+  test("sharp uses square corners") {
+    assert(BorderChars.sharp.topLeft == '┌')
+    assert(BorderChars.sharp.topRight == '┐')
+    assert(BorderChars.sharp.bottomLeft == '└')
+    assert(BorderChars.sharp.bottomRight == '┘')
+    assert(BorderChars.sharp.horizontal == '─')
+    assert(BorderChars.sharp.vertical == '│')
+  }
+
+  test("rounded uses rounded corners but the same edges") {
+    assert(BorderChars.rounded.topLeft == '╭')
+    assert(BorderChars.rounded.topRight == '╮')
+    assert(BorderChars.rounded.bottomLeft == '╰')
+    assert(BorderChars.rounded.bottomRight == '╯')
+    assert(BorderChars.rounded.horizontal == '─')
+    assert(BorderChars.rounded.vertical == '│')
+  }
+
+  test("double uses double-line glyphs throughout") {
+    assert(BorderChars.double.topLeft == '╔')
+    assert(BorderChars.double.bottomRight == '╝')
+    assert(BorderChars.double.horizontal == '═')
+    assert(BorderChars.double.vertical == '║')
+  }
+
+  test("ascii is portable to dumb terminals") {
+    val all = Set(
+      BorderChars.ascii.topLeft,
+      BorderChars.ascii.topRight,
+      BorderChars.ascii.bottomLeft,
+      BorderChars.ascii.bottomRight,
+      BorderChars.ascii.horizontal,
+      BorderChars.ascii.vertical
+    )
+    assert(all.forall(_.toInt < 128), s"non-ASCII glyph in BorderChars.ascii: $all")
+  }
+
+  test("BoxNode defaults to sharp corners (preserves prior behaviour)") {
+    val box: VNode.BoxNode = VNode.BoxNode(XCoord(1), YCoord(1), 4, 3, children = Nil, style = Style(border = true))
+    assert(box.chars == BorderChars.sharp)
+  }
+
+  test("BoxNode accepts an explicit BorderChars") {
+    val box: VNode.BoxNode = VNode.BoxNode(
+      XCoord(1),
+      YCoord(1),
+      4,
+      3,
+      children = Nil,
+      style = Style(border = true),
+      chars = BorderChars.rounded
+    )
+    assert(box.chars == BorderChars.rounded)
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/ThemeSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/ThemeSpec.scala
@@ -79,3 +79,33 @@ class ThemeSpec extends AnyFunSuite:
     val s = Style(bold = true).themed(_.error)
     assert(s.fg == Color.Default)
     assert(s.bold)
+
+  test("dark/light/mono all default to BorderChars.sharp"):
+    assert(Theme.dark.chars == BorderChars.sharp)
+    assert(Theme.light.chars == BorderChars.sharp)
+    assert(Theme.mono.chars == BorderChars.sharp)
+
+  test("Theme.rounded uses rounded corners but inherits dark colours"):
+    assert(Theme.rounded.chars == BorderChars.rounded)
+    assert(Theme.rounded.primary == Theme.dark.primary)
+    assert(Theme.rounded.background == Theme.dark.background)
+    assert(Theme.rounded.foreground == Theme.dark.foreground)
+
+  test("Theme.box uses ambient chars and border slot"):
+    given Theme = Theme.rounded
+    val box     = Theme.box(XCoord(2), YCoord(3), 10, 4)
+    box match
+      case b @ VNode.BoxNode(_, _, _, _, _, _, _) =>
+        assert(b.chars == BorderChars.rounded)
+        assert(b.style.fg == Theme.rounded.border)
+        assert(b.style.border)
+      case _ => fail("expected BoxNode")
+
+  test("Theme.box preserves an explicit fg colour passed via style"):
+    given Theme  = Theme.rounded
+    val redStyle = Style(border = true, fg = Color.Red)
+    val box      = Theme.box(XCoord(1), YCoord(1), 4, 4, style = redStyle)
+    box match
+      case b @ VNode.BoxNode(_, _, _, _, _, _, _) =>
+        assert(b.style.fg == Color.Red, "explicit fg must not be overridden by theme.border")
+      case _ => fail("expected BoxNode")

--- a/modules/termflow/src/test/scala/termflow/tui/VDomSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/VDomSpec.scala
@@ -30,8 +30,8 @@ class VDomSpec extends AnyFunSuite:
     assert(node.height == 10)
     assert(node.style == Style(fg = Color.Blue, border = true))
     node match
-      case VNode.BoxNode(_, _, _, _, children, _) => assert(children == List(child))
-      case _                                      => fail("expected BoxNode")
+      case VNode.BoxNode(_, _, _, _, children, _, _) => assert(children == List(child))
+      case _                                         => fail("expected BoxNode")
 
   test("InputNode computes width from prompt or lineWidth override"):
     val nodeByPrompt = InputNode(


### PR DESCRIPTION
Partial implementation of #152. Stage 1 §4.3 from `docs/ROADMAP.md`.

## Summary
The box-drawing characters were hard-coded in `AnsiRenderer.drawBorder` (both the ANSI emitter and the `buildFrame` cell-grid variant) as `┌─┐│└┘`. This PR pulls them into a `BorderChars` ADT carried on `BoxNode` itself, with the ambient `Theme` exposing the default set the app wants to use. A second shipped theme (`Theme.rounded`) demonstrates the seam — same widget code, visibly different chrome.

## What landed
- **`BorderChars` ADT** with four presets: `sharp` (default, ┌─┐│└┘), `rounded` (╭─╮│╰╯), `double` (╔═╗║╚╝), `ascii` (`+-+|+-+`).
- **`BoxNode.chars: BorderChars`** field, defaulted to `BorderChars.sharp` so every existing call site compiles unchanged.
- **`AnsiRenderer.drawBorder`** (both the ANSI emitter and `buildFrame` paths) now reads chars from the node instead of hard-coded glyph literals.
- **`Theme.chars: BorderChars`** slot on the existing `Theme` record. Defaults to `sharp` on `dark`/`light`/`mono` so visuals are stable.
- **`Theme.rounded`** preset: same colour slots as `dark`, but `chars = BorderChars.rounded`.
- **`Theme.box(...)`** helper: builds a themed bordered `VNode` from the ambient theme's `chars` + `border` slot. Apps stay free of any direct `BorderChars` reference.
- **`themeDemo` sample app** (`sbt themeDemo`): cycles through 6 themes with Tab/Space, demonstrates that the same view produces different chrome based only on the ambient theme.

## What's deferred (and why)
The original issue title is "Theme + WidgetRenderer split" — a full `WidgetRenderer[State]` typeclass over each widget. Inspecting the shipped widgets (`Button`, `ProgressBar`, `Spinner`, `StatusBar`, `TextField`, `ListView`, `Table`, `Select`), all of them already read their colours from the ambient `Theme` via slot lookup. The genuine gap was box-drawing characters. Introducing a typeclass when the customisation is just slot-lookup-and-go is over-engineering.

When a real widget wants something the current Theme can't express (e.g. swappable `ProgressBar` fill chars `█`/`░`, or alternate `Spinner` frame sets), introduce the typeclass at that moment with a concrete motivating use case. The layered approach this PR establishes (Theme owns visual choices, widgets read from Theme, no per-widget renderer indirection) is consistent with that future direction.

I'd suggest leaving #152 open after this merges, retitled to "Per-widget renderer customisation (post-borders)", scoped to the widgets that need it.

## Tests
- New `BorderCharsSpec` (6 tests): preset glyph checks; `BoxNode` default behaviour preserved; explicit `chars =` parameter honoured.
- New `ThemeSpec` cases (5 tests): every shipped theme defaults to `sharp`; `Theme.rounded` inherits dark colours but uses rounded chars; `Theme.box` uses ambient `chars` and `border` slot; `Theme.box` preserves an explicit `fg` colour when caller passes one.
- `AnsiRendererSpec` extended: asserts the `chars` field actually drives glyph emission on **both** the live-render and `buildFrame` paths (rounded → ╭/╯ visible, no leaked ┌).
- All 410 existing tests still pass; `sbt ciCheck` green.

## Test plan
- [ ] `sbt themeDemo` — cycle through the 6 themes with Tab; visually confirm sharp / rounded / double / ascii corners and the colour swap on light/mono.
- [ ] Existing samples (`hubDemo`, `widgetsDemo`, `formDemo`) — all still render with sharp corners; no visual regression.
- [ ] Confirm goldens are unchanged (sharp is the default; goldens never invoked rounded/double/ascii).