### PR TITLE
Stage 2 — capability expansion (mouse, paste, unicode, modifiers, styles)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -165,3 +165,4 @@ addCommandAlias("inputDemo",    "termflowSample/runMain termflow.apps.input.Inpu
 addCommandAlias("themeDemo",    "termflowSample/runMain termflow.apps.themes.ThemeDemoApp")
 addCommandAlias("dialogDemo",   "termflowSample/runMain termflow.apps.dialog.DialogDemoApp")
 addCommandAlias("showcase",     "termflowSample/runMain termflow.apps.showcase.Stage1ShowcaseApp")
+addCommandAlias("unicodeDemo",  "termflowSample/runMain termflow.apps.unicode.UnicodeDemoApp")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,8 +84,8 @@ full notes live at the bottom of the document (§9).
 
 | Stage | Versions | Theme | Status |
 |---|---|---|---|
-| 1 | 0.3.x | **Foundational refactor**: layout, layers, theme split, capabilities | proposed |
-| 2 | 0.4.x | **Capability expansion**: mouse, 256/truecolor, unicode width, paste | proposed |
+| 1 | 0.3.x | **Foundational refactor**: layout, layers, theme split, capabilities | done (2026-04-27) |
+| 2 | 0.4.x | **Capability expansion**: mouse, 256/truecolor, unicode width, paste | done (2026-04-27) |
 | 3 | 0.5.x | **Breadth**: dialog helpers, more widgets, testkit module | proposed |
 | 4 | 1.0.0 | **Stabilise**: module split, MiMa, docs site, three-layer narrative | proposed |
 | 5 | post-1.0 | **Alternative backends**: Swing emulator, telnet/SSH | speculative |
@@ -95,11 +95,29 @@ purpose of staying at 0.x. Stage 4 is the lock-in point.
 
 ---
 
-## 4. Stage 1 — Foundational refactor (target: 0.3.0)
+## 4. Stage 1 — Foundational refactor (target: 0.3.0) — **done 2026-04-27**
 
 **Goal**: fix the architectural debts that would be expensive to repair after
 1.0. Stage 1 is invasive but small in surface area; it is internal plumbing
 plus a few public-API breaks.
+
+**Outcome.** All sub-items landed across PRs #157–#164:
+
+| Sub-item | Lands in | Status |
+|---|---|---|
+| §4.1 Relative-coordinate VDom | `Layout.Fill` + render-time resolution via `RootNode.layout` (#162) | done — `Layout` is the structural API; positioned `VNode` retained as escape hatch |
+| §4.2 Layer / overlay system | `Overlay` primitive + `Dialogs.confirm/message` (#160) | done |
+| §4.3 Theme + WidgetRenderer split | `Theme` + themable `BoxNode.chars` (#159, plus existing `Theme.scala`) | done — `Theme` ships with `BorderChars` slots; per-widget renderers come in Stage 3 with the dialog/widget expansion |
+| §4.4 Color depth + capability detection | `Color.Indexed` / `Color.Rgb` + capability-driven downgrade (#157) | done |
+| §4.5 SIGWINCH | `Sub.TerminalResize` switched to `backend.onResize` signal with polling fallback (#158) | done |
+| §4.6 Module split | `termflow-testkit` promoted to a published artifact (#161) | partial — testkit is its own module; the finer-grained `termflow-terminal/screen/app/widgets` carve-out is deferred to Stage 4 (§7.1), where MiMa will be wired up at the same time |
+| §4.7 Definition of done | Stage 1 showcase demo (`sbt showcase`, #163) exercises layout, overlays, theme, color depth, and resize end-to-end | done |
+
+The §4.6 module split was scoped down deliberately: the user-facing pain of
+"no separate testkit" was real (#147) and is now fixed; the terminal/screen/app
+split is internal plumbing that is cheap to do later, and pairs naturally with
+Stage 4 stabilisation when MiMa filters need to be defined per-module anyway.
+
 
 ### 4.1 Relative-coordinate VDom (P0, large)
 
@@ -270,10 +288,39 @@ just `termflow-app` if they want to roll their own widgets.
 
 ---
 
-## 5. Stage 2 — Capability expansion (target: 0.4.0)
+## 5. Stage 2 — Capability expansion (target: 0.4.0) — **done 2026-04-27**
 
 User-visible features that turn TermFlow from "good for prompts" into "good
 for real apps".
+
+**Sequencing.** The two P0 items (mouse, unicode width) are the most visible
+and the most invasive. We ordered Stage 2 smallest-first so each landing is
+self-contained and the goldens churn least at each step:
+
+| # | Sub-item | Status |
+|---|---|---|
+| 1 | §5.5 Extended style attributes | done — `Style` gains `italic`/`dim`/`reverse`/`strikethrough`/`blink`; capability gate `Capabilities.extendedStyles` decides emission |
+| 2 | §5.6 Extended modifier parsing | done — new `KeyDecoder.Modifiers`, `InputKey.Modified`, `Insert`/`PageUp`/`PageDown`; CSI parser unified to read params then dispatch |
+| 3 | §5.4 Bracketed paste | done — `Capabilities.bracketedPaste`, `ANSI.enableBracketedPaste`/`disableBracketedPaste`, `InputKey.Paste(text)` collapses the whole `200~ … 201~` window into one event |
+| 4 | §5.3 Unicode width handling | initial cut — `WCWidth` helper, `RenderCell.width`, layout / diff respect wide cells. Known gap: `Prompt`/`InputNode` cursor math is still 1-char-per-column; multi-line input + grapheme clusters deferred |
+| 5 | §5.1 Mouse support | done — `MouseEvent` / `MouseButton` / `ScrollDirection` ADTs, `ANSI.enableMouse`/`disableMouse` SGR-1006 + button-event tracking, `InputKey.Mouse(event)` multiplexed onto the key stream so existing `Sub.InputKey` handlers see it. Hit-testing on the layout-pass rect cache is deferred to Stage 3 |
+
+The showcase demo (`sbt showcase`) was extended in the same session to
+exercise every sub-item — Styles panel for §5.5, Live-input panel for
+§5.6/§5.4/§5.1, Unicode panel for §5.3 — so Stage 2 is end-to-end visible
+in one screen. The Themes and Borders panels are click-to-select and
+scroll-to-cycle, which is the first user-driven mouse interaction shipped
+in the codebase.
+
+### 5.x Bug fix landed alongside Stage 2
+
+- **Overlay background opacity** — `BoxNode` only painted the border, so
+  any panel beneath the dialog rectangle bled through the interior.
+  `AnsiRenderer` now wipes the overlay's full rectangle with blank cells
+  (in `buildFrame`) and emits explicit-space rows (in `renderPatch`)
+  before drawing the overlay's children. Two `OverlaySpec` regression
+  tests pin the behaviour.
+
 
 ### 5.1 Mouse support (P0, medium)
 
@@ -660,6 +707,26 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
   (rejected — wrong shape for Scala); (b) freeze 0.2 and call it done
   (rejected — coordinate model and missing layers will become 2.0
   refactors otherwise).
+- *2026-04-27* — Stage 1 marked done; Stage 2 begins. The §4.6 module split
+  was deliberately reduced to "promote `termflow-testkit`" only; the rest of
+  the carve-out (`termflow-terminal/screen/app/widgets`) deferred to Stage 4
+  where it pairs naturally with MiMa setup. Stage 2 sequenced
+  smallest-first (5.5 → 5.6 → 5.4 → 5.3 → 5.1) to keep golden churn local
+  and let each piece ship independently.
+- *2026-04-27* — Stage 2 complete. Mouse landed as a single `InputKey.Mouse`
+  multiplexed onto the existing key stream rather than a parallel
+  `Sub.Mouse` source — this avoids two threads racing for bytes from the
+  reader and lets every existing `Sub.InputKey` consumer handle clicks by
+  pattern-matching. The roadmap's separate `Sub.Mouse` factory is reserved
+  for Stage 3, where it can sit on top of the layout-pass hit-test cache
+  and deliver per-widget click messages instead of raw screen coords.
+- *2026-04-27* — Showcase rewritten to use absolute panel positioning so the
+  Themes / Borders panels can be left-clicked to select and scroll-wheeled
+  to cycle. This is the first user-driven mouse interaction in the
+  codebase and validates the Stage 2 §5.1 wiring end-to-end. While
+  building this we hit and fixed the overlay-opacity bug: dialog interiors
+  no longer leak the panels beneath them, because `AnsiRenderer` now wipes
+  the overlay rectangle before drawing children.
 
 ---
 

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -6,27 +6,39 @@ import termflow.tui.Tui.*
 import termflow.tui.TuiPrelude.*
 
 /**
- * One-screen showcase of every Stage 1 capability:
+ * One-screen showcase of every Stage 1 capability *plus* the user-visible
+ * Stage 2 additions:
  *
+ * **Stage 1**
  *   - **Color depth + capability detection** (PR #157 / issue #148): the
- *     "Capabilities" panel surfaces the detected `ColorDepth`, mouse, and
- *     unicode flags from `ctx.terminal.capabilities`. The "Palette" panel
- *     paints a truecolor RGB swatch row — the renderer downgrades it to
- *     whatever depth the terminal actually supports.
+ *     "Capabilities" panel surfaces detected `ColorDepth`, mouse, and
+ *     unicode flags from `ctx.terminal.capabilities`; the "Palette" panel
+ *     paints a truecolor swatch row that the renderer downgrades on the
+ *     fly.
  *   - **Signal-driven resize** (PR #158 / issue #151): resize your
- *     terminal — the middle "Palette" column reflows in real time. The
- *     `Sub.TerminalResize` subscription is wired to JLine's SIGWINCH
- *     handler when available.
- *   - **Themable border characters** (PR #159 / issue #152): press `b` to
- *     cycle through `BorderChars.{sharp, rounded, double, ascii}`. Same
- *     widget code, visibly different chrome.
- *   - **Overlay / modal dialog** (PR #160 / issue #153): press `d` to open
- *     a confirm modal. Base-view bindings are gated on
- *     `model.dialog.isEmpty` — that's the modal contract.
- *   - **Layout.Fill + render-time resolution** (PR #162 / issue #154):
- *     the body uses `RootNode.layout` with a Row of fixed/Fill/fixed
- *     children. The renderer resolves it against the current terminal
- *     width, so resizing reflows automatically.
+ *     terminal — the middle column reflows live thanks to
+ *     `Sub.TerminalResize` wiring SIGWINCH.
+ *   - **Themable border characters** (PR #159 / issue #152): `b` cycles
+ *     `BorderChars.{sharp, rounded, double, ascii}` (or click the
+ *     "Borders" panel rows).
+ *   - **Overlay / modal dialog** (PR #160 / issue #153): `d` opens a
+ *     confirm modal that suppresses base-view bindings.
+ *
+ * **Stage 2**
+ *   - **Extended SGR attributes** (§5.5): the "Styles" panel renders bold
+ *     / italic / dim / underline / reverse / strikethrough / blink. The
+ *     terminal's `extendedStyles` capability decides which actually emit.
+ *   - **Extended modifier parsing** (§5.6): the "Live input" panel
+ *     reflects the most recent decoded key — try Ctrl+ArrowRight,
+ *     Shift+F5, Alt+letter.
+ *   - **Bracketed paste** (§5.4): paste anything into the terminal — the
+ *     "Live input" panel collapses the paste into one event.
+ *   - **Unicode width** (§5.3): the "Unicode" panel lays out CJK,
+ *     fullwidth ASCII, and emoji over a column ruler.
+ *   - **Mouse / SGR-1006** (§5.1): click a row in the **Themes** or
+ *     **Borders** panel to switch directly, or hover and scroll the
+ *     wheel to cycle. The "Live input" panel shows the decoded
+ *     `MouseEvent`.
  *
  * Run with `sbt showcase`.
  */
@@ -60,6 +72,25 @@ object Stage1ShowcaseApp:
     Color.Rgb(192, 96, 224)  // purple
   )
 
+  // ---- Layout constants (absolute positioning so mouse hit-testing is exact) ----
+  private val topRowY             = 3
+  private val topPanelHeight      = 11
+  private val bottomRowY          = topRowY + topPanelHeight + 1 // 15
+  private val bottomPanelHeight   = 13
+  private val capsPanelWidth      = 22
+  private val themesPanelWidth    = 22
+  private val bordersPanelWidth   = 22
+  private val stylesPanelWidth    = 18
+  private val liveInputPanelWidth = 36
+
+  /**
+   * Bounding box `(col, row, width, height)` of a panel — top-left col/row
+   *  are 1-based to match the renderer's coordinate convention.
+   */
+  final private case class Rect(col: Int, row: Int, width: Int, height: Int):
+    def contains(c: Int, r: Int): Boolean =
+      c >= col && c < col + width && r >= row && r < row + height
+
   enum Dialog:
     case None
     case ConfirmQuit(yesFocused: Boolean)
@@ -72,6 +103,8 @@ object Stage1ShowcaseApp:
     dialog: Dialog,
     capabilities: Capabilities,
     termName: String,
+    /** Most recent input event, formatted for display in the live panel. */
+    lastEvent: Option[String],
     input: Sub[Msg],
     resize: Sub[Msg]
   ):
@@ -87,6 +120,8 @@ object Stage1ShowcaseApp:
     case Resize(w: Int, h: Int)
     case CycleBorder
     case CycleTheme
+    case SelectThemeIdx(i: Int)
+    case SelectBorderIdx(i: Int)
     case OpenDialog
     case CloseDialog
     case ToggleDialogFocus
@@ -107,24 +142,31 @@ object Stage1ShowcaseApp:
         dialog = Dialog.None,
         capabilities = ctx.terminal.capabilities,
         termName = sys.env.getOrElse("TERM", "?"),
+        lastEvent = None,
         input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx),
         resize = Sub.TerminalResize[Msg](200, (w, h) => Resize(w, h), ctx)
       ).tui
 
     override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
       msg match
-        case Resize(w, h) => m.copy(width = w, height = h).tui
-        case CycleBorder  => m.copy(borderIdx = (m.borderIdx + 1) % borderStyles.size).tui
-        case CycleTheme   => m.copy(themeIdx = (m.themeIdx + 1) % themePresets.size).tui
-        case OpenDialog   => m.copy(dialog = Dialog.ConfirmQuit(yesFocused = false)).tui
-        case CloseDialog  => m.copy(dialog = Dialog.None).tui
+        case Resize(w, h)       => m.copy(width = w, height = h).tui
+        case CycleBorder        => m.copy(borderIdx = (m.borderIdx + 1) % borderStyles.size).tui
+        case CycleTheme         => m.copy(themeIdx = (m.themeIdx + 1) % themePresets.size).tui
+        case SelectThemeIdx(i)  => m.copy(themeIdx = clampIdx(i, themePresets.size)).tui
+        case SelectBorderIdx(i) => m.copy(borderIdx = clampIdx(i, borderStyles.size)).tui
+        case OpenDialog         => m.copy(dialog = Dialog.ConfirmQuit(yesFocused = false)).tui
+        case CloseDialog        => m.copy(dialog = Dialog.None).tui
         case ToggleDialogFocus =>
           m.dialog match
             case Dialog.ConfirmQuit(yes) => m.copy(dialog = Dialog.ConfirmQuit(!yes)).tui
             case Dialog.None             => m.tui
         case Quit        => Tui(m, Cmd.Exit)
         case KeyError(_) => m.tui
-        case Key(k)      => Tui(m, dispatch(m, k))
+        case Key(k) =>
+          val withEvent = m.copy(lastEvent = Some(formatEvent(k)))
+          Tui(withEvent, dispatch(withEvent, k))
+
+    private def clampIdx(i: Int, size: Int): Int = math.max(0, math.min(size - 1, i))
 
     private def dispatch(m: Model, k: KeyDecoder.InputKey): Cmd[Msg] =
       import KeyDecoder.InputKey.*
@@ -134,6 +176,7 @@ object Stage1ShowcaseApp:
             case ArrowLeft | ArrowRight => Cmd.GCmd(ToggleDialogFocus)
             case Enter                  => if yesFocused then Cmd.GCmd(Quit) else Cmd.GCmd(CloseDialog)
             case Escape                 => Cmd.GCmd(CloseDialog)
+            case Mouse(_)               => Cmd.NoCmd
             case _                      => Cmd.NoCmd
         case Dialog.None =>
           k match
@@ -142,7 +185,141 @@ object Stage1ShowcaseApp:
             case CharKey('d') | CharKey('D') => Cmd.GCmd(OpenDialog)
             case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
             case Escape                      => Cmd.GCmd(OpenDialog)
+            case Mouse(ev)                   => mouseDispatch(m, ev)
             case _                           => Cmd.NoCmd
+
+    /**
+     * Map a [[MouseEvent]] to a model command using static panel rects.
+     *
+     *   - Press inside the Themes panel's row strip → [[SelectThemeIdx]].
+     *   - Press inside the Borders panel's row strip → [[SelectBorderIdx]].
+     *   - Scroll wheel inside either panel cycles through entries.
+     *
+     * Returns [[Cmd.NoCmd]] for releases, drags, and clicks outside any
+     * known target — the live-input panel still reflects the raw event.
+     */
+    private def mouseDispatch(m: Model, ev: MouseEvent): Cmd[Msg] =
+      val (col, row) = ev.at
+      val themesR    = themesRect(m)
+      val bordersR   = bordersRect(m)
+
+      ev match
+        case MouseEvent.Press(MouseButton.Left, _, _, _) =>
+          if themesR.contains(col, row) then
+            themeIndexAtRow(themesR, row).map(i => Cmd.GCmd[Msg](SelectThemeIdx(i))).getOrElse(Cmd.NoCmd)
+          else if bordersR.contains(col, row) then
+            borderIndexAtRow(bordersR, row).map(i => Cmd.GCmd[Msg](SelectBorderIdx(i))).getOrElse(Cmd.NoCmd)
+          else Cmd.NoCmd
+
+        case MouseEvent.Scroll(dir, _, _, _) =>
+          if themesR.contains(col, row) then
+            val next = nextIndex(m.themeIdx, themePresets.size, dir)
+            Cmd.GCmd(SelectThemeIdx(next))
+          else if bordersR.contains(col, row) then
+            val next = nextIndex(m.borderIdx, borderStyles.size, dir)
+            Cmd.GCmd(SelectBorderIdx(next))
+          else Cmd.NoCmd
+
+        case _ => Cmd.NoCmd
+
+    private def nextIndex(current: Int, size: Int, dir: ScrollDirection): Int =
+      dir match
+        case ScrollDirection.Up | ScrollDirection.Left =>
+          (current - 1 + size) % size
+        case ScrollDirection.Down | ScrollDirection.Right =>
+          (current + 1) % size
+
+    /**
+     * Inside the Themes panel, the first selectable row is at `panel.row + 3`
+     *  (skip the top border + title + blank). One row per entry.
+     */
+    private def themeIndexAtRow(panel: Rect, row: Int): Option[Int] =
+      val offset = row - (panel.row + 3)
+      if offset >= 0 && offset < themePresets.size then Some(offset) else None
+
+    private def borderIndexAtRow(panel: Rect, row: Int): Option[Int] =
+      val offset = row - (panel.row + 3)
+      if offset >= 0 && offset < borderStyles.size then Some(offset) else None
+
+    private def themesRect(m: Model): Rect =
+      Rect(col = m.width - themesPanelWidth, row = topRowY, width = themesPanelWidth, height = topPanelHeight)
+
+    private def bordersRect(m: Model): Rect =
+      Rect(
+        col = m.width - themesPanelWidth - bordersPanelWidth - 1,
+        row = topRowY,
+        width = bordersPanelWidth,
+        height = topPanelHeight
+      )
+
+    private def capsRect: Rect =
+      Rect(col = 1, row = topRowY, width = capsPanelWidth, height = topPanelHeight)
+
+    private def paletteRect(m: Model): Rect =
+      val left  = capsRect.col + capsRect.width + 1
+      val right = bordersRect(m).col - 1
+      Rect(col = left, row = topRowY, width = math.max(10, right - left), height = topPanelHeight)
+
+    private def stylesRect: Rect =
+      Rect(col = 1, row = bottomRowY, width = stylesPanelWidth, height = bottomPanelHeight)
+
+    private def liveInputRect(m: Model): Rect =
+      Rect(
+        col = m.width - liveInputPanelWidth,
+        row = bottomRowY,
+        width = liveInputPanelWidth,
+        height = bottomPanelHeight
+      )
+
+    private def unicodeRect(m: Model): Rect =
+      val left  = stylesRect.col + stylesRect.width + 1
+      val right = liveInputRect(m).col - 1
+      Rect(col = left, row = bottomRowY, width = math.max(20, right - left), height = bottomPanelHeight)
+
+    /**
+     * One-line description of an [[KeyDecoder.InputKey]] for the "Live
+     * input" panel. Mouse / paste / modified keys get distinct prefixes so
+     * the Stage 2 wiring is visible at a glance.
+     */
+    private def formatEvent(k: KeyDecoder.InputKey): String =
+      import KeyDecoder.InputKey.*
+      k match
+        case CharKey(c)            => s"key  CharKey('${c}')"
+        case Ctrl(c)               => s"key  Ctrl+${c}"
+        case Modified(inner, mods) => s"key  ${describeMods(mods)}+${describeKey(inner)}"
+        case Paste(text) =>
+          val preview = text.take(40).replace("\n", "\\n").replace("\r", "\\r")
+          val suffix  = if text.length > 40 then "…" else ""
+          s"paste(${text.length} chars) \"$preview$suffix\""
+        case Mouse(ev) => s"mouse ${describeMouse(ev)}"
+        case other     => s"key  ${describeKey(other)}"
+
+    private def describeKey(k: KeyDecoder.InputKey): String =
+      import KeyDecoder.InputKey.*
+      k match
+        case CharKey(c) => s"'$c'"
+        case Ctrl(c)    => s"Ctrl+$c"
+        case other      => other.toString.takeWhile(_ != '(')
+
+    private def describeMods(m: KeyDecoder.Modifiers): String =
+      val parts = List(
+        Option.when(m.ctrl)("Ctrl"),
+        Option.when(m.alt)("Alt"),
+        Option.when(m.shift)("Shift"),
+        Option.when(m.meta)("Meta")
+      ).flatten
+      if parts.isEmpty then "" else parts.mkString("+")
+
+    private def describeMouse(ev: MouseEvent): String =
+      val (col, row) = ev.at
+      val mods       = describeMods(ev.modifiers)
+      val modPrefix  = if mods.isEmpty then "" else s"$mods+"
+      ev match
+        case MouseEvent.Press(b, _, _, _)   => s"${modPrefix}${b}-press   ($col,$row)"
+        case MouseEvent.Release(b, _, _, _) => s"${modPrefix}${b}-release ($col,$row)"
+        case MouseEvent.Drag(b, _, _, _)    => s"${modPrefix}${b}-drag    ($col,$row)"
+        case MouseEvent.Move(_, _, _)       => s"${modPrefix}move           ($col,$row)"
+        case MouseEvent.Scroll(d, _, _, _)  => s"${modPrefix}scroll-$d  ($col,$row)"
 
     override def view(m: Model): RootNode =
       given Theme = m.theme
@@ -151,7 +328,10 @@ object Stage1ShowcaseApp:
         2.x,
         1.y,
         List(
-          "TermFlow Stage 1 Showcase".themed(_.primary),
+          Text(
+            "TermFlow Showcase",
+            Style(fg = m.theme.primary, bold = true, italic = true)
+          ),
           "  ".text,
           s"theme=${m.themeName}".text,
           "  ".text,
@@ -161,19 +341,12 @@ object Stage1ShowcaseApp:
         )
       )
 
-      val body: Layout = Layout.Row(
-        gap = 1,
-        children = List(
-          Layout.Elem(capabilitiesPanel(m)),
-          Layout.Fill(Layout.Elem(palettePanel(m))),
-          Layout.Elem(borderInfoPanel(m))
-        )
-      )
-
       val helpNode = TextNode(
         2.x,
         (m.height - 1).y,
         List(
+          " click ".themed(_.primary),
+          "/scroll Themes & Borders to change  ".text,
           " b ".themed(_.primary),
           "border  ".text,
           " t ".themed(_.primary),
@@ -181,35 +354,31 @@ object Stage1ShowcaseApp:
           " d ".themed(_.primary),
           "dialog  ".text,
           " q ".themed(_.primary),
-          "quit  ".text,
-          " resize the window — Fill layout reflows live ".themed(_.success)
+          "quit ".text
         )
       )
 
-      val baseLayout = Layout.Column(
-        gap = 0,
-        children = List(
-          Layout.Spacer(1, 1), // title is on row 1, body starts row 3
-          Layout.Fill(body)    // body fills the middle
-        )
+      val panels: List[VNode] = List(
+        capabilitiesPanel(m, capsRect),
+        palettePanel(m, paletteRect(m)),
+        themesPanel(m, themesRect(m)),
+        bordersPanel(m, bordersRect(m)),
+        stylesPanel(stylesRect),
+        unicodePanel(unicodeRect(m)),
+        liveInputPanel(m, liveInputRect(m))
       )
 
       val baseRoot = RootNode(
         width = math.max(60, m.width),
-        height = math.max(12, m.height - 2), // leave room for title + footer
-        children = List(titleNode),
-        input = None,
-        layout = Some(baseLayout)
+        height = math.max(20, m.height),
+        children = titleNode :: panels ++ List(helpNode),
+        input = None
       )
 
-      // Help footer is positioned absolutely at row m.height - 1 (above the
-      // very last row, which TuiRuntime uses for cursor housekeeping).
-      val withFooter = baseRoot.copy(children = baseRoot.children :+ helpNode)
-
       m.dialog match
-        case Dialog.None => withFooter
+        case Dialog.None => baseRoot
         case Dialog.ConfirmQuit(yesFocused) =>
-          withFooter.copy(overlays =
+          baseRoot.copy(overlays =
             List(
               Dialogs.confirm(
                 prompt = "Quit the showcase?",
@@ -226,75 +395,120 @@ object Stage1ShowcaseApp:
 
     // ---- panels --------------------------------------------------------------
 
-    private def capabilitiesPanel(m: Model)(using theme: Theme): VNode =
-      val caps      = m.capabilities
-      val title     = TextNode(2.x, 1.y, List(" Capabilities ".themed(_.primary)))
-      val depthLine = TextNode(2.x, 3.y, List("depth: ".text, depthLabel(caps.colorDepth).themed(_.success)))
-      val mouseLine = TextNode(2.x, 4.y, List("mouse: ".text, (if caps.mouse then "yes" else "no").themed(_.info)))
-      val uniLine   = TextNode(2.x, 5.y, List("utf-8: ".text, (if caps.unicode then "yes" else "no").themed(_.info)))
-      val noteLine  = TextNode(2.x, 7.y, List("$TERM=".text, m.termName.themed(_.info)))
-      VNode.BoxNode(
-        x = 1.x,
-        y = 1.y,
-        width = 22,
-        height = 8,
-        children = List(title, depthLine, mouseLine, uniLine, noteLine),
-        style = Style(fg = theme.border, border = true),
-        chars = theme.chars
+    private def capabilitiesPanel(m: Model, r: Rect)(using theme: Theme): VNode =
+      val caps  = m.capabilities
+      val title = TextNode(2.x, 1.y, List(" Capabilities ".themed(_.primary)))
+      val rows = List(
+        kv(2, 3, "depth", depthLabel(caps.colorDepth)),
+        kv(2, 4, "mouse", yesNo(caps.mouse)),
+        kv(2, 5, "utf-8", yesNo(caps.unicode)),
+        kv(2, 6, "styles+", yesNo(caps.extendedStyles)),
+        kv(2, 7, "paste", yesNo(caps.bracketedPaste)),
+        TextNode(2.x, 9.y, List("$TERM=".text, m.termName.themed(_.info)))
       )
+      panel(r, theme, title :: rows)
 
-    private def palettePanel(m: Model)(using theme: Theme): VNode =
-      // The middle panel is sized by Layout.Fill; the BoxNode's width is
-      // overridden by the resolver. We author at width=10, the renderer
-      // resizes us to whatever's left after the side panels.
+    private def palettePanel(m: Model, r: Rect)(using theme: Theme): VNode =
       val title = TextNode(2.x, 1.y, List(" Palette ".themed(_.primary)))
       val description = TextNode(
         2.x,
         3.y,
-        List(
-          "RGB swatches downgrade ".text,
-          s"to ${depthLabel(m.capabilities.colorDepth)}".themed(_.info)
-        )
+        List("RGB swatches downgrade ".text, s"to ${depthLabel(m.capabilities.colorDepth)}".themed(_.info))
       )
       val swatch = TextNode(
         2.x,
         5.y,
         swatchRgb.toList.flatMap(c => List("███".text(fg = c), " ".text))
       )
+      panel(r, theme, List(title, description, swatch))
+
+    private def themesPanel(m: Model, r: Rect)(using theme: Theme): VNode =
+      val title = TextNode(2.x, 1.y, List(" Themes (click) ".themed(_.primary)))
+      val rows = themePresets.zipWithIndex.toList.map { case ((name, _), i) =>
+        renderableRow(2, 3 + i, name, selected = i == m.themeIdx, theme)
+      }
+      val hint = TextNode(2.x, (3 + themePresets.size + 1).y, List("scroll to cycle".themed(_.info)))
+      panel(r, theme, (title :: rows) :+ hint)
+
+    private def bordersPanel(m: Model, r: Rect)(using theme: Theme): VNode =
+      val title = TextNode(2.x, 1.y, List(" Borders (click) ".themed(_.primary)))
+      val rows = borderStyles.zipWithIndex.toList.map { case ((name, _), i) =>
+        renderableRow(2, 3 + i, name, selected = i == m.borderIdx, theme)
+      }
+      val hint = TextNode(2.x, (3 + borderStyles.size + 1).y, List("scroll to cycle".themed(_.info)))
+      panel(r, theme, (title :: rows) :+ hint)
+
+    private def renderableRow(col: Int, row: Int, name: String, selected: Boolean, theme: Theme): VNode =
+      val marker = if selected then "▸ " else "  "
+      val style =
+        if selected then Style(fg = theme.background, bg = theme.primary, bold = true)
+        else Style(fg = theme.foreground)
+      TextNode(col.x, row.y, List(Text(s"$marker$name", style)))
+
+    private def stylesPanel(r: Rect)(using theme: Theme): VNode =
+      val title = TextNode(2.x, 1.y, List(" Styles ".themed(_.primary)))
+      val rows = List(
+        TextNode(2.x, 3.y, List(Text("bold", Style(fg = theme.primary, bold = true)))),
+        TextNode(2.x, 4.y, List(Text("italic", Style(fg = theme.primary, italic = true)))),
+        TextNode(2.x, 5.y, List(Text("underline", Style(fg = theme.primary, underline = true)))),
+        TextNode(2.x, 6.y, List(Text("dim", Style(fg = theme.primary, dim = true)))),
+        TextNode(2.x, 7.y, List(Text("reverse", Style(fg = theme.primary, reverse = true)))),
+        TextNode(2.x, 8.y, List(Text("strike", Style(fg = theme.primary, strikethrough = true)))),
+        TextNode(2.x, 9.y, List(Text("blink", Style(fg = theme.primary, blink = true)))),
+        TextNode(
+          2.x,
+          11.y,
+          List(Text("combo", Style(fg = theme.success, bold = true, italic = true, underline = true)))
+        )
+      )
+      panel(r, theme, title :: rows)
+
+    private def unicodePanel(r: Rect)(using theme: Theme): VNode =
+      val title = TextNode(2.x, 1.y, List(" Unicode width ".themed(_.primary)))
+      val ruler = TextNode(2.x, 3.y, List("|0123456789|0123456789|0123456789|".themed(_.border)))
+      val cjk   = TextNode(2.x, 4.y, List("中文 日本語 한국어 → CJK = 2 cells".text(fg = theme.info)))
+      val full  = TextNode(2.x, 5.y, List("ＡＢＣＤＥ → fullwidth ASCII".text(fg = theme.info)))
+      val emoji = TextNode(2.x, 6.y, List("hello 🎉 world 🚀 → emoji = 2 cells".text(fg = theme.info)))
+      val mixed = TextNode(2.x, 7.y, List("a中b日c韓 → mixed lays out cleanly".text(fg = theme.info)))
+      val hint  = TextNode(2.x, 9.y, List("Each glyph above lines up with the ruler.".themed(_.success)))
+      panel(r, theme, List(title, ruler, cjk, full, emoji, mixed, hint))
+
+    private def liveInputPanel(m: Model, r: Rect)(using theme: Theme): VNode =
+      val title    = TextNode(2.x, 1.y, List(" Live input ".themed(_.primary)))
+      val intro    = TextNode(2.x, 3.y, List("Most recent decoded event:".text))
+      val event    = m.lastEvent.getOrElse("(press a key, click, or paste)")
+      val eventTxt = TextNode(2.x, 5.y, List(event.themed(_.success)))
+      val tips = List(
+        TextNode(2.x, 7.y, List("• Click rows in Themes/Borders".text)),
+        TextNode(2.x, 8.y, List("• Scroll-wheel to cycle".text)),
+        TextNode(2.x, 9.y, List("• Ctrl+Arrow → Modified key".text)),
+        TextNode(2.x, 10.y, List("• ⌘V / Ctrl-V paste → Paste(...)".text))
+      )
+      panel(r, theme, List(title, intro, eventTxt) ++ tips)
+
+    /** Bordered panel positioned at `r` with the theme's border style. */
+    private def panel(r: Rect, theme: Theme, children: List[VNode]): VNode =
       VNode.BoxNode(
-        x = 1.x,
-        y = 1.y,
-        width = 10, // overridden at render time by Fill
-        height = 8,
-        children = List(title, description, swatch),
+        x = r.col.x,
+        y = r.row.y,
+        width = r.width,
+        height = r.height,
+        children = children.map(translateInto(r, _)),
         style = Style(fg = theme.border, border = true),
         chars = theme.chars
       )
 
-    private def borderInfoPanel(m: Model)(using theme: Theme): VNode =
-      val title    = TextNode(2.x, 1.y, List(" Borders ".themed(_.primary)))
-      val nameLine = TextNode(2.x, 3.y, List("style: ".text, m.borderName.themed(_.success)))
-      val sample = TextNode(
-        2.x,
-        5.y,
-        List(
-          s"${m.chars.topLeft}${m.chars.horizontal}${m.chars.horizontal}${m.chars.topRight}".themed(_.border)
-        )
-      )
-      val sample2 = TextNode(
-        2.x,
-        6.y,
-        List(s"${m.chars.bottomLeft}${m.chars.horizontal}${m.chars.horizontal}${m.chars.bottomRight}".themed(_.border))
-      )
-      VNode.BoxNode(
-        x = 1.x,
-        y = 1.y,
-        width = 17,
-        height = 8,
-        children = List(title, nameLine, sample, sample2),
-        style = Style(fg = theme.border, border = true),
-        chars = theme.chars
-      )
+    /**
+     * Translate a child authored in panel-local (1.x, 1.y) coordinates into
+     *  the panel's absolute frame position.
+     */
+    private def translateInto(r: Rect, child: VNode): VNode =
+      Layout.translate(child, r.col - 1, r.row - 1)
+
+    private def kv(col: Int, row: Int, label: String, value: String)(using theme: Theme): VNode =
+      TextNode(col.x, row.y, List(s"$label: ".text, value.themed(_.success)))
+
+    private def yesNo(b: Boolean): String = if b then "yes" else "no"
 
     private def depthLabel(d: ColorDepth): String = d match
       case ColorDepth.Mono       => "Mono"

--- a/modules/termflow-sample/src/main/scala/termflow/apps/unicode/UnicodeDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/unicode/UnicodeDemoApp.scala
@@ -1,0 +1,89 @@
+package termflow.apps.unicode
+
+import termflow.tui.*
+import termflow.tui.Color.*
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Smoke-test sample exercising the [[WCWidth]] code path: CJK glyphs,
+ * fullwidth ASCII, emoji, and combining marks. Run via `sbt unicodeDemo`.
+ *
+ * The demo lays out a series of fixed-width "rules" (`|0123456789|`) below
+ * lines of mixed Latin / wide / emoji content so the eye can verify that
+ * each subsequent column lands where it should.
+ */
+object UnicodeDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  final case class Model(
+    width: Int,
+    height: Int,
+    input: Sub[Msg]
+  )
+
+  enum Msg:
+    case KeyPressed(key: KeyDecoder.InputKey)
+    case KeyError(t: Throwable)
+
+  import Msg.*
+
+  object App extends TuiApp[Model, Msg]:
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Model(
+        width = ctx.terminal.width,
+        height = ctx.terminal.height,
+        input = Sub.InputKey(KeyPressed.apply, KeyError.apply, ctx)
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      msg match
+        case KeyPressed(KeyDecoder.InputKey.CharKey('q')) => Tui(m, Cmd.Exit)
+        case KeyPressed(KeyDecoder.InputKey.Escape)       => Tui(m, Cmd.Exit)
+        case KeyPressed(_)                                => m.tui
+        case KeyError(_)                                  => m.tui
+
+    override def view(m: Model): RootNode =
+      val rule    = "|0123456789|0123456789|0123456789|"
+      val ruler   = Text(rule, Style(fg = BrightBlack))
+      val title   = Text("TermFlow — Unicode width demo (q to quit)", Style(fg = Yellow, bold = true))
+      val ascii   = Text("hello world!", Style(fg = Cyan))
+      val cjk     = Text("中文 日本語 한국어", Style(fg = Magenta))
+      val mixed   = Text("a中b日c韓", Style(fg = Green))
+      val full    = Text("ＡＢＣＤＥ", Style(fg = BrightBlue))
+      val emoji   = Text("hello 🎉 world 🚀", Style(fg = BrightYellow))
+      val combine = Text("café — naïve — schön", Style(fg = White))
+
+      val column = Layout.Column(
+        gap = 0,
+        children = List(
+          Layout.Elem(TextNode(1.x, 1.y, List(title))),
+          Layout.Spacer(1, 1),
+          Layout.Elem(TextNode(1.x, 1.y, List(ascii))),
+          Layout.Elem(TextNode(1.x, 1.y, List(ruler))),
+          Layout.Elem(TextNode(1.x, 1.y, List(cjk))),
+          Layout.Elem(TextNode(1.x, 1.y, List(ruler))),
+          Layout.Elem(TextNode(1.x, 1.y, List(mixed))),
+          Layout.Elem(TextNode(1.x, 1.y, List(ruler))),
+          Layout.Elem(TextNode(1.x, 1.y, List(full))),
+          Layout.Elem(TextNode(1.x, 1.y, List(ruler))),
+          Layout.Elem(TextNode(1.x, 1.y, List(emoji))),
+          Layout.Elem(TextNode(1.x, 1.y, List(ruler))),
+          Layout.Elem(TextNode(1.x, 1.y, List(combine))),
+          Layout.Elem(TextNode(1.x, 1.y, List(ruler)))
+        )
+      )
+
+      RootNode(
+        width = m.width,
+        height = m.height,
+        children = column.resolve(Coord(2.x, 1.y)),
+        input = None
+      )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      Right(KeyPressed(KeyDecoder.InputKey.CharKey('q')))

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -84,6 +84,155 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(wf.width > nf.width, s"wide frame should be wider than narrow (${wf.width} vs ${nf.width})")
   }
 
+  test("a key event updates lastEvent on the model") {
+    val d = driver
+    assert(d.model.lastEvent.isEmpty)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('x')))
+    assert(d.model.lastEvent.exists(_.contains("CharKey")))
+  }
+
+  test("a Modified key arrives with mod prefix in lastEvent") {
+    val d = driver
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Modified(InputKey.ArrowRight, termflow.tui.KeyDecoder.Modifiers(ctrl = true))
+      )
+    )
+    val rendered = d.model.lastEvent.getOrElse("")
+    assert(rendered.contains("Ctrl"), s"expected 'Ctrl' in $rendered")
+    assert(rendered.contains("ArrowRight"), s"expected 'ArrowRight' in $rendered")
+  }
+
+  test("a Mouse event arrives in lastEvent with coordinates") {
+    val d = driver
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            7,
+            3,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    val rendered = d.model.lastEvent.getOrElse("")
+    assert(rendered.startsWith("mouse"), s"expected mouse prefix in $rendered")
+    assert(rendered.contains("(7,3)"), s"expected (7,3) in $rendered")
+  }
+
+  test("a Paste event arrives in lastEvent with a length-bounded preview") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Paste("hello pasted world")))
+    val rendered = d.model.lastEvent.getOrElse("")
+    assert(rendered.startsWith("paste"), s"expected paste prefix in $rendered")
+    assert(rendered.contains("hello pasted world"), s"expected payload in $rendered")
+  }
+
+  // ---- Mouse hit-testing on the Themes / Borders panels --------------------
+
+  /**
+   * Themes panel sits at `(width - 22, 3)` with 22 cols × 11 rows. The first
+   *  selectable row is the 4th row of the panel (top border + title + blank).
+   */
+  private def themesRowCol(d: TuiTestDriver[Stage1ShowcaseApp.Model, Stage1ShowcaseApp.Msg]): Int =
+    d.model.width - 22 + 5
+
+  test("clicking the second row of the Themes panel selects 'light'") {
+    val d           = driver
+    val themeRowTop = 3 + 3 // panel top + title/blank offset
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            themesRowCol(d),
+            themeRowTop + 1,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.themeName == "light")
+  }
+
+  test("scroll-down inside the Themes panel cycles to the next theme") {
+    val d           = driver
+    val themesAnyY  = 3 + 5 // anywhere inside the panel rectangle
+    val initialName = d.model.themeName
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Scroll(
+            termflow.tui.ScrollDirection.Down,
+            themesRowCol(d),
+            themesAnyY,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.themeName != initialName, "scroll down should advance the selection")
+  }
+
+  test("scroll-up inside the Themes panel cycles to the previous theme (wraps)") {
+    val d          = driver
+    val themesAnyY = 3 + 5
+    // From dark (idx 0), Up should wrap to mono (idx 2).
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Scroll(
+            termflow.tui.ScrollDirection.Up,
+            themesRowCol(d),
+            themesAnyY,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.themeName == "mono")
+  }
+
+  test("clicking outside the Themes panel does not change the theme") {
+    val d           = driver
+    val initialName = d.model.themeName
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            1,
+            1,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.themeName == initialName, "clicks outside Themes should be no-ops")
+  }
+
+  test("clicking a row in the Borders panel selects that border style") {
+    val d            = driver
+    val bordersStart = d.model.width - 22 - 22 - 1
+    val bordersTop   = 3 + 3
+    // Row 0 = sharp, row 1 = rounded (initial), row 2 = double.
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            bordersStart + 5,
+            bordersTop + 2,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.borderName == "double")
+  }
+
   // Silence unused-import lint warning for AnsiRenderer (it's referenced
   // implicitly through TuiTestDriver, but the file would warn otherwise).
   private val _ = AnsiRenderer.getClass

