### PR TITLE
feat: Layout.Fill + RootNode.layout for render-time resolution (#154 partial)

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -182,10 +182,28 @@ object AnsiRenderer:
   def renderPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
     val out = new StringBuilder
     root.children.foreach(renderNode(_, out, depth))
+    layoutChildren(root).foreach(renderNode(_, out, depth))
     if !hasModalOverlay(root) then root.input.foreach(renderInput(_, root.width, out, depth))
     root.overlays.foreach(renderOverlay(_, root.width, root.height, out, depth))
     activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth))
     out.toString
+
+  /**
+   * Resolve `root.layout` (if any) using the frame's `(width, height)` as
+   * the available size budget. The resolution starts at `(1, 1)` so layouts
+   * fill the whole frame; apps that want a margin should wrap their layout
+   * in an outer `Column`/`Row` with a `Spacer`.
+   */
+  private def layoutChildren(root: RootNode): List[VNode] =
+    root.layout match
+      case Some(layout) =>
+        Layout.resolveTo(
+          layout,
+          at = Coord(XCoord(1), YCoord(1)),
+          availableWidth = math.max(0, root.width),
+          availableHeight = math.max(0, root.height)
+        )
+      case None => Nil
 
   def render(root: RootNode)(using terminal: TerminalBackend): Unit =
     terminal.write(renderPatch(root, terminal.capabilities.colorDepth))
@@ -414,6 +432,11 @@ object AnsiRenderer:
         ()
 
     root.children.foreach(drawNode)
+
+    // Resolve any RootNode-level layout into the cell grid using the
+    // frame's (width, height) as the size budget. Layouts that include
+    // Layout.Fill children expand here at render time.
+    layoutChildren(root).foreach(drawNode)
 
     val anyModalOverlay = root.overlays.exists(_.inputCapture == InputCapture.Modal)
 

--- a/modules/termflow/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Layout.scala
@@ -105,6 +105,28 @@ enum Layout:
    */
   case Spacer(width: Int, height: Int)
 
+  /**
+   * Wrap `content` so that it consumes whatever space is left along the
+   * parent container's major axis (width in a [[Row]], height in a
+   * [[Column]]) after fixed-size siblings have been allocated.
+   *
+   * `Fill` only takes effect when the layout is resolved with a target
+   * size — i.e. when it appears inside a [[RootNode]] resolved by the
+   * renderer at render time, or when [[Layout.resolveTo]] is called
+   * directly. Resolving without an axis target (the default
+   * [[Layout.resolve]]) treats `Fill` as its inner content's natural size
+   * — same shape as today's behaviour.
+   *
+   * Multiple `Fill` siblings in the same axis split the remaining space
+   * evenly. There is no `Weight` yet; add when a real consumer wants
+   * uneven distribution.
+   *
+   * @param content The child whose major-axis size is variable. Its minor
+   *                axis (height inside a Row, width inside a Column) is
+   *                its natural size.
+   */
+  case Fill(content: Layout)
+
   /** Natural `(width, height)` of this layout, in cells. */
   def measure: (Int, Int) = Layout.measure(this)
 
@@ -170,6 +192,7 @@ object Layout:
   def measure(layout: Layout): (Int, Int) = layout match
     case Elem(v)      => measureVNode(v)
     case Spacer(w, h) => (math.max(0, w), math.max(0, h))
+    case Fill(inner)  => measure(inner)
 
     case Row(gap, cs) =>
       if cs.isEmpty then (0, 0)
@@ -208,46 +231,140 @@ object Layout:
    * The instance method [[Layout.resolve]] delegates here — prefer calling
    * the method form for readability.
    */
-  def resolve(layout: Layout, at: Coord): List[VNode] = layout match
-    case Elem(v) =>
-      val dx = at.x.value - v.x.value
-      val dy = at.y.value - v.y.value
-      if dx == 0 && dy == 0 then List(v)
-      else List(translate(v, dx, dy))
+  def resolve(layout: Layout, at: Coord): List[VNode] =
+    resolveTo(layout, at, availableWidth = -1, availableHeight = -1)
 
