### PR TITLE
feat: Overlay primitive + Dialogs.confirm/message (#153 stage 1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,3 +144,4 @@ addCommandAlias("stressDemo",   "termflowSample/runMain termflow.apps.stress.Ren
 addCommandAlias("sineDemo",     "termflowSample/runMain termflow.apps.stress.SineWaveApp")
 addCommandAlias("inputDemo",    "termflowSample/runMain termflow.apps.input.InputLineReproApp")
 addCommandAlias("themeDemo",    "termflowSample/runMain termflow.apps.themes.ThemeDemoApp")
+addCommandAlias("dialogDemo",   "termflowSample/runMain termflow.apps.dialog.DialogDemoApp")

--- a/modules/termflow-sample/src/main/scala/termflow/apps/dialog/DialogDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/dialog/DialogDemoApp.scala
@@ -1,0 +1,119 @@
+package termflow.apps.dialog
+
+import termflow.tui.*
+import termflow.tui.Theme.themed
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Demonstrates the modal-overlay primitive shipped with #153.
+ *
+ * The base view is a counter. Pressing `d` opens a confirm dialog asking
+ * whether to reset the counter. While the dialog is up:
+ *   - all counter key bindings are ignored (modal capture)
+ *   - the dialog's left/right arrows move focus between Yes / No
+ *   - Enter activates the focused choice; Esc cancels
+ *
+ * Press `q` (with no dialog) to quit.
+ */
+object DialogDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  private given Theme = Theme.rounded
+
+  enum Dialog:
+    case None
+    case ConfirmReset(yesFocused: Boolean)
+
+  final case class Model(count: Int, dialog: Dialog, input: Sub[Msg])
+
+  enum Msg:
+    case Inc
+    case Dec
+    case OpenReset
+    case CloseDialog
+    case ToggleDialogFocus
+    case ConfirmYes
+    case ConfirmNo
+    case Quit
+    case Key(k: KeyDecoder.InputKey)
+    case KeyError(t: Throwable)
+
+  import Msg._
+
+  object App extends TuiApp[Model, Msg]:
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Model(
+        count = 0,
+        dialog = Dialog.None,
+        input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx)
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      msg match
+        case Inc         => m.copy(count = m.count + 1).tui
+        case Dec         => m.copy(count = m.count - 1).tui
+        case OpenReset   => m.copy(dialog = Dialog.ConfirmReset(yesFocused = false)).tui
+        case CloseDialog => m.copy(dialog = Dialog.None).tui
+        case ToggleDialogFocus =>
+          m.dialog match
+            case Dialog.ConfirmReset(yes) => m.copy(dialog = Dialog.ConfirmReset(!yes)).tui
+            case Dialog.None              => m.tui
+        case ConfirmYes  => m.copy(count = 0, dialog = Dialog.None).tui
+        case ConfirmNo   => m.copy(dialog = Dialog.None).tui
+        case Quit        => Tui(m, Cmd.Exit)
+        case KeyError(_) => m.tui
+        case Key(k)      => Tui(m, dispatch(m, k))
+
+    /**
+     * Key dispatch is gated on whether a dialog is open. This is the
+     * point of the modal: while a dialog is up, the underlying app does
+     * not respond to its own bindings.
+     */
+    private def dispatch(m: Model, k: KeyDecoder.InputKey): Cmd[Msg] =
+      import KeyDecoder.InputKey.*
+      m.dialog match
+        case Dialog.ConfirmReset(yesFocused) =>
+          k match
+            case ArrowLeft | ArrowRight => Cmd.GCmd(ToggleDialogFocus)
+            case Enter                  => if yesFocused then Cmd.GCmd(ConfirmYes) else Cmd.GCmd(ConfirmNo)
+            case Escape                 => Cmd.GCmd(CloseDialog)
+            case _                      => Cmd.NoCmd
+        case Dialog.None =>
+          k match
+            case CharKey('+') | ArrowUp                     => Cmd.GCmd(Inc)
+            case CharKey('-') | ArrowDown                   => Cmd.GCmd(Dec)
+            case CharKey('d') | CharKey('D') | CharKey('r') => Cmd.GCmd(OpenReset)
+            case CharKey('q') | CharKey('Q') | Escape       => Cmd.GCmd(Quit)
+            case _                                          => Cmd.NoCmd
+
+    override def view(m: Model): RootNode =
+      val title   = TextNode(2.x, 1.y, List("Dialog Demo".themed(_.primary)))
+      val counter = TextNode(2.x, 3.y, List("Count: ".text, m.count.toString.themed(_.success)))
+      val help1   = TextNode(2.x, 5.y, List("+ / ↑ : increment    - / ↓ : decrement".text))
+      val help2   = TextNode(2.x, 6.y, List("d : open reset dialog    q / Esc : quit".text))
+      val baseRoot = RootNode(
+        width = 60,
+        height = 12,
+        children = List(title, counter, help1, help2),
+        input = None
+      )
+
+      m.dialog match
+        case Dialog.None => baseRoot
+        case Dialog.ConfirmReset(yesFocused) =>
+          baseRoot.copy(overlays =
+            List(
+              Dialogs.confirm(
+                prompt = s"Reset counter (currently ${m.count}) to zero?",
+                yesFocused = yesFocused
+              )
+            )
+          )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      Left(TermFlowError.Validation("DialogDemo has no prompt"))

--- a/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -182,7 +182,9 @@ object AnsiRenderer:
   def renderPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
     val out = new StringBuilder
     root.children.foreach(renderNode(_, out, depth))
-    root.input.foreach(renderInput(_, root.width, out, depth))
+    if !hasModalOverlay(root) then root.input.foreach(renderInput(_, root.width, out, depth))
+    root.overlays.foreach(renderOverlay(_, root.width, root.height, out, depth))
+    activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth))
     out.toString
 
   def render(root: RootNode)(using terminal: TerminalBackend): Unit =