--- a/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -60,9 +60,47 @@ object ANSI:
   val hideCursor     = "\u001b[?25l"
   val showCursor     = "\u001b[?25h"
 
+  /**
+   * xterm bracketed-paste mode on. Pasted text arrives as
+   *  `ESC [ 200 ~ ... ESC [ 201 ~`, decoded into a single
+   *  [[KeyDecoder.InputKey.Paste]].
+   */
+  val enableBracketedPaste  = "\u001b[?2004h"
+  val disableBracketedPaste = "\u001b[?2004l"
+
+  /**
+   * Enable button-event mouse tracking (`?1002`) plus SGR coordinate
+   * encoding (`?1006`). With this combo the terminal sends
+   * `CSI < button ; col ; row M/m` for every press, release, drag, and
+   * scroll-wheel event, decoded into [[KeyDecoder.InputKey.Mouse]].
+   *
+   * `?1003` (any-event tracking — bare `Move` events) is intentionally
+   * left off. It floods the input stream with motion bytes that are
+   * rarely useful for TUIs and that cost real CPU on the decode path.
+   */
+  val enableMouse  = "\u001b[?1006h\u001b[?1002h"
+  val disableMouse = "\u001b[?1002l\u001b[?1006l"
+
 object AnsiRenderer:
   private val reset = "\u001b[0m"