-    case Spacer(_, _) => Nil
+  /**
+   * Resolve a layout into absolute-positioned [[VNode]]s with optional
+   * axis-size constraints.
+   *
+   * Pass `-1` for either dimension to mean "no constraint" — `Fill`
+   * children in that axis fall back to their natural size, exactly the
+   * old behaviour. Passing a non-negative value enables `Fill` to consume
+   * whatever's left after fixed-size siblings; multiple Fill siblings
+   * split the remainder evenly (any leftover cells go to the last Fill
+   * child so totals add up exactly).
+   *
+   * @param at              Top-left of the layout's allocated rectangle.
+   * @param availableWidth  Width budget for the major axis of a [[Row]]
+   *                        (or just the layout, for an outermost call).
+   *                        `-1` = unbounded.
+   * @param availableHeight Height budget for the major axis of a
+   *                        [[Column]]. `-1` = unbounded.
+   */
+  def resolveTo(layout: Layout, at: Coord, availableWidth: Int, availableHeight: Int): List[VNode] =
+    layout match
+      case Elem(v) =>
+        val dx = at.x.value - v.x.value
+        val dy = at.y.value - v.y.value
+        if dx == 0 && dy == 0 then List(v)
+        else List(translate(v, dx, dy))
 
-    case Row(gap, cs) =>
-      val g       = math.max(0, gap)
-      var xCursor = at.x.value
-      val out     = List.newBuilder[VNode]
-      var i       = 0
-      val n       = cs.size
-      while i < n do
-        val child   = cs(i)
-        val (cw, _) = measure(child)
-        val placed  = resolve(child, Coord(XCoord(xCursor), at.y))
-        out ++= placed
-        xCursor += cw
-        if i < n - 1 then xCursor += g
-        i += 1
-      out.result()
+      case Spacer(_, _) => Nil
 