@@ -195,8 +197,44 @@ object AnsiRenderer:
   /** Build ANSI patch for input-only repaint. */
   def inputPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
     val out = new StringBuilder
-    root.input.foreach(renderInput(_, root.width, out, depth))
+    if hasModalOverlay(root) then activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth))
+    else root.input.foreach(renderInput(_, root.width, out, depth))
     out.toString
+
+  /** True if any overlay in the root captures base-view input. */
+  private def hasModalOverlay(root: RootNode): Boolean =
+    root.overlays.exists(_.inputCapture == InputCapture.Modal)
+
+  /**
+   * Resolve which input the live cursor should follow:
+   *   - the topmost modal overlay's input, if any
+   *   - otherwise the topmost non-modal overlay's input, if any
+   *   - otherwise None
+   *
+   * Each overlay-owned input has its coordinates translated into root-frame
+   * absolutes by the time it is returned, so the existing input rendering
+   * code can consume it without overlay awareness.
+   */
+  private def activeOverlayInput(root: RootNode): Option[InputNode] =
+    val modal   = root.overlays.reverse.find(_.inputCapture == InputCapture.Modal)
+    val visible = modal.orElse(root.overlays.reverse.find(_.input.isDefined))
+    visible.flatMap(o => o.input.map(translateInput(o, root.width, root.height, _)))
+
+  private def translateInput(o: Overlay, rootWidth: Int, rootHeight: Int, in: InputNode): InputNode =
+    val (ox, oy) = OverlayPosition.resolve(o.position, o.width, o.height, rootWidth, rootHeight)
+    in.copy(x = in.x + (ox.value - 1), y = in.y + (oy.value - 1))
+
+  private def renderOverlay(
+    o: Overlay,
+    rootWidth: Int,
+    rootHeight: Int,
+    out: StringBuilder,
+    depth: ColorDepth
+  ): Unit =
+    val (ox, oy) = OverlayPosition.resolve(o.position, o.width, o.height, rootWidth, rootHeight)
+    val dx       = ox.value - 1
+    val dy       = oy.value - 1
+    o.children.foreach(child => renderNode(Layout.translate(child, dx, dy), out, depth))
 
   private def renderNode(v: VNode, out: StringBuilder, depth: ColorDepth): Unit = v match
     case TextNode(x, y, l) =>
@@ -377,10 +415,29 @@ object AnsiRenderer:
 
     root.children.foreach(drawNode)
 