-  final case class RenderCell(ch: Char, style: Style)
+
+  /**
+   * One cell on the rendered terminal grid.
+   *
+   * @param ch    The glyph to emit. For surrogate pairs / multi-cell
+   *              graphemes, only the leading code unit is stored here;
+   *              richer grapheme support is a future stage.
+   * @param style Foreground / background / SGR attributes.
+   * @param width Display width in cells: `1` for the typical narrow cell,
+   *              `2` for an East Asian Wide / Fullwidth glyph (the next
+   *              cell is a continuation), or `0` for a continuation cell
+   *              that exists only to absorb the second column of a wide
+   *              glyph emitted in the previous cell. The diff loop honours
+   *              `width = 0` cells by *not* emitting their `ch`, since the
+   *              terminal already advanced past that column when the wide
+   *              char was written.
+   */
+  final case class RenderCell(ch: Char, style: Style, width: Int = 1)
   final case class RenderFrame(
     width: Int,
     height: Int,
@@ -71,7 +109,7 @@ object AnsiRenderer:
   )
   final case class DiffResult(ansi: String, changedCells: Int, changedRows: Int)
   final private case class VisibleInput(text: String, cursorIndex: Int, width: Int)
-  private val blankCell = RenderCell(' ', Style())
+  private val blankCell = RenderCell(' ', Style(), 1)
 
   def moveTo(x: XCoord, y: YCoord): String =
     s"\u001b[${y.value};${x.value}H"
@@ -165,10 +203,21 @@ object AnsiRenderer:
     case Color.BrightWhite   => 7
     case _                   => 0
 