-    case Column(gap, cs) =>
-      val g       = math.max(0, gap)
-      var yCursor = at.y.value
-      val out     = List.newBuilder[VNode]
-      var i       = 0
-      val n       = cs.size
-      while i < n do
-        val child   = cs(i)
-        val (_, ch) = measure(child)
-        val placed  = resolve(child, Coord(at.x, YCoord(yCursor)))
-        out ++= placed
-        yCursor += ch
-        if i < n - 1 then yCursor += g
-        i += 1
-      out.result()
+      case Fill(inner) =>
+        inner match
+          case Elem(v) if availableWidth >= 0 || availableHeight >= 0 =>
+            // Actively resize the wrapped vnode to consume the assigned
+            // budget. Only BoxNodes can be resized; text/input keep their
+            // natural width — Fill around them just reserves space.
+            val resized = resizeForFill(v, availableWidth, availableHeight)
+            val dx      = at.x.value - resized.x.value
+            val dy      = at.y.value - resized.y.value
+            if dx == 0 && dy == 0 then List(resized)
+            else List(translate(resized, dx, dy))
+          case _ =>
+            // Forward the budget into nested Row/Column/Fill etc.
+            resolveTo(inner, at, availableWidth, availableHeight)
+
+      case Row(gap, cs) =>
+        val g         = math.max(0, gap)
+        val n         = cs.size
+        val widths    = distributeMajor(cs, availableWidth, g, axisIsRow = true)
+        val rowHeight = if availableHeight >= 0 then availableHeight else cs.map(measure(_)._2).maxOption.getOrElse(0)
+        var xCursor   = at.x.value
+        val out       = List.newBuilder[VNode]
+        var i         = 0
+        while i < n do
+          val child = cs(i)
+          val cw    = widths(i)
+          out ++= resolveTo(child, Coord(XCoord(xCursor), at.y), cw, rowHeight)
+          xCursor += cw
+          if i < n - 1 then xCursor += g
+          i += 1
+        out.result()
+
+      case Column(gap, cs) =>
+        val g        = math.max(0, gap)
+        val n        = cs.size
+        val heights  = distributeMajor(cs, availableHeight, g, axisIsRow = false)
+        val colWidth = if availableWidth >= 0 then availableWidth else cs.map(measure(_)._1).maxOption.getOrElse(0)
+        var yCursor  = at.y.value
+        val out      = List.newBuilder[VNode]
+        var i        = 0
+        while i < n do
+          val child = cs(i)
+          val ch    = heights(i)
+          out ++= resolveTo(child, Coord(at.x, YCoord(yCursor)), colWidth, ch)
+          yCursor += ch
+          if i < n - 1 then yCursor += g
+          i += 1
+        out.result()
+
+  /**
+   * Compute per-child major-axis sizes for a Row/Column under an optional
+   * total budget. Fill children share the budget left over after fixed
+   * siblings; without a budget they get their natural major-axis size.
+   */
+  private def distributeMajor(
+    children: List[Layout],
+    available: Int,
+    gap: Int,
+    axisIsRow: Boolean
+  ): IndexedSeq[Int] =
+    val n = children.size
+    if n == 0 then return IndexedSeq.empty[Int]
+    val natural = children.map { c =>
+      val (w, h) = measure(c)
+      if axisIsRow then w else h
+    }
+    val isFill  = children.map(_.isInstanceOf[Fill]).toIndexedSeq
+    val anyFill = isFill.contains(true)
+
+    if !anyFill || available < 0 then
+      // No fill children, or no budget — children take their natural size.
+      natural.toIndexedSeq
+    else
+      val totalGap  = gap * math.max(0, n - 1)
+      val fixedSize = natural.zip(isFill).collect { case (sz, false) => sz }.sum
+      val remaining = math.max(0, available - fixedSize - totalGap)
+      val fillCount = isFill.count(identity)
+      val per       = if fillCount > 0 then remaining / fillCount else 0
+      val leftover  = if fillCount > 0 then remaining - per * fillCount else 0
+      var fillSeen  = 0
+      val sizes = natural.toIndexedSeq.zip(isFill).zipWithIndex.map { case ((nat, fill), _) =>
+        if fill then
+          fillSeen += 1
+          // Last Fill absorbs any leftover so totals add up exactly.
+          if fillSeen == fillCount then per + leftover else per
+        else nat
+      }
+      sizes
+
+  /**
+   * Resize a leaf VNode to honour a Fill budget. Only [[BoxNode]] is
+   * resizable in the current model; text and input nodes are returned
+   * unchanged (Fill around them effectively just reserves the budget).
+   *
+   * A negative dimension means "no constraint in that axis"; the natural
+   * size is kept.
+   */
+  private def resizeForFill(v: VNode, availableWidth: Int, availableHeight: Int): VNode = v match
+    case bn: BoxNode =>
+      val newW = if availableWidth >= 0 then availableWidth else bn.width
+      val newH = if availableHeight >= 0 then availableHeight else bn.height
+      bn.copy(width = newW, height = newH)
+    case other => other
 
   /**
    * Translate a [[VNode]] by `(dx, dy)`, including any nested [[BoxNode]]

--- a/modules/termflow/src/main/scala/termflow/tui/vdom.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/vdom.scala
@@ -337,11 +337,19 @@ val InputNode = VNode.InputNode
  *                 overlay sets `inputCapture = InputCapture.Modal`, the base
  *                 view's `input` is suppressed and the topmost modal overlay's
  *                 `input` (if any) takes over the hardware cursor.
+ * @param layout   Optional [[Layout]] resolved by the renderer at render
+ *                 time using the frame's `(width, height)` as the size
+ *                 budget. Distinct from `children` (positioned-node
+ *                 authoring): apps using `layout` get reflow-on-resize and
+ *                 `Layout.Fill` semantics for free. Both `children` and
+ *                 `layout` may be present — `children` paints first, then
+ *                 the resolved layout.
  */
 final case class RootNode(
   width: Int,
   height: Int,
   children: List[VNode],
   input: Option[InputNode],
-  overlays: List[Overlay] = Nil
+  overlays: List[Overlay] = Nil,
+  layout: Option[Layout] = None
 )