-    root.input.foreach { inp =>
-      val visible = visibleInput(inp, root.width)
-      drawString(inp.x.value, inp.y.value, visible.text, inp.style)
-      cursor = Some(Coord(inp.x + visible.cursorIndex, inp.y))
+    val anyModalOverlay = root.overlays.exists(_.inputCapture == InputCapture.Modal)
+
+    if !anyModalOverlay then
+      root.input.foreach { inp =>
+        val visible = visibleInput(inp, root.width)
+        drawString(inp.x.value, inp.y.value, visible.text, inp.style)
+        cursor = Some(Coord(inp.x + visible.cursorIndex, inp.y))
+      }
+
+    // Composite overlays bottom-to-top. Each overlay's children are
+    // translated by the resolved position so callers author them in
+    // overlay-local coordinates (1.x / 1.y is the overlay's top-left).
+    root.overlays.foreach { o =>
+      val (ox, oy) = OverlayPosition.resolve(o.position, o.width, o.height, root.width, root.height)
+      val dx       = ox.value - 1
+      val dy       = oy.value - 1
+      o.children.foreach(child => drawNode(Layout.translate(child, dx, dy)))
+      o.input.foreach { in =>
+        val translated: InputNode = in.copy(x = in.x + dx, y = in.y + dy)
+        val visible               = visibleInput(translated, root.width)
+        drawString(translated.x.value, translated.y.value, visible.text, translated.style)
+        cursor = Some(Coord(translated.x + visible.cursorIndex, translated.y))
+      }
     }
 
     RenderFrame(width, height, cells, cursor)

--- a/modules/termflow/src/main/scala/termflow/tui/Dialogs.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Dialogs.scala
@@ -1,0 +1,116 @@
+package termflow.tui
+
+/**
+ * Builders for common modal dialogs as [[Overlay]] values.
+ *
+ * Each helper returns an `Overlay` ready to drop into
+ * [[RootNode.overlays]]. The dialog state (open / closed, selected button,
+ * entered text) lives in the app's own model — these helpers are pure
+ * presentation, mirroring the rest of TermFlow's view layer.
+ *
+ * The shipped helpers all use `InputCapture.Modal` so the base view's
+ * cursor and input are suppressed while the dialog is up. Apps decide
+ * whether to also gate their own `update` on the dialog being open
+ * (typically by pattern-matching on `model.dialog`).
+ */
+object Dialogs:
+
+  /**
+   * Choice button rendered in the action row of a dialog.
+   *
+   * @param label   Visible label (e.g. `"OK"`, `"Cancel"`).
+   * @param focused Whether this button currently owns focus.
+   */
+  final case class Choice(label: String, focused: Boolean)
+
+  /**
+   * Build a centred message dialog with one or more action buttons.
+   *
+   * Layout: bordered box, title row at the top, body text in the middle,
+   * a horizontal action row at the bottom with the supplied [[Choice]]s
+   * separated by two cells.
+   *
+   * Sizing: width is computed from the longest of (title + padding),
+   * (body + padding), (sum of choice widths + gaps), with a minimum of
+   * 40 cells. Height is 6 (top border + title + blank + body + actions +
+   * bottom border).
+   *
+   * Apps drive button focus / activation via their own keymap; this
+   * helper only renders the visual.
+   *
+   * @param title    Title rendered on the top border, in the theme's primary slot.
+   * @param body     One or more body lines, in the theme's foreground slot.
+   * @param choices  Action buttons, drawn left-to-right.
+   * @param position Anchor (default [[OverlayPosition.Centered]]).
+   * @param theme    Ambient theme (chars + colours).
+   */
+  def message(
+    title: String,
+    body: List[String],
+    choices: List[Choice],
+    position: OverlayPosition = OverlayPosition.Centered
+  )(using theme: Theme): Overlay =
+    val titleLen   = title.length + 4 // " <title> "
+    val bodyLen    = (0 :: body.map(_.length)).max + 4
+    val actionsLen = choiceWidth(choices) + 4
+    val width      = math.max(40, math.max(titleLen, math.max(bodyLen, actionsLen)))
+    val height     = math.max(7, 4 + body.size)
+
+    // Local coords inside the overlay: (1.x, 1.y) is the overlay's top-left.
+    val box       = Theme.box(XCoord(1), YCoord(1), width, height)
+    val titleNode = TextNode(XCoord(3), YCoord(1), List(Text(s" $title ", Style(fg = theme.primary, bold = true))))
+    val bodyNodes: List[VNode] =
+      body.zipWithIndex.map { case (line, i) =>
+        TextNode(XCoord(3), YCoord(3 + i), List(Text(line, Style(fg = theme.foreground))))
+      }
+    val actionsRow = renderActions(choices, width, height - 1, theme)
+
+    Overlay(
+      position = position,
+      width = width,
+      height = height,
+      children = box :: titleNode :: bodyNodes ++ List(actionsRow),
+      inputCapture = InputCapture.Modal
+    )
+
+  /**
+   * Convenience wrapper around [[message]] for the common "yes/no" case.
+   *
+   * @param prompt  Single-line question rendered as the body.
+   * @param yesFocused Which button starts focused. `true` highlights "Yes",
+   *                   `false` highlights "No". Default `false` (the safer
+   *                   destructive-action convention).
+   */
+  def confirm(
+    prompt: String,
+    yesFocused: Boolean = false,
+    title: String = "Confirm",
+    yesLabel: String = "Yes",
+    noLabel: String = "No",
+    position: OverlayPosition = OverlayPosition.Centered
+  )(using Theme): Overlay =
+    message(
+      title = title,
+      body = List(prompt),
+      choices = List(Choice(yesLabel, yesFocused), Choice(noLabel, !yesFocused)),
+      position = position
+    )
+
+  // ---- internals -----------------------------------------------------------
+
+  private def choiceWidth(choices: List[Choice]): Int =
+    if choices.isEmpty then 0
+    else choices.map(c => c.label.length + 4).sum + (choices.size - 1) * 2
+
+  private def renderActions(choices: List[Choice], boxWidth: Int, row: Int, theme: Theme): VNode =
+    val totalLen = choiceWidth(choices)
+    val startX   = math.max(2, ((boxWidth - totalLen) / 2) + 1)
+    val segments: List[Text] =
+      choices.zipWithIndex.flatMap { case (c, idx) =>
+        val fg    = if c.focused then theme.primary else theme.foreground
+        val bold  = c.focused
+        val label = if c.focused then s"[ ${c.label} ]" else s"  ${c.label}  "
+        val gap   = if idx == choices.size - 1 then "" else "  "
+        List(Text(label, Style(fg = fg, bold = bold)), Text(gap, Style()))
+      }
+    TextNode(XCoord(startX), YCoord(row), segments)

--- a/modules/termflow/src/main/scala/termflow/tui/Overlay.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Overlay.scala
@@ -1,0 +1,111 @@
+package termflow.tui
+
+/**
+ * Position of an [[Overlay]] relative to the parent root frame.
+ *
+ * Resolved to absolute `(x, y)` coordinates by the renderer based on the
+ * overlay's own width/height and the root's frame dimensions, so apps don't
+ * have to recompute positions on resize.
+ */
+enum OverlayPosition:
+  /** Centred horizontally and vertically inside the root frame. */
+  case Centered
+
+  /** Pinned to the top-left corner with a small inset. */
+  case TopLeft
+
+  /** Pinned to the top-right corner with a small inset. */
+  case TopRight
+
+  /** Pinned to the bottom-left corner with a small inset. */
+  case BottomLeft
+
+  /** Pinned to the bottom-right corner with a small inset. */
+  case BottomRight
+
+  /** Anchored at an explicit `(x, y)`. The simple escape hatch. */
+  case At(x: XCoord, y: YCoord)
+
+object OverlayPosition:
+  /** Standard inset (1 cell from each edge) used by the corner positions. */
+  val cornerInset: Int = 1
+
+  /**
+   * Resolve a position to an absolute top-left `(x, y)` for an overlay of
+   * the given `(width, height)` rendered inside `(rootWidth, rootHeight)`.
+   *
+   * Off-screen results are clamped so an oversized overlay stays anchored
+   * at `(1, 1)` rather than producing negative coordinates.
+   */
+  def resolve(
+    pos: OverlayPosition,
+    overlayWidth: Int,
+    overlayHeight: Int,
+    rootWidth: Int,
+    rootHeight: Int
+  ): (XCoord, YCoord) =
+    val (rawX, rawY) = pos match
+      case Centered =>
+        val cx = ((rootWidth - overlayWidth) / 2) + 1
+        val cy = ((rootHeight - overlayHeight) / 2) + 1
+        (cx, cy)
+      case TopLeft =>
+        (1 + cornerInset, 1 + cornerInset)
+      case TopRight =>
+        ((rootWidth - overlayWidth - cornerInset) + 1, 1 + cornerInset)
+      case BottomLeft =>
+        (1 + cornerInset, (rootHeight - overlayHeight - cornerInset) + 1)
+      case BottomRight =>
+        ((rootWidth - overlayWidth - cornerInset) + 1, (rootHeight - overlayHeight - cornerInset) + 1)
+      case At(x, y) =>
+        (x.value, y.value)
+    val clampedX = math.max(1, rawX)
+    val clampedY = math.max(1, rawY)
+    (XCoord(clampedX), YCoord(clampedY))
+
+/**
+ * How an [[Overlay]] interacts with input directed at the underlying frame.
+ *
+ * The renderer enforces visual stacking unconditionally; input semantics are
+ * the caller's responsibility — apps decide based on the overlay's
+ * `inputCapture` whether to ignore base-view key events while the overlay is
+ * up. The renderer suppresses the base view's [[InputNode]] when any overlay
+ * sets `inputCapture = Modal`, so the hardware cursor follows the dialog.
+ */
+enum InputCapture:
+  /** Visual only; base view continues to own the cursor and receive input. */
+  case None
+
+  /** Base view's input is suppressed while this overlay is shown. */
+  case Modal
+
+/**
+ * A positioned, sized rectangle of children rendered on top of the base view.
+ *
+ * Use overlays for transient UI that doesn't reflow the base view: confirm
+ * dialogs, command palettes, autocompletion popups, devtools panes. The base
+ * view's `view` function does not need to know an overlay is up — apps
+ * compose `RootNode(... overlays = List(...))` from their model state.
+ *
+ * Overlays inside a `RootNode.overlays` list are drawn bottom-to-top in
+ * document order, so later entries paint over earlier ones.
+ *
+ * @param position     Where to anchor the overlay's top-left.
+ * @param width        Cell width.
+ * @param height       Cell height.
+ * @param children     Child VNodes. Coordinates are local to the overlay's
+ *                     own top-left when relative-coord layout lands; until
+ *                     then they are absolute (1-based) just like
+ *                     [[RootNode.children]].
+ * @param input        Optional input the overlay owns. Suppresses base
+ *                     view's input under [[InputCapture.Modal]].
+ * @param inputCapture Whether base-view input is suppressed.
+ */
+final case class Overlay(
+  position: OverlayPosition,
+  width: Int,
+  height: Int,
+  children: List[VNode],
+  input: Option[InputNode] = None,
+  inputCapture: InputCapture = InputCapture.None
+)

--- a/modules/termflow/src/main/scala/termflow/tui/vdom.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/vdom.scala
@@ -328,14 +328,20 @@ val InputNode = VNode.InputNode
  * of the drawing surface and are used by `AnsiRenderer.buildFrame` to size
  * the cell matrix.
  *
- * @param width Frame width in cells.
- * @param height Frame height in cells.
+ * @param width    Frame width in cells.
+ * @param height   Frame height in cells.
  * @param children Static nodes to draw, in document order.
- * @param input Optional focused [[InputNode]] rendered last, with cursor placement.
+ * @param input    Optional focused [[InputNode]] rendered last, with cursor placement.
+ * @param overlays Optional stack of [[Overlay]]s composited on top of the base
+ *                 view, in document order (bottom-to-top z-order). When any
+ *                 overlay sets `inputCapture = InputCapture.Modal`, the base
+ *                 view's `input` is suppressed and the topmost modal overlay's
+ *                 `input` (if any) takes over the hardware cursor.
  */
 final case class RootNode(
   width: Int,
   height: Int,
   children: List[VNode],
-  input: Option[InputNode]
+  input: Option[InputNode],
+  overlays: List[Overlay] = Nil
 )

--- a/modules/termflow/src/test/scala/termflow/tui/DialogsSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DialogsSpec.scala
@@ -1,0 +1,77 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class DialogsSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  test("Dialogs.confirm produces a centred modal overlay") {
+    val o = Dialogs.confirm("Delete file?")
+    assert(o.position == OverlayPosition.Centered)
+    assert(o.inputCapture == InputCapture.Modal)
+    assert(o.input.isEmpty)
+    assert(o.width >= 40)
+    assert(o.height >= 7)
+  }
+
+  test("Dialogs.confirm respects yesFocused for button highlight") {
+    val noFocused  = Dialogs.confirm("Sure?", yesFocused = false)
+    val yesFocused = Dialogs.confirm("Sure?", yesFocused = true)
+    assert(stringForm(noFocused).contains("[ No ]"))
+    assert(stringForm(yesFocused).contains("[ Yes ]"))
+  }
+
+  test("Dialogs.confirm honours custom labels and title") {
+    val o = Dialogs.confirm(
+      "Continue?",
+      title = "Are you sure",
+      yesLabel = "Proceed",
+      noLabel = "Abort"
+    )
+    val s = stringForm(o)
+    assert(s.contains("Are you sure"))
+    assert(s.contains("Proceed"))
+    assert(s.contains("Abort"))
+  }
+
+  test("Dialogs.message wraps title, body lines, and choices") {
+    val o = Dialogs.message(
+      title = "Update available",
+      body = List("A new version is ready.", "Install now?"),
+      choices = List(Dialogs.Choice("Later", focused = false), Dialogs.Choice("Install", focused = true))
+    )
+    val s = stringForm(o)
+    assert(s.contains("Update available"))
+    assert(s.contains("A new version is ready."))
+    assert(s.contains("Install now?"))
+    assert(s.contains("Later"))
+    assert(s.contains("[ Install ]"))
+  }
+
+  test("a confirm dialog actually composites as a modal over a base RootNode") {
+    val baseRoot = RootNode(
+      width = 80,
+      height = 24,
+      children = List(TextNode(XCoord(2), YCoord(2), List(Text("background", Style())))),
+      input = Some(InputNode(XCoord(2), YCoord(20), prompt = "x", style = Style(), cursor = 1))
+    )
+    val withDialog = baseRoot.copy(overlays = List(Dialogs.confirm("OK to proceed?")))
+    val frame      = AnsiRenderer.buildFrame(withDialog)
+    val rendered   = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("OK to proceed?"))
+    assert(frame.cursor.isEmpty, "modal dialog must take the cursor away from the base view")
+  }
+
+  // ---- helper: walk an overlay's tree into a flat string for assertions ---
+
+  private def stringForm(o: Overlay): String =
+    val sb = new StringBuilder
+    o.children.foreach(walk(_, sb))
+    o.input.foreach(in => sb.append(in.prompt))
+    sb.toString
+
+  private def walk(v: VNode, sb: StringBuilder): Unit = v match
+    case TextNode(_, _, runs)                => runs.foreach(t => sb.append(t.txt))
+    case BoxNode(_, _, _, _, children, _, _) => children.foreach(walk(_, sb))
+    case _                                   => ()