-  private def styleToAnsi(s: Style, depth: ColorDepth): String =
+  private[tui] def styleToAnsi(s: Style, depth: ColorDepth): String =
+    styleToAnsi(s, depth, extendedStyles = true)
+
+  private[tui] def styleToAnsi(s: Style, depth: ColorDepth, extendedStyles: Boolean): String =
     val b = new StringBuilder
     if s.bold then b.append("\u001b[1m")
     if s.underline then b.append("\u001b[4m")
+    if extendedStyles then
+      // SGR ordering follows the canonical xterm sequence so terminals that
+      // only honour a subset still see the supported codes contiguously.
+      if s.dim then b.append("\u001b[2m")
+      if s.italic then b.append("\u001b[3m")
+      if s.blink then b.append("\u001b[5m")
+      if s.reverse then b.append("\u001b[7m")
+      if s.strikethrough then b.append("\u001b[9m")
     b.append(colorToAnsi(s.fg, isBg = false, depth))
     b.append(colorToAnsi(s.bg, isBg = true, depth))
     b.toString
@@ -180,12 +229,15 @@ object AnsiRenderer:
     terminal.write(clearPatch)
 
   def renderPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
+    renderPatch(root, depth, extendedStyles = true)
+
+  def renderPatch(root: RootNode, depth: ColorDepth, extendedStyles: Boolean): String =
     val out = new StringBuilder
-    root.children.foreach(renderNode(_, out, depth))
-    layoutChildren(root).foreach(renderNode(_, out, depth))
-    if !hasModalOverlay(root) then root.input.foreach(renderInput(_, root.width, out, depth))
-    root.overlays.foreach(renderOverlay(_, root.width, root.height, out, depth))
-    activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth))
+    root.children.foreach(renderNode(_, out, depth, extendedStyles))
+    layoutChildren(root).foreach(renderNode(_, out, depth, extendedStyles))
+    if !hasModalOverlay(root) then root.input.foreach(renderInput(_, root.width, out, depth, extendedStyles))
+    root.overlays.foreach(renderOverlay(_, root.width, root.height, out, depth, extendedStyles))
+    activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth, extendedStyles))
     out.toString
 
   /**
@@ -206,17 +258,21 @@ object AnsiRenderer:
       case None => Nil
 
   def render(root: RootNode)(using terminal: TerminalBackend): Unit =
-    terminal.write(renderPatch(root, terminal.capabilities.colorDepth))
+    terminal.write(renderPatch(root, terminal.capabilities.colorDepth, terminal.capabilities.extendedStyles))
 
   /** Re-render only the input, leaving existing children intact. */
   def renderInputOnly(root: RootNode)(using terminal: TerminalBackend): Unit =
-    terminal.write(inputPatch(root, terminal.capabilities.colorDepth))
+    terminal.write(inputPatch(root, terminal.capabilities.colorDepth, terminal.capabilities.extendedStyles))
 
   /** Build ANSI patch for input-only repaint. */
   def inputPatch(root: RootNode, depth: ColorDepth = ColorDepth.Ansi8): String =
+    inputPatch(root, depth, extendedStyles = true)
+
+  def inputPatch(root: RootNode, depth: ColorDepth, extendedStyles: Boolean): String =
     val out = new StringBuilder
-    if hasModalOverlay(root) then activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth))
-    else root.input.foreach(renderInput(_, root.width, out, depth))
+    if hasModalOverlay(root) then
+      activeOverlayInput(root).foreach(renderInput(_, root.width, out, depth, extendedStyles))
+    else root.input.foreach(renderInput(_, root.width, out, depth, extendedStyles))
     out.toString
 
   /** True if any overlay in the root captures base-view input. */
@@ -247,25 +303,34 @@ object AnsiRenderer:
     rootWidth: Int,
     rootHeight: Int,
     out: StringBuilder,
-    depth: ColorDepth
+    depth: ColorDepth,
+    extendedStyles: Boolean
   ): Unit =
     val (ox, oy) = OverlayPosition.resolve(o.position, o.width, o.height, rootWidth, rootHeight)
     val dx       = ox.value - 1
     val dy       = oy.value - 1
-    o.children.foreach(child => renderNode(Layout.translate(child, dx, dy), out, depth))
+    // Wipe the overlay rectangle with spaces so the dialog interior is
+    // opaque and panels behind don't bleed through.
+    val blankRow = " " * o.width
+    var row      = 0
+    while row < o.height do
+      out.append(moveTo(XCoord(ox.value), YCoord(oy.value + row))).append(blankRow)
+      row += 1
+    o.children.foreach(child => renderNode(Layout.translate(child, dx, dy), out, depth, extendedStyles))
 
-  private def renderNode(v: VNode, out: StringBuilder, depth: ColorDepth): Unit = v match
-    case TextNode(x, y, l) =>
-      out.append(moveTo(x, y))
-      l.foreach { case Text(str, style) =>
-        out.append(styleToAnsi(style, depth)).append(str).append(reset)
-      }
+  private def renderNode(v: VNode, out: StringBuilder, depth: ColorDepth, extendedStyles: Boolean): Unit =
+    v match
+      case TextNode(x, y, l) =>
+        out.append(moveTo(x, y))
+        l.foreach { case Text(str, style) =>
+          out.append(styleToAnsi(style, depth, extendedStyles)).append(str).append(reset)
+        }
 
-    case BoxNode(x, y, w, h, children, style, chars) =>
-      if style.border then drawBorder(x, y, w, h, style.fg, chars, out, depth)
-      children.foreach(renderNode(_, out, depth))
+      case BoxNode(x, y, w, h, children, style, chars) =>
+        if style.border then drawBorder(x, y, w, h, style.fg, chars, out, depth)
+        children.foreach(renderNode(_, out, depth, extendedStyles))
 