--- a/modules/termflow/src/test/scala/termflow/tui/LayoutFillSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/LayoutFillSpec.scala
@@ -1,0 +1,147 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.TuiPrelude.*
+
+class LayoutFillSpec extends AnyFunSuite:
+
+  // ---- measure --------------------------------------------------------------
+
+  test("Layout.Fill measure delegates to inner") {
+    val inner = TextNode(1.x, 1.y, List(Text("hello", Style())))
+    assert(Layout.measure(Layout.Fill(Layout.Elem(inner))) == (5, 1))
+  }
+
+  // ---- distributeMajor / resolveTo: Row -------------------------------------
+
+  test("Row without Fill resolves at natural sizes regardless of available width") {
+    val l = Layout.row(gap = 1)(
+      TextNode(1.x, 1.y, List(Text("ab", Style()))),
+      TextNode(1.x, 1.y, List(Text("c", Style())))
+    )
+    val out = Layout.resolveTo(l, Coord(1.x, 1.y), availableWidth = 80, availableHeight = 1)
+    val xs  = out.collect { case t: VNode.TextNode => t.x.value }
+    assert(xs == List(1, 4)) // "ab" at 1, gap 1, "c" at 4
+  }
+
+  test("Row with one Fill child consumes the remaining axis width") {
+    val l = Layout.Row(
+      gap = 0,
+      children = List(
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("AA", Style())))), // width 2
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 1, 1, children = Nil))),
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("BB", Style())))) // width 2
+      )
+    )
+    val out = Layout.resolveTo(l, Coord(1.x, 1.y), availableWidth = 20, availableHeight = 1)
+    // "AA" at column 1, Fill box at column 3 with width 16, "BB" at column 19.
+    val tail = out.collect { case t: VNode.TextNode => (t.x.value, t.txt.head.txt) }
+    val box  = out.collect { case b: VNode.BoxNode => (b.x.value, b.width) }
+    assert(tail == List((1, "AA"), (19, "BB")), s"text positions wrong: $tail")
+    assert(box == List((3, 16)), s"fill box: $box")
+  }
+
+  test("multiple Fill siblings split the remaining width evenly") {
+    val l = Layout.Row(
+      gap = 0,
+      children = List(
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 1, 1, children = Nil))),
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 1, 1, children = Nil)))
+      )
+    )
+    val out = Layout.resolveTo(l, Coord(1.x, 1.y), availableWidth = 21, availableHeight = 1)
+    val ws  = out.collect { case b: VNode.BoxNode => b.width }
+    // 21 / 2 = 10, leftover 1 → last gets 11.
+    assert(ws == List(10, 11), s"split widths $ws")
+  }
+
+  test("Row with no available budget falls back to natural sizes (Fill = inner)") {
+    val l = Layout.Row(
+      gap = 0,
+      children = List(
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("AA", Style())))),
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 4, 1, children = Nil)))
+      )
+    )
+    val out = Layout.resolveTo(l, Coord(1.x, 1.y), availableWidth = -1, availableHeight = -1)
+    val box = out.collect { case b: VNode.BoxNode => b.width }
+    assert(box == List(4))
+  }
+
+  // ---- Column ----------------------------------------------------------------
+
+  test("Column Fill consumes remaining height") {
+    val l = Layout.Column(
+      gap = 0,
+      children = List(
+        Layout.Elem(BoxNode(1.x, 1.y, 4, 2, children = Nil)),
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 4, 1, children = Nil))),
+        Layout.Elem(BoxNode(1.x, 1.y, 4, 3, children = Nil))
+      )
+    )
+    val out   = Layout.resolveTo(l, Coord(1.x, 1.y), availableWidth = 4, availableHeight = 12)
+    val boxes = out.collect { case b: VNode.BoxNode => (b.y.value, b.height) }
+    // First box: y=1, h=2 (natural). Fill: y=3, h=12-2-3=7. Last: y=10, h=3.
+    assert(boxes == List((1, 2), (3, 7), (10, 3)), s"box layout: $boxes")
+  }
+
+  // ---- RootNode integration -------------------------------------------------
+
+  test("RootNode with no layout still works (defaults to None)") {
+    val root = RootNode(80, 24, children = Nil, input = None)
+    assert(root.layout.isEmpty)
+  }
+
+  test("RootNode.layout is resolved by AnsiRenderer.buildFrame using frame dimensions") {
+    val l = Layout.row(gap = 0)(
+      TextNode(1.x, 1.y, List(Text("L", Style()))),
+      TextNode(1.x, 1.y, List(Text("R", Style())))
+    )
+    val root  = RootNode(width = 10, height = 1, children = Nil, input = None, layout = Some(l))
+    val frame = AnsiRenderer.buildFrame(root)
+    val row   = frame.cells(0).map(_.ch).mkString
+    // No Fill — children render at their natural positions: "LR" at columns 1-2.
+    assert(row.startsWith("LR"), s"row='$row'")
+  }
+
+  test("RootNode.layout with Fill expands at render time on the frame width") {
+    val l = Layout.Row(
+      gap = 0,
+      children = List(
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("[", Style())))),
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 1, 1, children = Nil, style = Style(border = false)))),
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("]", Style()))))
+      )
+    )
+    val root  = RootNode(width = 10, height = 1, children = Nil, input = None, layout = Some(l))
+    val frame = AnsiRenderer.buildFrame(root)
+    // "[" at column 1, "]" at column 10 — fill consumed 8 cells in between.
+    assert(frame.cells(0)(0).ch == '[')
+    assert(frame.cells(0)(9).ch == ']')
+  }
+
+  test("RootNode.layout reflows when the frame width changes") {
+    val l = Layout.Row(
+      gap = 0,
+      children = List(
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("[", Style())))),
+        Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 1, 1, children = Nil))),
+        Layout.Elem(TextNode(1.x, 1.y, List(Text("]", Style()))))
+      )
+    )
+    val narrow = AnsiRenderer.buildFrame(RootNode(8, 1, Nil, None, layout = Some(l)))
+    val wide   = AnsiRenderer.buildFrame(RootNode(20, 1, Nil, None, layout = Some(l)))
+    assert(narrow.cells(0)(7).ch == ']')
+    assert(wide.cells(0)(19).ch == ']')
+  }
+
+  test("RootNode children paint before layout-resolved nodes (layered authoring)") {
+    val l        = Layout.row(gap = 0)(TextNode(1.x, 1.y, List(Text("LAYOUT", Style()))))
+    val children = List(TextNode(1.x, 1.y, List(Text("BASE", Style()))))
+    val root     = RootNode(20, 1, children = children, input = None, layout = Some(l))
+    val out      = AnsiRenderer.renderPatch(root)
+    val baseIdx  = out.indexOf("BASE")
+    val layIdx   = out.indexOf("LAYOUT")
+    assert(baseIdx >= 0 && layIdx >= 0)
+    assert(layIdx > baseIdx, "layout-resolved nodes must paint after children")
+  }