--- a/modules/termflow/src/test/scala/termflow/tui/OverlaySpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/OverlaySpec.scala
@@ -1,0 +1,147 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class OverlaySpec extends AnyFunSuite:
+
+  // ---- OverlayPosition.resolve --------------------------------------------
+
+  test("Centered places overlay at frame midpoint") {
+    val (x, y) = OverlayPosition.resolve(OverlayPosition.Centered, 20, 4, 80, 24)
+    assert(x.value == 31) // (80 - 20) / 2 + 1 = 31
+    assert(y.value == 11) // (24 - 4)  / 2 + 1 = 11
+  }
+
+  test("TopLeft pins to (1+inset, 1+inset)") {
+    val inset  = OverlayPosition.cornerInset
+    val (x, y) = OverlayPosition.resolve(OverlayPosition.TopLeft, 10, 4, 80, 24)
+    assert(x.value == 1 + inset)
+    assert(y.value == 1 + inset)
+  }
+
+  test("BottomRight pins to (rootW - w - inset + 1, rootH - h - inset + 1)") {
+    val inset  = OverlayPosition.cornerInset
+    val (x, y) = OverlayPosition.resolve(OverlayPosition.BottomRight, 10, 4, 80, 24)
+    assert(x.value == 80 - 10 - inset + 1) // = 70
+    assert(y.value == 24 - 4 - inset + 1)  // = 20
+  }
+
+  test("At passes coordinates through unchanged") {
+    val (x, y) = OverlayPosition.resolve(OverlayPosition.At(XCoord(5), YCoord(3)), 10, 4, 80, 24)
+    assert(x.value == 5)
+    assert(y.value == 3)
+  }
+
+  test("Oversized overlays clamp to (1, 1) instead of going negative") {
+    val (x, y) = OverlayPosition.resolve(OverlayPosition.Centered, 200, 100, 80, 24)
+    assert(x.value == 1)
+    assert(y.value == 1)
+  }
+
+  // ---- buildFrame compositing ---------------------------------------------
+
+  private val baseRoot: RootNode = RootNode(
+    width = 40,
+    height = 10,
+    children = List(TextNode(XCoord(2), YCoord(2), List(Text("base", Style())))),
+    input = None
+  )
+
+  test("RootNode.overlays default is empty (compat with existing call sites)") {
+    assert(baseRoot.overlays == Nil)
+  }
+
+  test("an overlay paints over the base content at its resolved position") {
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(2), YCoord(2)),
+      width = 4,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("OVER", Style()))))
+    )
+    val frame = AnsiRenderer.buildFrame(baseRoot.copy(overlays = List(overlay)))
+    // Row 1 (0-indexed) starting at column 1 (0-indexed)
+    val row     = frame.cells(1).map(_.ch).mkString
+    val painted = row.substring(1, 5)
+    assert(painted == "OVER", s"expected OVER overpaint at (2,2), got '$painted' in row '$row'")
+  }
+
+  test("non-modal overlay leaves base view input/cursor in place") {
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(10), YCoord(2)),
+      width = 5,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("hint!", Style()))))
+    )
+    val withInput = baseRoot.copy(
+      input = Some(InputNode(XCoord(2), YCoord(8), prompt = "ab", style = Style(), cursor = 1)),
+      overlays = List(overlay)
+    )
+    val frame = AnsiRenderer.buildFrame(withInput)
+    assert(frame.cursor.isDefined, "non-modal overlay must not suppress base cursor")
+    assert(frame.cursor.get.x.value == 3, "cursor at base input column 2 + cursor index 1")
+  }
+
+  test("modal overlay suppresses the base view's input cursor") {
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(2), YCoord(2)),
+      width = 5,
+      height = 1,
+      children = Nil,
+      inputCapture = InputCapture.Modal
+    )
+    val withInput = baseRoot.copy(
+      input = Some(InputNode(XCoord(2), YCoord(8), prompt = "ab", style = Style(), cursor = 1)),
+      overlays = List(overlay)
+    )
+    val frame = AnsiRenderer.buildFrame(withInput)
+    assert(frame.cursor.isEmpty, "modal overlay must suppress the base view's cursor")
+  }
+
+  test("modal overlay with its own input owns the cursor (translated to root coords)") {
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(10), YCoord(5)),
+      width = 8,
+      height = 3,
+      children = Nil,
+      input = Some(InputNode(XCoord(2), YCoord(2), prompt = "go", style = Style(), cursor = 2)),
+      inputCapture = InputCapture.Modal
+    )
+    val frame = AnsiRenderer.buildFrame(baseRoot.copy(overlays = List(overlay)))
+    assert(frame.cursor.isDefined, "overlay's own input should produce a cursor")
+    val c = frame.cursor.get
+    // overlay (10, 5) + input local (2, 2) → absolute (11, 6); cursor at index 2 → x = 13.
+    assert(c.x.value == 13, s"expected x=13, got ${c.x.value}")
+    assert(c.y.value == 6, s"expected y=6, got ${c.y.value}")
+  }
+
+  test("multiple overlays paint bottom-to-top in document order") {
+    val low = Overlay(
+      position = OverlayPosition.At(XCoord(2), YCoord(2)),
+      width = 4,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("LOWX", Style()))))
+    )
+    val high = Overlay(
+      position = OverlayPosition.At(XCoord(2), YCoord(2)),
+      width = 4,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("HIGH", Style()))))
+    )
+    val frame   = AnsiRenderer.buildFrame(baseRoot.copy(overlays = List(low, high)))
+    val painted = frame.cells(1).map(_.ch).mkString.substring(1, 5)
+    assert(painted == "HIGH", s"top-of-stack overlay should win, got $painted")
+  }
+
+  test("renderPatch emits the overlay content after the base") {
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(2), YCoord(2)),
+      width = 4,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("TOP!", Style(fg = Color.Red)))))
+    )
+    val out        = AnsiRenderer.renderPatch(baseRoot.copy(overlays = List(overlay)))
+    val baseIdx    = out.indexOf("base")
+    val overlayIdx = out.indexOf("TOP!")
+    assert(baseIdx >= 0 && overlayIdx >= 0)
+    assert(overlayIdx > baseIdx, "overlay text must come after base text in the render order")
+  }