-    case _: InputNode => () // handled separately
+      case _: InputNode => () // handled separately
 
   private def drawBorder(
     x: XCoord,
@@ -327,7 +392,13 @@ object AnsiRenderer:
     val cursorIndex = math.max(0, math.min(cursorLimit, unclampedCursorIndex))
     VisibleInput(visibleText, cursorIndex, width)
 
-  private def renderInput(inp: InputNode, rootWidth: Int, out: StringBuilder, depth: ColorDepth): Unit =
+  private def renderInput(
+    inp: InputNode,
+    rootWidth: Int,
+    out: StringBuilder,
+    depth: ColorDepth,
+    extendedStyles: Boolean
+  ): Unit =
     val visible = visibleInput(inp, rootWidth)
 
     // Clear full terminal row from column 1, then position to input x.
@@ -337,7 +408,7 @@ object AnsiRenderer:
     out.append(moveTo(inp.x, inp.y))
 
     val baseStyle = inp.style
-    val baseAnsi  = styleToAnsi(baseStyle, depth)
+    val baseAnsi  = styleToAnsi(baseStyle, depth, extendedStyles)
     // Draw the bounded single-line viewport only; never rely on terminal soft-wrap.
     out.append(baseAnsi).append(visible.text).append(reset)
 
@@ -348,7 +419,7 @@ object AnsiRenderer:
   def buildFrame(root: RootNode): RenderFrame =
     def nodeExtents(node: VNode): (Int, Int) = node match
       case TextNode(x, y, segments) =>
-        val textWidth = segments.foldLeft(0)((acc, seg) => acc + seg.txt.length)
+        val textWidth = segments.foldLeft(0)((acc, seg) => acc + WCWidth.stringWidth(seg.txt))
         val right     = x.value + math.max(0, textWidth - 1)
         (right, y.value)
 
@@ -392,10 +463,22 @@ object AnsiRenderer:
 
     def drawString(x: Int, y: Int, str: String, style: Style): Unit =
       var col = x
-      str.foreach { ch =>
-        putCell(col, y, RenderCell(ch, style))
-        col += 1
-      }
+      var i   = 0
+      while i < str.length do
+        val cp = str.codePointAt(i)
+        val w  = WCWidth.codePointWidth(cp)
+        val ch = str.charAt(i)
+        if w == 2 then
+          putCell(col, y, RenderCell(ch, style, 2))
+          putCell(col + 1, y, RenderCell(' ', style, 0))
+          col += 2
+        else if w == 1 then
+          putCell(col, y, RenderCell(ch, style, 1))
+          col += 1
+        // Combining marks / control / zero-width: skip silently. They would
+        // ideally attach to the previous cell, but the cell model doesn't
+        // carry composing-glyph slots yet — punting to a future iteration.
+        i += java.lang.Character.charCount(cp)
 
     def drawBorder(x: Int, y: Int, w: Int, h: Int, style: Style, chars: BorderChars): Unit =
       if w > 0 && h > 0 then
@@ -421,7 +504,7 @@ object AnsiRenderer:
         var col = x.value
         segments.foreach { case Text(str, style) =>
           drawString(col, y.value, str, style)
-          col += str.length
+          col += WCWidth.stringWidth(str)
         }
 
       case BoxNode(x, y, w, h, children, style, chars) =>
@@ -450,10 +533,21 @@ object AnsiRenderer:
     // Composite overlays bottom-to-top. Each overlay's children are
     // translated by the resolved position so callers author them in
     // overlay-local coordinates (1.x / 1.y is the overlay's top-left).
+    //
+    // Before drawing the children we wipe the overlay's rectangle with
+    // blank cells so anything beneath is opaquely occluded — without this,
+    // the box border draws but the interior leaks the panels behind it.
     root.overlays.foreach { o =>
       val (ox, oy) = OverlayPosition.resolve(o.position, o.width, o.height, root.width, root.height)
       val dx       = ox.value - 1
       val dy       = oy.value - 1
+      var fy       = 0
+      while fy < o.height do
+        var fx = 0
+        while fx < o.width do
+          putCell(ox.value + fx, oy.value + fy, blankCell)
+          fx += 1
+        fy += 1
       o.children.foreach(child => drawNode(Layout.translate(child, dx, dy)))
       o.input.foreach { in =>
         val translated: InputNode = in.copy(x = in.x + dx, y = in.y + dy)
@@ -467,10 +561,19 @@ object AnsiRenderer:
 
   /** Diff two frames and emit only changed runs plus cursor movement. */
   def diff(prev: Option[RenderFrame], current: RenderFrame): DiffResult =
-    diff(prev, current, ColorDepth.Ansi8)
+    diff(prev, current, ColorDepth.Ansi8, extendedStyles = true)
 
   /** Diff two frames at the given color depth. */
   def diff(prev: Option[RenderFrame], current: RenderFrame, depth: ColorDepth): DiffResult =
+    diff(prev, current, depth, extendedStyles = true)
+
+  /** Diff two frames honouring color depth and extended SGR capability. */
+  def diff(
+    prev: Option[RenderFrame],
+    current: RenderFrame,
+    depth: ColorDepth,
+    extendedStyles: Boolean
+  ): DiffResult =
     def cellAt(frame: Option[RenderFrame], row: Int, col: Int): RenderCell =
       frame match
         case Some(f) if row < f.height && col < f.width => f.cells(row)(col)
@@ -494,13 +597,17 @@ object AnsiRenderer:
           var cursor = col
           while cursor < current.width && cellAt(Some(current), row, cursor) != blankCell do
             val style = cellAt(Some(current), row, cursor).style
-            out.append(reset).append(styleToAnsi(style, depth))
+            out.append(reset).append(styleToAnsi(style, depth, extendedStyles))
             var j = cursor
             while j < current.width &&
               cellAt(Some(current), row, j) != blankCell &&
               cellAt(Some(current), row, j).style == style
             do
-              out.append(cellAt(Some(current), row, j).ch)
+              // Wide-char continuation cells (width = 0) carry the same
+              // style as their leading wide cell but no glyph of their own
+              // — the terminal already advanced its cursor past that
+              // column when the wide glyph was emitted.
+              if cellAt(Some(current), row, j).width != 0 then out.append(cellAt(Some(current), row, j).ch)
               j += 1
             cursor = j
           col = cursor
@@ -528,10 +635,18 @@ object AnsiRenderer:
     DiffResult(out.toString, changedCellsCount, changedRowsCount)
 
   def renderDiff(prev: Option[RenderFrame], current: RenderFrame): String =
-    diff(prev, current, ColorDepth.Ansi8).ansi
+    diff(prev, current, ColorDepth.Ansi8, extendedStyles = true).ansi
 
   def renderDiff(prev: Option[RenderFrame], current: RenderFrame, depth: ColorDepth): String =
-    diff(prev, current, depth).ansi
+    diff(prev, current, depth, extendedStyles = true).ansi
+
+  def renderDiff(
+    prev: Option[RenderFrame],
+    current: RenderFrame,
+    depth: ColorDepth,
+    extendedStyles: Boolean
+  ): String =
+    diff(prev, current, depth, extendedStyles).ansi
 
 final case class SimpleANSIRenderer() extends TuiRenderer:
   private var lastFrame: Option[AnsiRenderer.RenderFrame] = None
@@ -546,13 +661,14 @@ final case class SimpleANSIRenderer() extends TuiRenderer:
     val currentFrame = AnsiRenderer.buildFrame(textNode)
     val resized      = lastFrame.exists(prev => prev.width != currentFrame.width || prev.height != currentFrame.height)
     val depth        = terminal.capabilities.colorDepth
+    val ext          = terminal.capabilities.extendedStyles
     val initialDiff =
-      if resized then AnsiRenderer.diff(None, currentFrame, depth)
-      else AnsiRenderer.diff(lastFrame, currentFrame, depth)
+      if resized then AnsiRenderer.diff(None, currentFrame, depth, ext)
+      else AnsiRenderer.diff(lastFrame, currentFrame, depth, ext)
     val shouldFullRepaint =
       resized || initialDiff.changedRows >= math.min(currentFrame.height, FullRepaintRowThreshold)
     val diffResult =
-      if shouldFullRepaint then AnsiRenderer.diff(None, currentFrame, depth)
+      if shouldFullRepaint then AnsiRenderer.diff(None, currentFrame, depth, ext)
       else initialDiff
     val ansi =
       if shouldFullRepaint then ANSI.clearScreen + ANSI.homeCursor + diffResult.ansi

--- a/modules/termflow/src/main/scala/termflow/tui/Capabilities.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Capabilities.scala
@@ -21,17 +21,33 @@ enum ColorDepth:
  * Best-effort terminal capabilities, populated either from environment
  * variables (see [[Capabilities.detect]]) or supplied explicitly by tests.
  *
- * @param colorDepth Maximum color depth the renderer should emit. Higher-depth
- *                   colors are downgraded to this depth at render time.
- * @param unicode    True if the terminal claims a UTF-8 locale.
- * @param mouse      True if the terminal advertises mouse support
- *                   (`xterm`-family `$TERM` values, `screen`, `tmux`,
- *                   `alacritty`, `rxvt`, `linux`).
+ * @param colorDepth     Maximum color depth the renderer should emit.
+ *                       Higher-depth colors are downgraded to this depth at
+ *                       render time.
+ * @param unicode        True if the terminal claims a UTF-8 locale.
+ * @param mouse          True if the terminal advertises mouse support
+ *                       (`xterm`-family `$TERM` values, `screen`, `tmux`,
+ *                       `alacritty`, `rxvt`, `linux`).
+ * @param extendedStyles True if the terminal is expected to honour the
+ *                       extended SGR attributes ([[Style.italic]],
+ *                       [[Style.dim]], [[Style.reverse]],
+ *                       [[Style.strikethrough]], [[Style.blink]]). When false,
+ *                       the renderer strips these codes and emits only the
+ *                       universally-supported [[Style.bold]] /
+ *                       [[Style.underline]] attributes.
+ * @param bracketedPaste True if the terminal is expected to honour xterm
+ *                       bracketed-paste mode (`CSI ?2004h`). When false the
+ *                       runtime does not enable the mode at startup and the
+ *                       parser will see the pasted bytes as a stream of
+ *                       individual keypresses, just as if the user had typed
+ *                       them.
  */
 final case class Capabilities(
   colorDepth: ColorDepth,
   unicode: Boolean,
-  mouse: Boolean
+  mouse: Boolean,
+  extendedStyles: Boolean = true,
+  bracketedPaste: Boolean = true
 )
 
 object Capabilities:
@@ -44,7 +60,9 @@ object Capabilities:
   val default: Capabilities = Capabilities(
     colorDepth = ColorDepth.Ansi8,
     unicode = true,
-    mouse = false
+    mouse = false,
+    extendedStyles = true,
+    bracketedPaste = true
   )
 
   /**
@@ -83,7 +101,22 @@ object Capabilities:
 
     val mouse = isXtermFamily(term)
 
-    Capabilities(colorDepth, unicode, mouse)
+    // Extended SGR attributes (italic, dim, reverse, strikethrough, blink) are
+    // safe on the same xterm-family terminals that handle colour and mouse
+    // cleanly, plus VT-derived terminals like `vt100`/`ansi`. Suppressed for
+    // `dumb` and unknown TERMs so primitive backends don't render the SGR
+    // codes literally.
+    val extendedStyles =
+      if term.isEmpty || term == "dumb" then false
+      else if isXtermFamily(term) then true
+      else term.startsWith("vt") || term == "ansi"
+
+    // Bracketed paste support — universally available on the xterm family
+    // and tmux/screen relays. Suppressed for the same dumb/unknown subset
+    // because the start/end markers would otherwise echo as literal text.
+    val bracketedPaste = isXtermFamily(term)
+
+    Capabilities(colorDepth, unicode, mouse, extendedStyles, bracketedPaste)
 
   private def isXtermFamily(term: String): Boolean =
     term.startsWith("xterm")

--- a/modules/termflow/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
@@ -2,10 +2,12 @@ package termflow.tui
 
 import termflow.tui.AsciiControl.*
 import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
 
 import java.io.Reader
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 import scala.util.Success
 import scala.util.Try
@@ -20,90 +22,229 @@ trait TerminalKeySource:
   def close(): Try[Unit]
 
 object ConsoleKeyPressSource:
-  private val EndOfStream = Int.MinValue
+  private val EndOfStream                   = Int.MinValue
+  private val csiPollTimeoutMs: Long        = 50L
+  private val standaloneEscapeMs: Long      = 50L
+  private val DefaultModifierIfMissing: Int = 1
 
-  @tailrec
-  private def processKey(c: Int, queueBridge: BlockingQueue[Integer], buffer: List[Int]): InputKey =
-    (c, buffer) match
-      case (x, Nil) if x != ESC =>
-        KeyDecoder.decode(x)
+  /**
+   * Top-level decoder: classifies a single byte as a printable, control,
+   * standalone Escape, or the start of a CSI / SS3 sequence and dispatches
+   * to the appropriate sub-parser.
+   */
+  private def processKey(c: Int, queueBridge: BlockingQueue[Integer]): InputKey =
+    if c != ESC then KeyDecoder.decode(c)
+    else
+      // Standalone ESC: 50 ms grace period to see if a sequence follows.
+      val next: Integer = queueBridge.poll(standaloneEscapeMs, TimeUnit.MILLISECONDS)
+      Option(next).map(_.intValue()) match
+        case None =>
+          InputKey.Escape
+        case Some(`EndOfStream`) =>
+          queueBridge.put(EndOfStream)
+          InputKey.Escape
+        case Some(b) if b == `[` =>
+          decodeCsi(queueBridge)
+        case Some(b) if b == O =>
+          decodeSs3(queueBridge)
+        case Some(b) =>
+          // ESC followed by any other byte is the conventional Alt+key
+          // encoding (xterm "metaSendsEscape"). Wrap whatever the byte
+          // decodes to with `alt = true`.
+          val base = KeyDecoder.decode(b)
+          withMods(base, Modifiers(alt = true))
 
-      case (ESC, Nil) =>
-        val next: Integer =
-          queueBridge.poll(50, java.util.concurrent.TimeUnit.MILLISECONDS)
-        Option(next).map(_.intValue()) match
-          case None =>
-            InputKey.Escape
-          case Some(`EndOfStream`) =>
-            queueBridge.put(EndOfStream)
-            InputKey.Escape
-          case Some(n) =>
-            processKey(n, queueBridge, ESC :: Nil)
+  /**
+   * Read a CSI body — parameter bytes (`0..9`, `;`) followed by a final
+   * byte (any other printable) — then map to an `InputKey`. Returns
+   * `Unknown` for malformed or unrecognised sequences.
+   *
+   * Bytes outside the CSI parameter alphabet that arrive before a final
+   * byte (e.g. `?`, `<`, `>`, `!`) trigger a fallback that consumes until
+   * the next final byte and reports `Unknown`. SGR mouse (`CSI < ...`)
+   * will be handled separately at the mouse-support stage.
+   */
+  private def decodeCsi(queueBridge: BlockingQueue[Integer]): InputKey =
+    val builder         = new StringBuilder
+    var prefix: Char    = '\u0000'
+    var finalByte: Char = '\u0000'
+    var done            = false
+    var endOfStream     = false
 
-      case (O, ESC :: Nil) =>
-        processKey(queueBridge.take(), queueBridge, buffer :+ c)
-      case (`[`, ESC :: Nil) =>
-        processKey(queueBridge.take(), queueBridge, buffer :+ c)
+    while !done do
+      val n: Integer = queueBridge.poll(csiPollTimeoutMs, TimeUnit.MILLISECONDS)
+      if n == null then
+        // Truncated CSI sequence — give up and report Unknown.
+        finalByte = '\u0000'
+        done = true
+      else if n.intValue() == EndOfStream then
+        queueBridge.put(EndOfStream)
+        endOfStream = true
+        done = true
+      else
+        val ch = n.intValue().toChar
+        if (ch >= '0' && ch <= '9') || ch == ';' then builder.append(ch)
+        else if prefix == '\u0000' && (ch == '?' || ch == '<' || ch == '>' || ch == '!') then prefix = ch
+        else
+          finalByte = ch
+          done = true
 
-      case (P, List(ESC, O)) =>
-        InputKey.F1
-      case (Q, List(ESC, O)) =>
-        InputKey.F2
-      case (R, List(ESC, O)) =>
-        InputKey.F3
-      case (S, List(ESC, O)) =>
-        InputKey.F4
+    if endOfStream || finalByte == '\u0000' then InputKey.Unknown(s"CSI ${builder.toString}")
+    else
+      val params: Vector[Int] =
+        if builder.isEmpty then Vector.empty
+        else builder.toString.split(";", -1).toVector.map(p => if p.isEmpty then 0 else p.toInt)
+      prefix match
+        case '<'      => decodeSgrMouse(params, finalByte)
+        case '\u0000' => csiToKey(params, finalByte, queueBridge)
+        case other    => InputKey.Unknown(s"CSI $other${builder.toString}$finalByte")
 
-      case (A, List(ESC, `[`)) =>
-        InputKey.ArrowUp
-      case (B, List(ESC, `[`)) =>
-        InputKey.ArrowDown
-      case (C, List(ESC, `[`)) =>
-        InputKey.ArrowRight
-      case (D, List(ESC, `[`)) =>
-        InputKey.ArrowLeft
+  /**
+   * SS3 prefix (`ESC O`): function-key encoding used by some terminals
+   * for F1..F4, plus a few alternate Home/End forms.
+   */
+  private def decodeSs3(queueBridge: BlockingQueue[Integer]): InputKey =
+    val n: Integer = queueBridge.poll(csiPollTimeoutMs, TimeUnit.MILLISECONDS)
+    if n == null then InputKey.Escape
+    else if n.intValue() == EndOfStream then
+      queueBridge.put(EndOfStream)
+      InputKey.Escape
+    else
+      n.intValue().toChar match
+        case 'P'   => InputKey.F1
+        case 'Q'   => InputKey.F2
+        case 'R'   => InputKey.F3
+        case 'S'   => InputKey.F4
+        case 'H'   => InputKey.Home
+        case 'F'   => InputKey.End
+        case other => InputKey.Unknown(s"SS3 $other")
 
-      case (H, List(ESC, `[`)) =>
-        InputKey.Home
-      case (F, List(ESC, `[`)) =>
-        InputKey.End
-      case (Z, List(ESC, `[`)) =>
-        InputKey.BackTab
-      case (H, List(ESC, O)) =>
-        InputKey.Home
-      case (F, List(ESC, O)) =>
-        InputKey.End
-
-      // Delete key: ESC [ 3 ~
-      case (`~`, List(ESC, `[`, `51`)) =>
-        InputKey.Delete
-
-      case (x, List(ESC, `[`)) =>
-        processKey(queueBridge.take(), queueBridge, buffer :+ x)
-      case (x, List(ESC, `[`, `49`)) =>
-        processKey(queueBridge.take(), queueBridge, buffer :+ x)
-      case (x, List(ESC, `[`, `50`)) =>
-        processKey(queueBridge.take(), queueBridge, buffer :+ x)
-
-      case (`~`, List(ESC, `[`, `49`, `53`)) =>
-        InputKey.F5
-      case (`~`, List(ESC, `[`, `49`, `55`)) =>
-        InputKey.F6
-      case (`~`, List(ESC, `[`, `49`, `56`)) =>
-        InputKey.F7
-      case (`~`, List(ESC, `[`, `49`, `57`)) =>
-        InputKey.F8
-      case (`~`, List(ESC, `[`, `50`, `48`)) =>
-        InputKey.F9
-      case (`~`, List(ESC, `[`, `50`, `49`)) =>
-        InputKey.F10
-      case (`~`, List(ESC, `[`, `50`, `51`)) =>
-        InputKey.F11
-      case (`~`, List(ESC, `[`, `50`, `52`)) =>
-        InputKey.F12
-
+  /**
+   * Map `(params, finalByte)` from a CSI body to an `InputKey`.
+   *
+   * Cursor / navigation keys use the `CSI 1 ; <mod> <letter>` form. The
+   * leading `1` is the cursor-position marker; we accept it implicitly
+   * and pull modifiers out of the second parameter.
+   *
+   * Function keys with parameters use `CSI <key> ; <mod> ~`; the modifier
+   * (when present) is in the second parameter.
+   */
+  private def csiToKey(
+    params: Vector[Int],
+    finalByte: Char,
+    queueBridge: BlockingQueue[Integer]
+  ): InputKey =
+    finalByte match
+      case 'A' => withMods(InputKey.ArrowUp, modsAt(params, 1))
+      case 'B' => withMods(InputKey.ArrowDown, modsAt(params, 1))
+      case 'C' => withMods(InputKey.ArrowRight, modsAt(params, 1))
+      case 'D' => withMods(InputKey.ArrowLeft, modsAt(params, 1))
+      case 'H' => withMods(InputKey.Home, modsAt(params, 1))
+      case 'F' => withMods(InputKey.End, modsAt(params, 1))
+      case 'Z' => InputKey.BackTab
+      case 'P' => withMods(InputKey.F1, modsAt(params, 1))
+      case 'Q' => withMods(InputKey.F2, modsAt(params, 1))
+      case 'R' => withMods(InputKey.F3, modsAt(params, 1))
+      case 'S' => withMods(InputKey.F4, modsAt(params, 1))
+      case '~' =>
+        val keyId = params.headOption.getOrElse(DefaultModifierIfMissing)
+        if keyId == 200 then collectPaste(queueBridge)
+        else if keyId == 201 then
+          // A stray paste-end marker without a matching start. Drop it
+          // silently — surfacing it as Unknown would leak the protocol
+          // marker to apps that didn't ask for it.
+          InputKey.Unknown(s"CSI 201~ (orphan paste end)")
+        else
+          val mods = modsAt(params, 1)
+          keyForTilde(keyId) match
+            case Some(k) => withMods(k, mods)
+            case None    => InputKey.Unknown(s"CSI ${params.mkString(";")}~")
       case _ =>
-        InputKey.Unknown(c.toString)
+        InputKey.Unknown(s"CSI ${params.mkString(";")}$finalByte")
+
+  /**
+   * Map the leading parameter of a `CSI <n> ~` sequence to its base key.
+   * Numbers come straight from xterm CTLSEQS:
+   *   1, 7 → Home   2 → Insert   3 → Delete   4, 8 → End
+   *   5 → PageUp    6 → PageDown
+   *   11..15 → F1..F5   17..21 → F6..F10   23..24 → F11..F12
+   */
+  private def keyForTilde(n: Int): Option[InputKey] = n match
+    case 1 | 7 => Some(InputKey.Home)
+    case 2     => Some(InputKey.Insert)
+    case 3     => Some(InputKey.Delete)
+    case 4 | 8 => Some(InputKey.End)
+    case 5     => Some(InputKey.PageUp)
+    case 6     => Some(InputKey.PageDown)
+    case 11    => Some(InputKey.F1)
+    case 12    => Some(InputKey.F2)
+    case 13    => Some(InputKey.F3)
+    case 14    => Some(InputKey.F4)
+    case 15    => Some(InputKey.F5)
+    case 17    => Some(InputKey.F6)
+    case 18    => Some(InputKey.F7)
+    case 19    => Some(InputKey.F8)
+    case 20    => Some(InputKey.F9)
+    case 21    => Some(InputKey.F10)
+    case 23    => Some(InputKey.F11)
+    case 24    => Some(InputKey.F12)
+    case _     => None
+
+  private def modsAt(params: Vector[Int], idx: Int): Modifiers =
+    if params.length > idx then Modifiers.fromXtermCode(params(idx)) else Modifiers.none
+
+  private def withMods(key: InputKey, mods: Modifiers): InputKey =
+    if mods.isEmpty then key else InputKey.Modified(key, mods)
+
+  /**
+   * Decode an SGR-1006 mouse sequence — `CSI < button ; col ; row M/m`.
+   *
+   * The terminal sends the final byte as `M` for press, motion, and scroll
+   * events and `m` for releases; the button parameter is the encoded
+   * button-and-modifier byte documented on [[MouseEvent.fromSgr]].
+   */
+  private def decodeSgrMouse(params: Vector[Int], finalByte: Char): InputKey =
+    if params.length < 3 then InputKey.Unknown(s"CSI <${params.mkString(";")}$finalByte")
+    else
+      val button       = params(0)
+      val col          = params(1)
+      val row          = params(2)
+      val releaseFinal = finalByte == 'm'
+      MouseEvent.fromSgr(button, col, row, releaseFinal) match
+        case Some(ev) => InputKey.Mouse(ev)
+        case None     => InputKey.Unknown(s"CSI <${params.mkString(";")}$finalByte")
+
+  /**
+   * Read pasted bytes after the `ESC [ 200 ~` start marker, stopping when
+   * the matching `ESC [ 201 ~` end marker arrives. Bytes between the two
+   * markers — including embedded ESC characters that don't continue the
+   * end marker — become the [[InputKey.Paste]] payload verbatim.
+   */
+  private def collectPaste(queueBridge: BlockingQueue[Integer]): InputKey =
+    val EndMarker = "[201~"
+    val sb        = new StringBuilder
+    var matchPos  = 0
+    var done      = false
+    while !done do
+      val n = queueBridge.take().intValue()
+      if n == EndOfStream then
+        queueBridge.put(EndOfStream)
+        if matchPos > 0 then sb.append(EndMarker.substring(0, matchPos))
+        done = true
+      else
+        val ch = n.toChar
+        if ch == EndMarker.charAt(matchPos) then
+          matchPos += 1
+          if matchPos == EndMarker.length then done = true
+        else
+          // Mismatch: the partial-match prefix turns out to be content.
+          if matchPos > 0 then
+            sb.append(EndMarker.substring(0, matchPos))
+            matchPos = 0
+          // The non-matching byte itself might start a fresh match.
+          if ch == EndMarker.charAt(0) then matchPos = 1
+          else sb.append(ch)
+    InputKey.Paste(sb.toString)
 
   /** Create a `TerminalKeySource` from a reader. */
   def apply(reader: Reader): TerminalKeySource =
@@ -136,7 +277,7 @@ object ConsoleKeyPressSource:
               inputReads.put(InputRead.End)
               loop(false)
             else
-              val key = processKey(c, bridge, Nil)
+              val key = processKey(c, bridge)
               inputReads.put(InputRead.Key(key))
               loop(true)
         loop(true)

--- a/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
@@ -2,14 +2,66 @@ package termflow.tui
 
 object KeyDecoder:
 
+  /**
+   * Modifier-key state attached to an [[InputKey]] via [[InputKey.Modified]].
+   *
+   * Decoded from the xterm modifier byte that appears in CSI sequences such
+   * as `ESC [ 1 ; 5 A` (Ctrl+ArrowUp) and `ESC [ 15 ; 2 ~` (Shift+F5).
+   * The xterm encoding is `code = 1 + Shift + 2*Alt + 4*Ctrl + 8*Meta`.
+   *
+   * The `none` value (no modifiers) never appears wrapped in `Modified` —
+   * the parser unwraps it to the bare key, so a downstream `case ArrowUp =>`
+   * still matches when no modifier is held.
+   *
+   * @param shift Shift key was held.
+   * @param alt   Alt / Option key was held.
+   * @param ctrl  Control key was held.
+   * @param meta  Meta / Super key was held (uncommon — most terminals do not emit this).
+   */
+  final case class Modifiers(
+    shift: Boolean = false,
+    alt: Boolean = false,
+    ctrl: Boolean = false,
+    meta: Boolean = false
+  ):
+    def isEmpty: Boolean  = !shift && !alt && !ctrl && !meta
+    def nonEmpty: Boolean = !isEmpty
+
+  object Modifiers:
+
+    /** No modifiers held. */
+    val none: Modifiers = Modifiers()
+
+    /**
+     * Decode the xterm modifier byte (parameter that follows the `;` in
+     * sequences like `CSI 1 ; 5 A`). The valid range is 2..16; anything
+     * outside is decoded as `none`.
+     *
+     * Encoding (xterm CTLSEQS): `code = 1 + Shift + 2*Alt + 4*Ctrl + 8*Meta`,
+     * so `2` is Shift, `3` is Alt, `5` is Ctrl, `6` is Shift+Ctrl, …
+     */
+    def fromXtermCode(code: Int): Modifiers =
+      if code < 2 || code > 16 then none
+      else
+        val n = code - 1
+        Modifiers(
+          shift = (n & 1) != 0,
+          alt = (n & 2) != 0,
+          ctrl = (n & 4) != 0,
+          meta = (n & 8) != 0
+        )
+
   /** Normalised key representation used by the TUI. */
   enum InputKey:
     case CharKey(ch: Char)
     case Ctrl(ch: Char)
     case Backspace
     case Delete
+    case Insert
     case Home
     case End
+    case PageUp
+    case PageDown
     case Enter
     case Escape
     case ArrowUp
@@ -31,6 +83,36 @@ object KeyDecoder:
     case F10
     case F11
     case F12
+
+    /**
+     * A base key with one or more [[Modifiers]] held. Produced by the CSI
+     * parser when an `ESC [ 1 ; <mod> <letter>` or `ESC [ <key> ; <mod> ~`
+     * sequence is recognised. The wrapped `key` is never itself a
+     * `Modified`, and `mods.nonEmpty` is always true — bare keys are
+     * returned without wrapping.
+     */
+    case Modified(key: InputKey, mods: Modifiers)
+
+    /**
+     * A run of pasted text delivered as a single key event by the xterm
+     * bracketed-paste protocol (`ESC [ 200 ~ ... ESC [ 201 ~`), activated by
+     * [[ANSI.enableBracketedPaste]] at startup. The `text` payload preserves
+     * embedded newlines; subscribers should treat it as opaque input rather
+     * than a stream of individual keypresses.
+     */
+    case Paste(text: String)
+
+    /**
+     * A pointing-device event decoded from the xterm SGR-1006 mouse
+     * protocol. Multiplexed onto the key stream so apps can handle keyboard
+     * and mouse uniformly without owning two separate sources of bytes from
+     * the terminal — pattern-match on `Mouse(_)` in the same handler that
+     * sees `CharKey('q')`.
+     *
+     * Mouse reporting is enabled by [[ANSI.enableMouse]] at startup when
+     * [[Capabilities.mouse]] is true.
+     */
+    case Mouse(event: MouseEvent)
     case Unknown(seq: String)
     case EndOfInput
 

--- a/modules/termflow/src/main/scala/termflow/tui/Mouse.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Mouse.scala
@@ -1,0 +1,109 @@
+package termflow.tui
+
+/** Pointing-device button reported by the SGR mouse protocol. */
+enum MouseButton:
+  case Left
+  case Middle
+  case Right
+
+  /** A reported xterm "extra" button (back / forward on five-button mice). */
+  case Other(code: Int)
+
+/** Direction reported by [[MouseEvent.Scroll]]. */
+enum ScrollDirection:
+  case Up
+  case Down
+  case Left
+  case Right
+
+/**
+ * A single mouse event decoded from the xterm SGR-1006 mouse protocol
+ * (`CSI < button ; col ; row M / m`).
+ *
+ * Coordinates are 1-based to match every other coordinate pair in the
+ * library — `col=1, row=1` is the top-left cell.
+ *
+ * The capture mode (xterm "any-event tracking", `CSI ?1003h`) decides
+ * whether [[Move]] events without a held button arrive at all; today the
+ * runtime enables button-event tracking only (`CSI ?1002h`), so apps will
+ * see [[Press]] / [[Release]] / [[Drag]] / [[Scroll]] but no bare moves.
+ * The enum is wired up regardless so a future "track everything" toggle
+ * doesn't change the public API.
+ */
+enum MouseEvent:
+  case Press(button: MouseButton, col: Int, row: Int, mods: KeyDecoder.Modifiers)
+  case Release(button: MouseButton, col: Int, row: Int, mods: KeyDecoder.Modifiers)
+  case Drag(button: MouseButton, col: Int, row: Int, mods: KeyDecoder.Modifiers)
+  case Move(col: Int, row: Int, mods: KeyDecoder.Modifiers)
+  case Scroll(direction: ScrollDirection, col: Int, row: Int, mods: KeyDecoder.Modifiers)
+
+  /** Position the event references on the terminal grid (1-based). */
+  def at: (Int, Int) = this match
+    case Press(_, c, r, _)   => (c, r)
+    case Release(_, c, r, _) => (c, r)
+    case Drag(_, c, r, _)    => (c, r)
+    case Move(c, r, _)       => (c, r)
+    case Scroll(_, c, r, _)  => (c, r)
+
+  /** Modifier-key state at the time of the event. */
+  def modifiers: KeyDecoder.Modifiers = this match
+    case Press(_, _, _, m)   => m
+    case Release(_, _, _, m) => m
+    case Drag(_, _, _, m)    => m
+    case Move(_, _, m)       => m
+    case Scroll(_, _, _, m)  => m
+
+object MouseEvent:
+
+  /**
+   * Decode an SGR mouse sequence.
+   *
+   * @param button       Raw button byte from the SGR sequence. Bits 0..1
+   *                     pick the base button (or `3` for "no button" on
+   *                     motion); bit 2 = shift, bit 3 = alt, bit 4 = ctrl,
+   *                     bit 5 = motion (drag / move), bit 6 = scroll, bit 7
+   *                     = extra (button 8/9 etc).
+   * @param col          1-based column.
+   * @param row          1-based row.
+   * @param releaseFinal True when the final byte was `m` (release); false
+   *                     when it was `M` (press / motion / scroll).
+   */
+  def fromSgr(button: Int, col: Int, row: Int, releaseFinal: Boolean): Option[MouseEvent] =
+    val mods = KeyDecoder.Modifiers(
+      shift = (button & 0x04) != 0,
+      alt = (button & 0x08) != 0,
+      ctrl = (button & 0x10) != 0
+    )
+    val isScroll = (button & 0x40) != 0
+    val isMotion = (button & 0x20) != 0
+    val baseCode = button & 0x03
+    val extraCode =
+      if (button & 0x80) != 0 then Some(8 + (button & 0x03))
+      else if isScroll then Some(button & 0x43) // keep the scroll bits intact for downstream
+      else None
+
+    if isScroll then
+      val dir = button & 0x03 match
+        case 0 => Some(ScrollDirection.Up)
+        case 1 => Some(ScrollDirection.Down)
+        case 2 => Some(ScrollDirection.Left)
+        case 3 => Some(ScrollDirection.Right)
+        case _ => None
+      dir.map(d => Scroll(d, col, row, mods))
+    else
+      val btn = (button & 0x80) match
+        case 0 =>
+          baseCode match
+            case 0 => MouseButton.Left
+            case 1 => MouseButton.Middle
+            case 2 => MouseButton.Right
+            case _ => MouseButton.Other(baseCode)
+        case _ => MouseButton.Other(extraCode.getOrElse(baseCode))
+
+      if isMotion then
+        // Motion with the no-button code (3) is a bare Move; otherwise it's
+        // a Drag with the held button.
+        if baseCode == 3 then Some(Move(col, row, mods))
+        else Some(Drag(btn, col, row, mods))
+      else if releaseFinal then Some(Release(btn, col, row, mods))
+      else Some(Press(btn, col, row, mods))

--- a/modules/termflow/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -191,8 +191,13 @@ object TuiRuntime:
     val frameworkLog     = FrameworkLog(config.logging)
     val renderMetrics    = new RenderMetrics(config.metrics, frameworkLog)
 
+    val pasteCapable = terminalBackend.capabilities.bracketedPaste
+    val mouseCapable = terminalBackend.capabilities.mouse
+
     def restoreTerminalState(): Unit =
       if restored.compareAndSet(false, true) then
+        if mouseCapable then terminalBackend.write(ANSI.disableMouse)
+        if pasteCapable then terminalBackend.write(ANSI.disableBracketedPaste)
         terminalBackend.write(ANSI.showCursor)
         terminalBackend.write(ANSI.exitAltBuffer)
         terminalBackend.flush()
@@ -208,6 +213,8 @@ object TuiRuntime:
     terminalBackend.write(ANSI.enterAltBuffer)
     terminalBackend.write(ANSI.clearScreen)
     terminalBackend.write(ANSI.showCursor)
+    if pasteCapable then terminalBackend.write(ANSI.enableBracketedPaste)
+    if mouseCapable then terminalBackend.write(ANSI.enableMouse)
     terminalBackend.flush()
     Runtime.getRuntime.addShutdownHook(shutdownHook)
 

--- a/modules/termflow/src/main/scala/termflow/tui/WCWidth.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/WCWidth.scala
@@ -1,0 +1,109 @@
+package termflow.tui
+
+/**
+ * Display-width calculator for Unicode code points and strings, mirroring
+ * the venerable `wcwidth` API by Markus Kuhn.
+ *
+ * Returns the number of terminal cells a code point occupies:
+ *   - `-1` for control characters (the caller decides what to do)
+ *   - `0`  for combining marks, zero-width joiners, and other composition glue
+ *   - `1`  for the common case of narrow / latin / typical text
+ *   - `2`  for East Asian Wide / Fullwidth characters and emoji that round
+ *          to two cells in monospace
+ *
+ * Supplementary-plane code points beyond `0xFFFF` (most emoji, including ZWJ
+ * sequences) are still handled at the [[stringWidth]] level — the
+ * `String.codePoints` view yields full 32-bit code points — but they cannot
+ * round-trip through a single Java `Char`. The cell grid stores them as
+ * surrogate pairs in two adjacent cells; rendering quality on those is
+ * terminal-dependent.
+ *
+ * Ambiguous-width characters (UAX #11 category A) default to width 1
+ * ("narrow"). The convention matches xterm in the locale we target most
+ * often; CJK locales that prefer width-2 rendering would need a
+ * locale-aware override that is currently out of scope.
+ */
+object WCWidth:
+
+  /**
+   * Display width of a single Unicode code point. Returns `-1` for `C0`/`C1`
+   * control characters; the caller is expected to either drop them or render
+   * a placeholder.
+   */
+  def codePointWidth(cp: Int): Int =
+    if cp == 0 then 0
+    else if cp < 32 || (cp >= 0x7f && cp < 0xa0) then -1
+    else if isZeroWidth(cp) then 0
+    else if isWide(cp) then 2
+    else 1
+
+  /**
+   * Display width of a single Java `Char`, usable when the caller can
+   * guarantee BMP-only input. Surrogate halves report width 1 because we
+   * cannot resolve them in isolation.
+   */
+  def charWidth(ch: Char): Int =
+    if ch.isSurrogate then 1
+    else codePointWidth(ch.toInt)
+
+  /**
+   * Sum of [[codePointWidth]] across `s`, treating control characters as
+   * width 0 (they would otherwise drag the total negative). Use this for
+   * layout calculations — cell counts, viewport sizing, scroll offsets.
+   */
+  def stringWidth(s: String): Int =
+    var i     = 0
+    var total = 0
+    while i < s.length do
+      val cp = s.codePointAt(i)
+      val w  = codePointWidth(cp)
+      if w > 0 then total += w
+      i += java.lang.Character.charCount(cp)
+    total
+
+  /**
+   * Combining marks, zero-width joiner / non-joiner, and the variation
+   * selectors. Sourced from Unicode general categories `Mn`, `Me`, `Cf` plus
+   * the well-known explicit zero-width code points; not exhaustive but
+   * covers the cases that matter for typical TUI content.
+   */
+  private def isZeroWidth(cp: Int): Boolean =
+    cp == 0x200b ||                     // zero-width space
+      cp == 0x200c ||                   // zero-width non-joiner
+      cp == 0x200d ||                   // zero-width joiner
+      cp == 0xfeff ||                   // BOM
+      (cp >= 0x0300 && cp <= 0x036f) || // combining diacritical marks
+      (cp >= 0x1ab0 && cp <= 0x1aff) || // combining marks ext.
+      (cp >= 0x1dc0 && cp <= 0x1dff) || // combining marks supplement
+      (cp >= 0x20d0 && cp <= 0x20ff) || // combining marks for symbols
+      (cp >= 0xfe00 && cp <= 0xfe0f) || // variation selectors 1..16
+      (cp >= 0xfe20 && cp <= 0xfe2f) || // combining half marks
+      (cp >= 0xe0100 && cp <= 0xe01ef)  // variation selectors supp.
+
+  /**
+   * East Asian Wide / Fullwidth ranges plus the major emoji blocks. Derived
+   * from Unicode UAX #11 (EastAsianWidth) — `W` and `F` rows — and a small
+   * curated set of emoji ranges. Updates with newer Unicode revisions are
+   * cheap (just append a range).
+   */
+  private def isWide(cp: Int): Boolean =
+    // CJK Symbols and Punctuation .. CJK Unified Ideographs Extension A
+    (cp >= 0x1100 && cp <= 0x115f) ||   // Hangul Jamo
+      (cp >= 0x2e80 && cp <= 0x303e) || // CJK Radicals Supplement, Kangxi
+      (cp >= 0x3041 && cp <= 0x33ff) || // Hiragana, Katakana, CJK Sym/Punc
+      (cp >= 0x3400 && cp <= 0x4dbf) || // CJK Unified Ideographs Ext A
+      (cp >= 0x4e00 && cp <= 0x9fff) || // CJK Unified Ideographs
+      (cp >= 0xa000 && cp <= 0xa4cf) || // Yi Syllables
+      (cp >= 0xac00 && cp <= 0xd7a3) || // Hangul Syllables
+      (cp >= 0xf900 && cp <= 0xfaff) || // CJK Compatibility Ideographs
+      (cp >= 0xfe30 && cp <= 0xfe4f) || // CJK Compatibility Forms
+      (cp >= 0xff00 && cp <= 0xff60) || // Fullwidth Forms
+      (cp >= 0xffe0 && cp <= 0xffe6) || // Fullwidth signs
+      // Emoji / pictographs
+      (cp >= 0x1f300 && cp <= 0x1f64f) || // Misc Symbols, Emoticons
+      (cp >= 0x1f680 && cp <= 0x1f6ff) || // Transport & Map
+      (cp >= 0x1f700 && cp <= 0x1f77f) || // Alchemical
+      (cp >= 0x1f900 && cp <= 0x1f9ff) || // Supplemental Symbols and Pictographs
+      (cp >= 0x1fa70 && cp <= 0x1faff) || // Symbols and Pictographs Ext-A
+      (cp >= 0x20000 && cp <= 0x2fffd) || // CJK Ideographs Extension B..F
+      (cp >= 0x30000 && cp <= 0x3fffd)    // CJK Ideographs Extension G+

--- a/modules/termflow/src/main/scala/termflow/tui/vdom.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/vdom.scala
@@ -155,10 +155,23 @@ object Color:
  * `AnsiRenderer` and emitted as SGR escape sequences. A default-constructed
  * `Style` produces no escape sequences at all, so "plain text" stays plain.
  *
+ * The five extended attributes ([[italic]], [[dim]], [[reverse]],
+ * [[strikethrough]], [[blink]]) are gated by
+ * [[Capabilities.extendedStyles]]: on terminals that don't claim support for
+ * them, the renderer silently strips the SGR codes rather than emitting
+ * sequences a primitive terminal would render literally. [[bold]] and
+ * [[underline]] always emit — they are universally supported.
+ *
  * @param fg Foreground colour. [[Color.Default]] leaves it unset.
  * @param bg Background colour. [[Color.Default]] leaves it unset.
- * @param bold Enable the bold attribute.
- * @param underline Enable the underline attribute.
+ * @param bold Enable the bold attribute (SGR 1). Always emitted.
+ * @param underline Enable the underline attribute (SGR 4). Always emitted.
+ * @param italic Enable italics (SGR 3). Capability-gated.
+ * @param dim Enable dim/faint (SGR 2). Capability-gated.
+ * @param reverse Swap foreground and background (SGR 7). Capability-gated.
+ * @param strikethrough Strike through the glyph (SGR 9). Capability-gated.
+ * @param blink Slow-blink the cell (SGR 5). Capability-gated. Most terminals
+ *              ignore or render it as bold; use sparingly.
  * @param border Only meaningful on a [[BoxNode]]: draw a border around the box.
  */
 final case class Style(
@@ -166,6 +179,11 @@ final case class Style(
   bg: Color = Color.Default,
   bold: Boolean = false,
   underline: Boolean = false,
+  italic: Boolean = false,
+  dim: Boolean = false,
+  reverse: Boolean = false,
+  strikethrough: Boolean = false,
+  blink: Boolean = false,
   border: Boolean = false
 )
 

--- a/modules/termflow/src/test/scala/termflow/tui/AnsiRendererSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/AnsiRendererSpec.scala
@@ -528,3 +528,80 @@ class AnsiRendererSpec extends AnyFunSuite:
     val secondOut = captureRendererOut(renderer, second)
     assert(secondOut.contains(ANSI.clearScreen))
     assert(secondOut.contains(ANSI.homeCursor))
+
+  // ---- Extended style attributes (Stage 2 §5.5) ----
+
+  private def styleSgr(s: Style, extendedStyles: Boolean = true): String =
+    val root = RootNode(
+      width = 10,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("x", s)))),
+      input = None
+    )
+    AnsiRenderer.renderPatch(root, ColorDepth.Ansi8, extendedStyles)
+
+  test("italic, dim, reverse, blink, strikethrough emit their SGR codes when supported"):
+    val out = styleSgr(
+      Style(italic = true, dim = true, reverse = true, blink = true, strikethrough = true)
+    )
+    assert(out.contains("[2m"), s"dim missing: $out")
+    assert(out.contains("[3m"), s"italic missing: $out")
+    assert(out.contains("[5m"), s"blink missing: $out")
+    assert(out.contains("[7m"), s"reverse missing: $out")
+    assert(out.contains("[9m"), s"strikethrough missing: $out")
+
+  test("extended style codes are stripped when capability is disabled, bold/underline still emit"):
+    val out =
+      styleSgr(Style(bold = true, underline = true, italic = true, reverse = true), extendedStyles = false)
+    assert(out.contains("[1m"), s"bold should still emit: $out")
+    assert(out.contains("[4m"), s"underline should still emit: $out")
+    assert(!out.contains("[3m"), s"italic should be stripped: $out")
+    assert(!out.contains("[7m"), s"reverse should be stripped: $out")
+
+  test("Style defaults leave all extended attributes off"):
+    val s = Style()
+    assert(!s.italic && !s.dim && !s.reverse && !s.strikethrough && !s.blink)
+    val out = styleSgr(s)
+    Seq("[2m", "[3m", "[5m", "[7m", "[9m").foreach { code =>
+      assert(!out.contains(code), s"unexpected code $code in: $out")
+    }
+
+  // ---- Unicode display width (Stage 2 §5.3) ----
+
+  test("buildFrame places a wide CJK glyph in one cell + a width=0 continuation"):
+    val root = RootNode(
+      width = 6,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("中A", Style())))),
+      input = None
+    )
+    val frame = AnsiRenderer.buildFrame(root)
+    assert(frame.cells(0)(0).ch == '中')
+    assert(frame.cells(0)(0).width == 2)
+    assert(frame.cells(0)(1).width == 0, "continuation cell after wide glyph")
+    assert(frame.cells(0)(2).ch == 'A')
+    assert(frame.cells(0)(2).width == 1)
+
+  test("renderDiff emits the wide glyph once and skips its continuation cell"):
+    val root = RootNode(
+      width = 4,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("中A", Style())))),
+      input = None
+    )
+    val ansi    = AnsiRenderer.renderDiff(None, AnsiRenderer.buildFrame(root))
+    val zhCount = ansi.count(_ == '中')
+    val aCount  = ansi.count(_ == 'A')
+    assert(zhCount == 1, s"wide glyph should appear exactly once in: $ansi")
+    assert(aCount == 1, s"narrow glyph should appear exactly once in: $ansi")
+
+  test("nodeExtents accounts for wide-char display width"):
+    // Three CJK glyphs at column 1 occupy columns 1..6 — frame must size to fit.
+    val root = RootNode(
+      width = 1,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("中日韓", Style())))),
+      input = None
+    )
+    val frame = AnsiRenderer.buildFrame(root)
+    assert(frame.width >= 6, s"expected frame width >= 6, got ${frame.width}")