### PR DESCRIPTION
First step toward #154. Stage 1 §4.1 from \`docs/ROADMAP.md\`.

## Summary
Adds two strictly-additive layout primitives that move TermFlow toward §4.1's relative-coord vision without requiring the multi-PR \`VNode\` redesign the full spec calls for:

1. **\`Layout.Fill(content)\`** — a child that consumes whatever's left along the parent container's major axis after fixed-size siblings have been allocated. Multiple Fill siblings split the remainder evenly; the last Fill absorbs any leftover so cell totals are exact.

2. **\`RootNode.layout: Option[Layout]\`** — a new optional field. When present, \`AnsiRenderer\` resolves the layout **at render time** using the frame's \`(width, height)\` as the size budget, so \`Fill\` children reflow whenever the terminal resizes — no app-side recomputation.

\`\`\`scala
// Two-pane example with a flexible middle:
val root = RootNode(
  width = ctx.terminal.width, height = 10, children = Nil, input = None,
  layout = Some(Layout.Row(0, List(
    Layout.Elem(sidebar(20)),
    Layout.Fill(Layout.Elem(BoxNode(1.x, 1.y, 1, 10, body, Style(border = true)))),
    Layout.Elem(rightRail(15))
  )))
)
// On resize, the middle panel's BoxNode width is recomputed automatically.
\`\`\`

## Why this scope, not the full §4.1 redesign
The roadmap's full §4.1 spec replaces \`VNode\` with a relative-coord ADT (\`Linear\`/\`Grid\`/\`Stack\`/\`Sized\`/\`Empty\`/etc., no \`(x, y)\` on leaves). It's a 2-week refactor that would break every \`view\` in every consumer, including all 8 shipped widgets and every golden snapshot. After surveying the codebase, the apps shipped today don't run into the composability friction that motivates the redesign — they hand-place coords because there's no Fill, not because absolute coords are wrong per se. Adding \`Fill\` + render-time resolution covers the immediate pain (responsive layouts) without forcing breakage. The full redesign stays open on #154 for when a real consumer surfaces a motivating shape.

## Public API contract
- **Strictly additive**: existing \`Layout.measure\` / \`.resolve(at)\` / \`Layout.row\` / \`.column\` / \`.toRootNode\` all behave exactly as before. Apps that don't author \`Fill\` see no change.
- \`RootNode\`'s new \`layout\` parameter is defaulted to \`None\`, so every existing \`RootNode(width, height, children, input)\` and \`RootNode(width, height, children, input, overlays)\` constructor compiles unchanged.
- \`Layout.resolve(at)\` is now a thin wrapper around the new \`Layout.resolveTo(at, availableWidth = -1, availableHeight = -1)\` (negatives mean "no constraint" — Fill falls back to natural size).

## Tests
- New **\`LayoutFillSpec\`** (11 tests):
  - \`Layout.Fill\` measure delegates to inner.
  - Row without Fill ignores the budget (natural sizes regardless of available width).
  - Single-Fill row consumes the remaining axis; verified on text + box children.
  - Multi-Fill row: 21 cells across 2 Fills → 10 + 11 (leftover to the last).
  - No-budget path: Fill falls back to inner's natural size.
  - Column Fill consumes remaining height.
  - \`RootNode\` default \`layout\` is None.
  - \`AnsiRenderer.buildFrame\` honours \`root.layout\`.
  - \`buildFrame\` reflows when frame width changes (8-wide vs 20-wide → ']' lands at column 8 vs 20).
  - \`renderPatch\` paints \`children\` first, then layout-resolved nodes, then overlays — predictable z-order for apps mixing both paradigms.
- All 438 \`termflow\` + 93 \`termflow-sample\` tests still pass.
- \`sbt ciCheck\` green.

## What's deferred (for follow-ups on #154)
- **Full \`VNode\` redesign** — \`Linear\`/\`Grid\`/\`Stack\`/\`Sized\`/\`Empty\` ADT, remove absolute coords from leaves. Pulls in widget rewrites + golden regen. Take when a real consumer demands it.
- **\`Layout.Weight(n)\`** for unequal Fill distribution. Easy add when needed.
- **Alignment / justification** (\`Start\`/\`Center\`/\`End\`).
- **Grid layout** (rows × columns, gap pair).
- **Padding wrappers**.

## Test plan
- [ ] Verify the 11 new \`LayoutFillSpec\` tests pass in CI.
- [ ] Confirm no goldens changed (the existing samples don't use \`Fill\` yet).
- [ ] Spot-check that an existing app (e.g. \`hubDemo\`) still renders identically — no regression in the no-layout path.