### PR DESCRIPTION
First half of #153. Stage 1 §4.2 from `docs/ROADMAP.md`.

## Summary
Visual modal-overlay primitive plus two dialog helpers built on top. TermFlow had no answer for "show a confirm dialog over the current screen" — every consumer was on track to reinvent z-ordering. This PR ships the foundation: a single `Overlay` ADT, a `RootNode.overlays` list, renderer compositing, modal input suppression, and `Dialogs.confirm` / `Dialogs.message` helpers. The dialog's open/closed state lives in the app's model — the helpers are pure presentation.

## Public API
```scala
enum OverlayPosition:
  case Centered, TopLeft, TopRight, BottomLeft, BottomRight
  case At(x: XCoord, y: YCoord)

enum InputCapture:
  case None    // visual only; base view keeps cursor
  case Modal   // base view's input is suppressed

final case class Overlay(
  position: OverlayPosition,
  width: Int,
  height: Int,
  children: List[VNode],
  input: Option[InputNode] = None,
  inputCapture: InputCapture = InputCapture.None
)

// RootNode gains an additive `overlays: List[Overlay] = Nil` field.

object Dialogs:
  def confirm(prompt: String, ...): Overlay
  def message(title: String, body: List[String], choices: List[Choice], ...): Overlay
```

Renderer behaviour:
- Overlays are composited bottom-to-top in document order in both the live-render path (`renderPatch`) and `buildFrame`. Each overlay's children are authored in **overlay-local coordinates** (`(1.x, 1.y)` is the overlay's top-left); the renderer translates to absolute via `Layout.translate`.
- When any overlay sets `inputCapture = Modal`, the base view's `InputNode` is suppressed. If the topmost-modal overlay has its own `input`, it takes over and its cursor is translated into the root frame.
- Overlays auto-position on resize — apps don't recompute coordinates.