--- a/modules/termflow/src/test/scala/termflow/tui/CapabilitiesSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/CapabilitiesSpec.scala
@@ -92,9 +92,35 @@ class CapabilitiesSpec extends AnyFunSuite:
     assert(!ColorDepth.Ansi16.supports(ColorDepth.Indexed256))
   }
 
-  test("default capabilities are Ansi8 + Unicode + no mouse") {
+  test("default capabilities are Ansi8 + Unicode + no mouse + extended styles on") {
     val d = Capabilities.default
     assert(d.colorDepth == ColorDepth.Ansi8)
     assert(d.unicode)
     assert(!d.mouse)
+    assert(d.extendedStyles)
+  }
+
+  test("xterm-family TERM advertises extendedStyles") {
+    assert(Capabilities.detect(Map("TERM" -> "xterm")).extendedStyles)
+    assert(Capabilities.detect(Map("TERM" -> "xterm-256color")).extendedStyles)
+    assert(Capabilities.detect(Map("TERM" -> "tmux")).extendedStyles)
+    assert(Capabilities.detect(Map("TERM" -> "alacritty")).extendedStyles)
+  }
+
+  test("vt-family / ansi advertise extendedStyles") {
+    assert(Capabilities.detect(Map("TERM" -> "vt100")).extendedStyles)
+    assert(Capabilities.detect(Map("TERM" -> "ansi")).extendedStyles)
+  }
+
+  test("dumb / empty TERM disables extendedStyles") {
+    assert(!Capabilities.detect(Map("TERM" -> "dumb")).extendedStyles)
+    assert(!Capabilities.detect(Map.empty).extendedStyles)
+  }
+
+  test("xterm-family advertises bracketedPaste; dumb / unknown does not") {
+    assert(Capabilities.detect(Map("TERM" -> "xterm-256color")).bracketedPaste)
+    assert(Capabilities.detect(Map("TERM" -> "tmux")).bracketedPaste)
+    assert(!Capabilities.detect(Map("TERM" -> "dumb")).bracketedPaste)
+    assert(!Capabilities.detect(Map("TERM" -> "vt100")).bracketedPaste)
+    assert(!Capabilities.detect(Map.empty).bracketedPaste)
   }

--- a/modules/termflow/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
@@ -49,3 +49,138 @@ class ConsoleKeyPressSourceSpec extends AnyFunSuite:
     assert(source.close().isSuccess)
     assert(source.close().isSuccess)
     assert(reader.closedCount.get() == 1)
+
+  // ---- Extended modifier parsing (Stage 2 §5.6) ----
+
+  private def decode(input: String): InputKey =
+    val source = ConsoleKeyPressSource(new StringReader(input))
+    try
+      source.next() match
+        case Key(k) => k
+        case other  => fail(s"expected Key, got $other")
+    finally
+      assert(source.close().isSuccess)
+      ()
+
+  test("decodes Shift+ArrowUp (CSI 1;2 A) as Modified(ArrowUp, shift)"):
+    val key = decode("[1;2A")
+    assert(key == InputKey.Modified(InputKey.ArrowUp, KeyDecoder.Modifiers(shift = true)))
+
+  test("decodes Ctrl+ArrowRight (CSI 1;5 C)"):
+    val key = decode("[1;5C")
+    assert(key == InputKey.Modified(InputKey.ArrowRight, KeyDecoder.Modifiers(ctrl = true)))
+
+  test("decodes Shift+Ctrl+ArrowLeft (CSI 1;6 D)"):
+    val key = decode("[1;6D")
+    assert(key == InputKey.Modified(InputKey.ArrowLeft, KeyDecoder.Modifiers(shift = true, ctrl = true)))
+
+  test("decodes Shift+F5 (CSI 15;2 ~)"):
+    val key = decode("[15;2~")
+    assert(key == InputKey.Modified(InputKey.F5, KeyDecoder.Modifiers(shift = true)))
+
+  test("decodes Ctrl+Delete (CSI 3;5 ~)"):
+    val key = decode("[3;5~")
+    assert(key == InputKey.Modified(InputKey.Delete, KeyDecoder.Modifiers(ctrl = true)))
+
+  test("decodes Insert / PageUp / PageDown / Home / End from CSI tilde forms"):
+    assert(decode("[2~") == InputKey.Insert)
+    assert(decode("[5~") == InputKey.PageUp)
+    assert(decode("[6~") == InputKey.PageDown)
+    assert(decode("[1~") == InputKey.Home)
+    assert(decode("[4~") == InputKey.End)
+
+  test("CSI without modifier still decodes to bare key (no Modified wrapper)"):
+    assert(decode("[A") == InputKey.ArrowUp)
+    assert(decode("[H") == InputKey.Home)
+    assert(decode("[3~") == InputKey.Delete)
+
+  test("decodes Alt+character (ESC + char) as Modified(CharKey, alt)"):
+    val key = decode("a")
+    assert(key == InputKey.Modified(InputKey.CharKey('a'), KeyDecoder.Modifiers(alt = true)))
+
+  // ---- Bracketed paste (Stage 2 §5.4) ----
+
+  test("CSI 200~ ... CSI 201~ collapses to a single InputKey.Paste"):
+    val input = "[200~hello world[201~"
+    assert(decode(input) == InputKey.Paste("hello world"))
+
+  test("paste content preserves embedded newlines"):
+    val input = "[200~line one\nline two\r\nline three[201~"
+    assert(decode(input) == InputKey.Paste("line one\nline two\r\nline three"))
+
+  test("paste with a stray ESC inside reads through to the real end marker"):
+    // A literal ESC character inside paste content (not followed by [201~)
+    // becomes part of the payload rather than ending the paste.
+    val input = "[200~beforeabc[201~"
+    assert(decode(input) == InputKey.Paste("beforeabc"))
+
+  test("orphan paste-end (no preceding start) is ignored"):
+    val input = "[201~"
+    decode(input) match
+      case InputKey.Unknown(_) => ()
+      case other               => fail(s"expected Unknown, got $other")
+
+  test("paste containing the start marker prefix-then-mismatch keeps content intact"):
+    // Content includes `[200` followed by `X` — the partial match resets
+    // and the bytes are emitted as content.
+    val input = "[200~head[200X[201~"
+    assert(decode(input) == InputKey.Paste("head[200X"))
+
+  // ---- Mouse / SGR-1006 (Stage 2 §5.1) ----
+
+  test("CSI <0;col;row M decodes as left-button press at (col,row)"):
+    val key = decode("\u001b[<0;7;3M")
+    assert(key == InputKey.Mouse(MouseEvent.Press(MouseButton.Left, 7, 3, KeyDecoder.Modifiers())))
+
+  test("CSI <0;col;row m decodes as left-button release"):
+    val key = decode("\u001b[<0;7;3m")
+    assert(key == InputKey.Mouse(MouseEvent.Release(MouseButton.Left, 7, 3, KeyDecoder.Modifiers())))
+
+  test("CSI <2;col;row M decodes as right-button press"):
+    val key = decode("\u001b[<2;5;5M")
+    assert(key == InputKey.Mouse(MouseEvent.Press(MouseButton.Right, 5, 5, KeyDecoder.Modifiers())))
+
+  test("CSI <32;col;row M decodes as left-button drag (motion bit set)"):
+    val key = decode("\u001b[<32;10;4M")
+    assert(key == InputKey.Mouse(MouseEvent.Drag(MouseButton.Left, 10, 4, KeyDecoder.Modifiers())))
+
+  test("CSI <35;col;row M decodes as bare Move (button code 3 = none)"):
+    val key = decode("\u001b[<35;12;7M")
+    assert(key == InputKey.Mouse(MouseEvent.Move(12, 7, KeyDecoder.Modifiers())))
+
+  test("CSI <64;col;row M decodes as scroll up"):
+    val key = decode("\u001b[<64;3;3M")
+    assert(key == InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Up, 3, 3, KeyDecoder.Modifiers())))
+
+  test("CSI <65;col;row M decodes as scroll down"):
+    val key = decode("\u001b[<65;3;3M")
+    assert(key == InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Down, 3, 3, KeyDecoder.Modifiers())))
+
+  test("Ctrl+Shift+Left-press carries the modifier bits"):
+    // button = 0 (left) + 4 (shift) + 16 (ctrl) = 20
+    val key = decode("\u001b[<20;1;1M")
+    assert(
+      key == InputKey.Mouse(
+        MouseEvent.Press(MouseButton.Left, 1, 1, KeyDecoder.Modifiers(shift = true, ctrl = true))
+      )
+    )
+
+  test("malformed mouse sequence is reported as Unknown"):
+    decode("\u001b[<99M") match
+      case InputKey.Unknown(_) => ()
+      case other               => fail(s"expected Unknown, got $other")
+
+  test("Modifiers.fromXtermCode encodes the xterm bitmap"):
+    import KeyDecoder.Modifiers
+    assert(Modifiers.fromXtermCode(2) == Modifiers(shift = true))
+    assert(Modifiers.fromXtermCode(3) == Modifiers(alt = true))
+    assert(Modifiers.fromXtermCode(4) == Modifiers(shift = true, alt = true))
+    assert(Modifiers.fromXtermCode(5) == Modifiers(ctrl = true))
+    assert(Modifiers.fromXtermCode(6) == Modifiers(shift = true, ctrl = true))
+    assert(Modifiers.fromXtermCode(7) == Modifiers(alt = true, ctrl = true))
+    assert(Modifiers.fromXtermCode(8) == Modifiers(shift = true, alt = true, ctrl = true))
+    assert(Modifiers.fromXtermCode(9) == Modifiers(meta = true))
+    // Out-of-range bytes decode as `none` rather than raising.
+    assert(Modifiers.fromXtermCode(0) == Modifiers.none)
+    assert(Modifiers.fromXtermCode(1) == Modifiers.none)
+    assert(Modifiers.fromXtermCode(99) == Modifiers.none)

