### PR TITLE
fix: decode CR (byte 13) as Enter, not Ctrl('M')

### DIFF
--- a/modules/termflow/src/main/scala/termflow/tui/History.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/History.scala
@@ -92,7 +92,7 @@ object PromptHistory:
         (cleared, Some(Cmd.Exit))
 
       // Enter: commit line to history and parse
-      case KeyDecoder.InputKey.Ctrl('M') | KeyDecoder.InputKey.Enter =>
+      case KeyDecoder.InputKey.Enter =>
         val line                     = Prompt.render(state.prompt)
         val (nextHistory, nextStore) = addToHistory(state.history, state.store, line)
         val result                   = toMsg(PromptLine(line))

--- a/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
@@ -38,8 +38,12 @@ object KeyDecoder:
 
   def decode(key: Int): InputKey =
     key match
-      case 10  => Enter
-      case 127 => Backspace
+      // Both CR (13, what most terminals send for Enter in raw mode where
+      // CR-to-LF translation is disabled) and LF (10) decode as Enter.
+      // Ctrl+M produces byte 13 too — at this layer we cannot distinguish
+      // it from Enter, so we standardise on the higher-level intent.
+      case 10 | 13 => Enter
+      case 127     => Backspace
       case code if code >= 1 && code <= 26 =>
         Ctrl(('A' + code - 1).toChar)
       case code if code >= 32 && code <= 126 =>

--- a/modules/termflow/src/main/scala/termflow/tui/Prompt.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Prompt.scala
@@ -32,7 +32,7 @@ object Prompt:
       case KeyDecoder.InputKey.Ctrl('C') | KeyDecoder.InputKey.Ctrl('D') =>
         (State(Vector.empty, 0), Some(Cmd.Exit))
 
-      case KeyDecoder.InputKey.Ctrl('M') | KeyDecoder.InputKey.Enter =>
+      case KeyDecoder.InputKey.Enter =>
         val raw = render(state)
         val cmd = toMsg(PromptLine(raw)).fold(err => Cmd.TermFlowErrorCmd(err), g => Cmd.GCmd(g))
         (State(Vector.empty, 0), Some(cmd))

--- a/modules/termflow/src/test/scala/termflow/tui/KeyDecoderSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/KeyDecoderSpec.scala
@@ -5,8 +5,12 @@ import termflow.tui.KeyDecoder.InputKey
 
 class KeyDecoderSpec extends AnyFunSuite:
 
-  test("decode Enter key"):
+  test("decode Enter key — both LF (10) and CR (13)"):
+    // Cooked terminals deliver Enter as LF (10); JLine raw mode disables
+    // CR-to-LF translation and delivers CR (13). Both must decode to Enter
+    // so dialogs/Prompt/History don't have to special-case Ctrl('M').
     assert(KeyDecoder.decode(10) == InputKey.Enter)
+    assert(KeyDecoder.decode(13) == InputKey.Enter)
 
   test("decode Backspace key"):
     assert(KeyDecoder.decode(127) == InputKey.Backspace)


### PR DESCRIPTION
Fixes the Enter key in dialogs, the Stage 1 showcase, and any future app that uses \`InputKey.Enter\` directly.

## Root cause
\`JLineTerminalBackend.enterRawMode()\` puts the tty in raw mode, which disables CR-to-LF translation on input. So when the user presses Enter, the terminal delivers byte **13** (CR), not byte 10 (LF).

\`KeyDecoder.decode\` only mapped \`case 10 => Enter\`. Byte 13 then fell into the \`Ctrl(A..Z)\` range and was delivered to consumers as **\`Ctrl('M')\`**.

Two existing consumers — \`Prompt.handleKey\` and \`History.handleKey\` — papered over this with a per-call-site workaround:

\`\`\`scala
case KeyDecoder.InputKey.Ctrl('M') | KeyDecoder.InputKey.Enter => …
\`\`\`

Anything written without that workaround (the new \`Dialogs\` helpers, the \`DialogDemoApp\`, the Stage 1 showcase, plus future apps) silently dropped Enter — pressing it in a confirm dialog matched no case and the app did nothing.

## Fix
One line in \`KeyDecoder\`:

\`\`\`scala
- case 10  => Enter
+ case 10 | 13 => Enter
\`\`\`

Apps that genuinely want to distinguish Ctrl+M from Enter cannot at this layer (both produce byte 13), and that's the right model — they're the same key press on every common terminal.

The two workaround sites in \`Prompt\` and \`History\` collapse back to a plain \`case Enter =>\` match — same behaviour, no special case to remember.

## Tests
- \`KeyDecoderSpec\` "decode Enter key" now asserts **both** LF (10) and CR (13) decode to \`Enter\`, with a comment pinning the raw-mode rationale.
- All 531 tests across \`termflow\` / \`termflow-testkit\` / \`termflow-sample\` still pass; \`sbt ciCheck\` green.

## Caller-impact summary
| Consumer | Before | After |
|---|---|---|
| \`Prompt.handleKey\` | Worked via \`Ctrl('M') \| Enter\` workaround | Works via \`Enter\` (workaround removed) |
| \`History.handleKey\` | Worked via \`Ctrl('M') \| Enter\` workaround | Works via \`Enter\` (workaround removed) |
| \`Dialogs.confirm\` / \`DialogDemoApp\` | Enter was a no-op (silent fail) | Enter activates the focused choice |
| Stage 1 showcase (PR #163) | Enter was a no-op | Enter activates the focused dialog choice |

## Note on Esc
The reporter's other half — "esc doesn't do the default cancel action" — should already work correctly: \`KeyDecoder\` returns \`Escape\` for a bare ESC byte after a 50ms timeout, and the dialog dispatch maps \`Escape => CloseDialog\`. The fact that arrow keys (also escape sequences) come through correctly confirms the ESC-byte path is intact. If Esc still doesn't behave after this fix lands, please open a separate issue with reproduction details — most likely a stray byte in the input buffer that would need different investigation.

## Test plan
- [ ] \`sbt dialogDemo\` → press \`d\` → press Enter → confirm "No" closes the dialog (count not reset).
- [ ] \`sbt dialogDemo\` → press \`d\` → arrow → Enter → confirm "Yes" resets the count.
- [ ] \`sbt dialogDemo\` → press \`d\` → Esc → confirm dialog closes.
- [ ] After PR #163 lands, \`sbt showcase\` → press \`q\` → arrow → Enter (Quit) actually exits.