## Why this scope, not the full Layer stack
The issue spec also calls for a runtime sub-app `Layer[Model, Msg]` stack with `pushLayer` / `popLayer` / `onResult` plumbing. That's the right end-state, but it pulls in existential types over `(Model, Msg)` and a per-layer `Cmd` / `Sub` lifecycle that's a substantial PR on its own. The visual primitive is the strict subset every higher-level layering scheme builds on, and it's enough to ship `MessageDialog` / `ConfirmDialog` today. I'd retitle #153 after this merges to scope the follow-up.

## Sample app
`sbt dialogDemo` — a counter with a "press d to confirm reset" modal. Demonstrates that base-view bindings (`+`/`-`/`q`) are suppressed while the dialog is up, by pattern-matching on `model.dialog` in `update`. Left/right move focus between Yes/No; Enter activates; Esc cancels.

## Tests
- New `OverlaySpec` (10 tests): position resolution for every variant including the oversized-clamp case, `RootNode` default empty overlays, base-paint-then-overpaint, non-modal preserves base cursor, modal suppresses base cursor, overlay's own input owns the cursor with correct root-coord translation, multi-overlay z-order, `renderPatch` emission order.
- New `DialogsSpec` (5 tests): `Dialogs.confirm` produces a centred modal, `yesFocused` selects the highlighted choice, custom labels/title honoured, `Dialogs.message` wraps title/body/choices, end-to-end composite of `Dialogs.confirm` over a base `RootNode` confirms the rendered text + cursor suppression.
- All 427 existing tests still pass; `sbt ciCheck` green.

## Test plan
- [ ] `sbt dialogDemo` — open/close the dialog with `d` / `Esc`, switch focus with arrows, confirm reset, verify base bindings are inert while dialog is up.
- [ ] Spot-check existing apps (`hubDemo`, `widgetsDemo`) — `RootNode.overlays` defaults to `Nil` so visuals must be unchanged.
- [ ] Confirm goldens are unchanged.

## Follow-up issues (will file after merge)
1. Sub-app Layer stack with `pushLayer` / `popLayer` / `onResult`.
2. `Dialogs.textInput`, `Dialogs.listSelect`, `Dialogs.fileOpen` — Lanterna parity, all built on `Overlay`.