--- a/modules/termflow/src/test/scala/termflow/tui/OverlaySpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/OverlaySpec.scala
@@ -145,3 +145,52 @@ class OverlaySpec extends AnyFunSuite:
     assert(baseIdx >= 0 && overlayIdx >= 0)
     assert(overlayIdx > baseIdx, "overlay text must come after base text in the render order")
   }
+
+  test("buildFrame: overlay rectangle wipes cells beneath it (no background leakage)") {
+    // Base frame with a long line of `panel-content` across the middle row.
+    val crowdedBase = RootNode(
+      width = 30,
+      height = 5,
+      children = List(TextNode(XCoord(1), YCoord(2), List(Text("XXXXXXXXXXXXXXXXXXXXXXXXXXXX", Style())))),
+      input = None
+    )
+    // Overlay covers cols 5..14 on row 2 with a single TextNode + a 1×3 box.
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(5), YCoord(2)),
+      width = 10,
+      height = 3,
+      children = List(VNode.BoxNode(XCoord(1), YCoord(1), 10, 3, Nil, Style(border = true)))
+    )
+    val frame = AnsiRenderer.buildFrame(crowdedBase.copy(overlays = List(overlay)))
+
+    // Cells inside the overlay rectangle but outside the border (col 6..13 on row 2)
+    // must be blank — no `X` from the underlying panel should leak through.
+    val rowText  = frame.cells(1).map(_.ch).mkString
+    val interior = rowText.substring(5, 13) // 0-based slice of the overlay interior
+    assert(!interior.contains('X'), s"overlay interior leaked underlying X chars: '$interior'")
+
+    // Cells outside the overlay rectangle still hold the panel content.
+    assert(rowText.charAt(0) == 'X' && rowText.charAt(15) == 'X', s"non-overlay cells should remain: '$rowText'")
+  }
+
+  test("renderPatch: overlay clears its rectangle before drawing children") {
+    val crowdedBase = RootNode(
+      width = 30,
+      height = 5,
+      children = List(TextNode(XCoord(1), YCoord(2), List(Text("LEAK-LEAK-LEAK-LEAK", Style())))),
+      input = None
+    )
+    val overlay = Overlay(
+      position = OverlayPosition.At(XCoord(5), YCoord(2)),
+      width = 10,
+      height = 1,
+      children = List(TextNode(XCoord(1), YCoord(1), List(Text("DLG", Style()))))
+    )
+    val out      = AnsiRenderer.renderPatch(crowdedBase.copy(overlays = List(overlay)))
+    val leakIdx  = out.indexOf("LEAK")
+    val blankIdx = out.indexOf("          ", leakIdx) // 10 spaces written by the wipe
+    val dlgIdx   = out.indexOf("DLG")
+    assert(leakIdx >= 0, "base text should still appear in patch")
+    assert(blankIdx > leakIdx, "wipe blanks must come after the base content")
+    assert(dlgIdx > blankIdx, "overlay glyphs must come after the wipe")
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
@@ -197,3 +197,108 @@ class TuiRuntimeSpec extends AnyFunSuite:
     val printed = backend.out.toString
     assert(printed.contains(ANSI.showCursor))
     assert(printed.contains(ANSI.exitAltBuffer))
+
+  test("runtime enables and disables bracketed paste when the backend supports it"):
+    final class StopRuntime extends RuntimeException("stop-runtime")
+
+    final class PasteCapableBackend extends TerminalBackend:
+      val out                     = new StringWriter()
+      override def reader: Reader = new StringReader("")
+      override def writer         = out
+      override def width: Int     = 80
+      override def height: Int    = 24
+      override def close(): Unit  = ()
+      override def capabilities: Capabilities =
+        Capabilities.default.copy(bracketedPaste = true)
+
+    val renderer = new TuiRenderer:
+      override def render(
+        textNode: RootNode,
+        err: Option[TermFlowError],
+        terminal: TerminalBackend,
+        renderMetrics: RenderMetrics
+      ): Unit = throw new StopRuntime
+
+    object App extends TuiApp[Int, Unit]:
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model = 0, cmd = Cmd.NoCmd)
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model)
+      override def view(model: Int): RootNode             = RootNode(80, 24, children = List.empty, input = None)
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val backend = new PasteCapableBackend
+    intercept[StopRuntime]:
+      TuiRuntime.run(app = App, renderer = renderer, terminalBackend = backend, config = TestConfig)
+
+    val printed = backend.out.toString
+    assert(printed.contains(ANSI.enableBracketedPaste))
+    assert(printed.contains(ANSI.disableBracketedPaste))
+
+  test("runtime enables and disables mouse mode when the backend supports it"):
+    final class StopRuntime extends RuntimeException("stop-runtime")
+
+    final class MouseCapableBackend extends TerminalBackend:
+      val out                     = new StringWriter()
+      override def reader: Reader = new StringReader("")
+      override def writer         = out
+      override def width: Int     = 80
+      override def height: Int    = 24
+      override def close(): Unit  = ()
+      override def capabilities: Capabilities =
+        Capabilities.default.copy(mouse = true)
+
+    val renderer = new TuiRenderer:
+      override def render(
+        textNode: RootNode,
+        err: Option[TermFlowError],
+        terminal: TerminalBackend,
+        renderMetrics: RenderMetrics
+      ): Unit = throw new StopRuntime
+
+    object App extends TuiApp[Int, Unit]:
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model = 0, cmd = Cmd.NoCmd)
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model)
+      override def view(model: Int): RootNode             = RootNode(80, 24, children = List.empty, input = None)
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val backend = new MouseCapableBackend
+    intercept[StopRuntime]:
+      TuiRuntime.run(app = App, renderer = renderer, terminalBackend = backend, config = TestConfig)
+
+    val printed = backend.out.toString
+    assert(printed.contains(ANSI.enableMouse))
+    assert(printed.contains(ANSI.disableMouse))
+
+  test("runtime omits bracketed-paste setup when backend does not support it"):
+    final class StopRuntime extends RuntimeException("stop-runtime")
+
+    final class NoPasteBackend extends TerminalBackend:
+      val out                     = new StringWriter()
+      override def reader: Reader = new StringReader("")
+      override def writer         = out
+      override def width: Int     = 80
+      override def height: Int    = 24
+      override def close(): Unit  = ()
+      override def capabilities: Capabilities =
+        Capabilities.default.copy(bracketedPaste = false)
+
+    val renderer = new TuiRenderer:
+      override def render(
+        textNode: RootNode,
+        err: Option[TermFlowError],
+        terminal: TerminalBackend,
+        renderMetrics: RenderMetrics
+      ): Unit = throw new StopRuntime
+
+    object App extends TuiApp[Int, Unit]:
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model = 0, cmd = Cmd.NoCmd)
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model)
+      override def view(model: Int): RootNode             = RootNode(80, 24, children = List.empty, input = None)
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val backend = new NoPasteBackend
+    intercept[StopRuntime]:
+      TuiRuntime.run(app = App, renderer = renderer, terminalBackend = backend, config = TestConfig)
+
+    val printed = backend.out.toString
+    assert(!printed.contains(ANSI.enableBracketedPaste))
+    assert(!printed.contains(ANSI.disableBracketedPaste))

--- a/modules/termflow/src/test/scala/termflow/tui/WCWidthSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/WCWidthSpec.scala
@@ -1,0 +1,57 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class WCWidthSpec extends AnyFunSuite:
+
+  test("ASCII printable code points are width 1") {
+    assert(WCWidth.codePointWidth('A') == 1)
+    assert(WCWidth.codePointWidth(' ') == 1)
+    assert(WCWidth.codePointWidth('~') == 1)
+  }
+
+  test("control characters report -1") {
+    assert(WCWidth.codePointWidth(0x07) == -1) // BEL
+    assert(WCWidth.codePointWidth(0x1b) == -1) // ESC
+    assert(WCWidth.codePointWidth(0x7f) == -1) // DEL
+  }
+
+  test("CJK characters are width 2") {
+    assert(WCWidth.codePointWidth('中') == 2) // U+4E2D
+    assert(WCWidth.codePointWidth('日') == 2)
+    assert(WCWidth.codePointWidth('한') == 2)    // Hangul syllable
+    assert(WCWidth.codePointWidth(0x3042) == 2) // ぁ Hiragana
+  }
+
+  test("Fullwidth ASCII variants are width 2") {
+    assert(WCWidth.codePointWidth(0xff21) == 2) // Ａ fullwidth A
+    assert(WCWidth.codePointWidth(0xff10) == 2) // ０ fullwidth 0
+  }
+
+  test("emoji code points are width 2") {
+    assert(WCWidth.codePointWidth(0x1f600) == 2) // 😀
+    assert(WCWidth.codePointWidth(0x1f389) == 2) // 🎉
+    assert(WCWidth.codePointWidth(0x1f680) == 2) // 🚀
+  }
+
+  test("combining marks and ZWJ are width 0") {
+    assert(WCWidth.codePointWidth(0x0301) == 0) // combining acute accent
+    assert(WCWidth.codePointWidth(0x200d) == 0) // ZWJ
+    assert(WCWidth.codePointWidth(0xfe0f) == 0) // VS16 (emoji presentation)
+    assert(WCWidth.codePointWidth(0x200b) == 0) // zero-width space
+  }
+
+  test("stringWidth sums code-point widths and ignores controls") {
+    assert(WCWidth.stringWidth("hello") == 5)
+    assert(WCWidth.stringWidth("中国") == 4)
+    assert(WCWidth.stringWidth("a中b") == 4)          // 1 + 2 + 1
+    assert(WCWidth.stringWidth("helloworld") == 10) // ESC swallowed
+    assert(WCWidth.stringWidth("é") == 1)           // e + combining acute
+    assert(WCWidth.stringWidth("") == 0)
+  }
+
+  test("stringWidth handles surrogate-pair emoji") {
+    val rocket = new String(Character.toChars(0x1f680))
+    assert(rocket.length == 2)               // two Java chars
+    assert(WCWidth.stringWidth(rocket) == 2) // one wide column pair
+  }


### PR DESCRIPTION
## Summary

Closes the user-visible Stage 2 work in one drop. ROADMAP marks Stage 2 done; every sub-item lands here:

- **§5.5 Extended SGR attributes** — `Style` gains `italic` / `dim` / `reverse` / `strikethrough` / `blink`, gated by new `Capabilities.extendedStyles`.
- **§5.6 Extended modifier parsing** — `KeyDecoder.Modifiers` + `InputKey.Modified`; CSI parser unified (read params then dispatch). `Insert` / `PageUp` / `PageDown` added to the enum.
- **§5.4 Bracketed paste** — `Capabilities.bracketedPaste`, `ANSI.enable/disableBracketedPaste`, `InputKey.Paste(text)` collapses `CSI 200~ … CSI 201~` into one event. Runtime enables/disables on startup/shutdown.
- **§5.3 Unicode width** — new `WCWidth` helper, `RenderCell.width` field, layout / diff respect wide cells. Known gap: `Prompt`/`InputNode` cursor math is still 1-char-per-column (multi-line input + grapheme clusters deferred).
- **§5.1 Mouse / SGR-1006** — `MouseEvent` / `MouseButton` / `ScrollDirection` ADTs, `ANSI.enable/disableMouse` enables `?1006h?1002h`, `InputKey.Mouse(event)` multiplexed onto the existing key stream so any `Sub.InputKey` consumer pattern-matches clicks. Hit-testing on the layout-pass rect cache is deferred to Stage 3.

### Showcase rewrite (`sbt showcase`)

Restructured to use absolute-positioned panels so the new **Themes** and **Borders** panels are click-to-select / scroll-to-cycle — first user-driven mouse interaction in the codebase. Also adds a **Styles** panel (§5.5), **Unicode width** panel with a column ruler (§5.3), and a **Live input** panel that shows the most recent decoded event (modified keys, mouse events with coords, paste payload preview).

### Bug fix bundled in

While building the click-driven showcase we hit and fixed an overlay opacity bug: `BoxNode` only painted the border, so panels behind a dialog leaked through the interior. `AnsiRenderer` now wipes the overlay rectangle with blank cells (`buildFrame`) and explicit-space rows (`renderPatch`) before drawing children. Two `OverlaySpec` regression tests pin the behaviour.

### Stats

- 19 files changed, +1825 / -241
- 593 tests pass (`sbt ciCheck`)
- New files: `WCWidth.scala`, `Mouse.scala`, `WCWidthSpec.scala`, `UnicodeDemoApp.scala`

## Test plan

- [x] `sbt ciCheck` — scalafmt + scalafix + all tests
- [x] `sbt showcase` rendered in a real terminal — click rows, scroll wheel, paste, modified keys all reflect in Live-input
- [x] Open dialog with `d` — interior is opaque, no panel bleed-through
- [x] Resize the terminal during showcase — panels reposition (themes/borders pinned right, palette/unicode flex)