### PR TITLE
feat: AsyncResult alias + Cmd.asyncResult — stay effect-system-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,46 @@ debug key sequences and line editing behaviour.
 - Avoid implicit conversions; return explicit `Tui` values (for example, `model.tui`).
 - Keep migration changes behavior-preserving unless a PR states otherwise.
 
+## Async Work
+
+`termflow` stays effect-system-agnostic. Async commands use `scala.concurrent.Future`
+combined with the framework's `Result[A] = Either[TermFlowError, A]`, exposed as a
+type alias that mirrors the [llm4s](https://github.com/llm4s/llm4s) core 1:1 so values
+flow between the two libraries without an adapter:
+
+```scala
+type AsyncResult[+A] = Future[Result[A]]
+```
+
+Lift one onto the command bus with `Cmd.asyncResult`:
+
+```scala
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+enum Msg:
+  case Loaded(value: User)
+  case Failed(err: TermFlowError)
+
+def fetch(id: UserId): AsyncResult[User] = ...
+
+Cmd.asyncResult(
+  task      = fetch(id),
+  onSuccess = Msg.Loaded.apply,
+  onError   = Msg.Failed.apply,
+  onEnqueue = Some(Msg.LoadingFlash)   // optional
+)
+```
+
+`Future` failures (network drops, JVM exceptions) surface through the runtime's
+standard `Cmd.TermFlowErrorCmd` path automatically; only domain errors need an
+explicit `onError`. `AsyncResult` ships a small companion with `success`,
+`failure`, `fromResult`, and `fromFuture` for lifting at the boundary.
+
+We do **not** ship cats-effect or ZIO adapter modules — apps that use `IO` /
+`ZIO` can bridge to a `Future` at the `Cmd` boundary in a couple of characters
+of glue.
+
 ## Versioning
 
 Versioning is fully driven by git tags via `sbt-dynver`; nothing is hand-edited

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -27,9 +27,22 @@ Commands represent side effects that happen “after” an update:
 
 - `Cmd.GCmd(msg)` – enqueue a message for the next update loop
 - `Cmd.FCmd(...)` – run an async task and publish its result as a message
+- `Cmd.asyncResult(task, onSuccess, onError)` – idiomatic helper for the
+  common case where the async task returns `AsyncResult[A]` (i.e.
+  `Future[Result[A]]`). Routes successes through `onSuccess`, logical
+  failures through `onError`, and lets the runtime surface infrastructure
+  failures via `Cmd.TermFlowErrorCmd` automatically.
 - `Cmd.Exit` – exit the runtime
+- `Cmd.TermFlowErrorCmd(err)` – surface a recoverable error to the renderer
 
 This keeps `update` mostly pure and makes long-running work explicit.
+
+**Effect-system stance.** TermFlow uses `scala.concurrent.Future` and the
+framework's `Result[A] = Either[TermFlowError, A]`, exposed as
+`type AsyncResult[+A] = Future[Result[A]]` in `TuiPrelude`. The alias
+mirrors the `llm4s` core 1:1 so values pass between the two libraries
+without an adapter. We do not ship cats-effect or ZIO integration modules;
+apps that use those bridge to a `Future` at the `Cmd` boundary.
 
 ### `Sub` (subscriptions)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -677,10 +677,17 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
 
 ## 10. Open questions
 
-1. **Coroutine integration.** Should `Cmd.FCmd` accept anything beyond
-   `Future`? Cats-Effect `IO`? ZIO? ZIO-style typed errors? Probably out of
-   scope for 1.0; revisit post-1.0 as a separate `termflow-effect-cats` /
-   `termflow-effect-zio` integration.
+1. ~~**Coroutine integration.** Should `Cmd.FCmd` accept anything beyond
+   `Future`?~~ **Decided 2026-04-27 — stay stdlib.** TermFlow speaks
+   `scala.concurrent.Future` plus `Result[A] = Either[TermFlowError, A]`,
+   exposed as `type AsyncResult[+A] = Future[Result[A]]` mirroring the
+   `llm4s` core 1:1 so values cross between the two libraries without an
+   adapter. `Cmd.asyncResult(task, onSuccess, onError)` is the ergonomic
+   bridge. **No** `termflow-effect-cats` / `termflow-effect-zio` modules
+   are planned; apps using `IO`/`ZIO` bridge to `Future` at the `Cmd`
+   boundary in a couple of characters. Rationale: zero new abstractions,
+   composes with `llm4s` and any other stdlib-`Future` library, no
+   per-effect-system maintenance tax on every release.
 2. **Cross-publish for Scala 2.13.** Already on `legacy-213-track`. Keep
    parity through 1.0, then re-evaluate based on adoption.
 3. **Native image.** `sbt-native-image` build for `graalvm-native-image`?
@@ -727,6 +734,14 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
   building this we hit and fixed the overlay-opacity bug: dialog interiors
   no longer leak the panels beneath them, because `AnsiRenderer` now wipes
   the overlay rectangle before drawing children.
+- *2026-04-27* — Effect-system question closed. `Cmd.FCmd` stays
+  `Future`-typed; `AsyncResult[+A] = Future[Result[A]]` ships in
+  `TuiPrelude` mirroring `llm4s`, and `Cmd.asyncResult` is the one-liner
+  ergonomic bridge for "async work with a typed error". No
+  `termflow-effect-cats` / `termflow-effect-zio` modules will ship — the
+  cost (extra publish, MiMa, docs, expert maintainer per effect system)
+  isn't justified when the escape hatch (`io.unsafeToFuture()`) is two
+  characters of glue at the call site.
 
 ---
 

--- a/modules/termflow/src/main/scala/termflow/tui/Tui.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Tui.scala
@@ -143,6 +143,64 @@ enum Cmd[+Msg]:
    */
   case TermFlowErrorCmd(msg: TermFlowError) extends Cmd[Msg]
 
+object Cmd:
+
+  /**
+   * Lift an [[TuiPrelude.AsyncResult]] onto the command bus.
+   *
+   * This is the idiomatic way to bridge async work that can fail with a
+   * domain error: pass the future, route success values through
+   * `onSuccess`, and route logical failures through `onError`. Future
+   * failures themselves (network drops, JVM exceptions) still surface via
+   * the runtime's standard [[TermFlowErrorCmd]] path — there's no need to
+   * recover them here.
+   *
+   * Equivalent to:
+   *
+   * {{{
+   * Cmd.FCmd[Result[A], Msg](
+   *   task = asyncResult,
+   *   toCmd = {
+   *     case Right(a)  => Cmd.GCmd(onSuccess(a))
+   *     case Left(err) => Cmd.GCmd(onError(err))
+   *   },
+   *   onEnqueue = onEnqueue
+   * )
+   * }}}
+   *
+   * but reads as one expression at the call site:
+   *
+   * {{{
+   * Cmd.asyncResult(
+   *   task = client.fetch(id),
+   *   onSuccess = Msg.Loaded.apply,
+   *   onError   = Msg.Failed.apply
+   * )
+   * }}}
+   *
+   * @param task      Async work returning `Result[A]` — typically an
+   *                  [[TuiPrelude.AsyncResult]] alias.
+   * @param onSuccess Maps a successful value to the follow-up message.
+   * @param onError   Maps a logical failure to the follow-up message.
+   * @param onEnqueue Optional message dispatched immediately on enqueue —
+   *                  useful for flipping a "loading" flag before the
+   *                  future resolves.
+   */
+  def asyncResult[A, Msg](
+    task: TuiPrelude.AsyncResult[A],
+    onSuccess: A => Msg,
+    onError: TermFlowError => Msg,
+    onEnqueue: Option[Msg] = None
+  ): Cmd[Msg] =
+    Cmd.FCmd[TuiPrelude.Result[A], Msg](
+      task = task,
+      toCmd = {
+        case Right(a)  => Cmd.GCmd(onSuccess(a))
+        case Left(err) => Cmd.GCmd(onError(err))
+      },
+      onEnqueue = onEnqueue
+    )
+
 /**
  * The Elm-style application contract: a model, an update function, a view,
  * and a way to turn prompt input into messages.

--- a/modules/termflow/src/main/scala/termflow/tui/TuiPrelude.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/TuiPrelude.scala
@@ -1,5 +1,7 @@
 package termflow.tui
 
+import scala.concurrent.Future
+
 /**
  * Shared type aliases and lightweight syntax sugar used across TermFlow
  * applications.
@@ -7,6 +9,8 @@ package termflow.tui
  * Import the contents of `TuiPrelude.*` at the top of an app file to
  * unlock:
  *   - `Result[A]` as a shorthand for `Either[TermFlowError, A]`
+ *   - `AsyncResult[A]` as `Future[Result[A]]` — the async-with-error idiom
+ *     TermFlow shares with the `llm4s` core
  *   - `2.x` / `3.y` coordinate syntax
  *   - `"hello".text` / `"hi".text(fg = Color.Green, bold = true)` styled
  *     text constructors
@@ -38,6 +42,45 @@ object TuiPrelude:
    * [[Cmd.TermFlowErrorCmd]] without terminating the app.
    */
   type Result[A] = Either[TermFlowError, A]
+
+  /**
+   * Async-with-typed-error: the future you'd return from a network call,
+   * a database lookup, or a tool invocation that can fail in domain ways
+   * the caller wants to handle.
+   *
+   * Mirrors the `AsyncResult[+A]` in the `llm4s` core so apps can pass
+   * values across the two libraries without an adapter. Wraps a
+   * `scala.concurrent.Future[Result[A]]` — `Result` for logical failures
+   * the app should react to, `Future` failures for genuinely
+   * unrecoverable infrastructure errors that the runtime surfaces via
+   * [[Cmd.TermFlowErrorCmd]].
+   *
+   * Lift one onto the command bus with [[Cmd.asyncResult]].
+   */
+  type AsyncResult[+A] = Future[Result[A]]
+
+  object AsyncResult:
+
+    import scala.concurrent.ExecutionContext
+
+    /** Wrap an already-known successful value. */
+    def success[A](value: A): AsyncResult[A] = Future.successful(Right(value))
+
+    /** Wrap an already-known logical failure. */
+    def failure[A](err: TermFlowError): AsyncResult[A] = Future.successful(Left(err))
+
+    /** Lift a `Result[A]` into an `AsyncResult[A]` without scheduling work. */
+    def fromResult[A](r: Result[A]): AsyncResult[A] = Future.successful(r)
+
+    /**
+     * Lift a `Future[A]` into an `AsyncResult[A]`, mapping infrastructure
+     * failures to a [[TermFlowError.Unexpected]]. Use this at the boundary
+     * with libraries that hand you a plain `Future`.
+     */
+    def fromFuture[A](task: Future[A])(using ec: ExecutionContext): AsyncResult[A] =
+      task
+        .map(Right(_))
+        .recover { case t => Left(TermFlowError.Unexpected(t.getMessage, Some(t))) }
 
   /**
    * 1-based coordinate syntax: write `2.x` / `10.y` instead of

--- a/modules/termflow/src/test/scala/termflow/tui/AsyncResultSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/AsyncResultSpec.scala
@@ -1,0 +1,92 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.TuiPrelude.*
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.duration.*
+
+/**
+ * Pins the `AsyncResult` constructors and `Cmd.asyncResult` ergonomics
+ * — these are the public bridge between application code and the runtime
+ * for "async work that can fail with a domain error", and we want their
+ * shape to stay stable.
+ */
+class AsyncResultSpec extends AnyFunSuite:
+
+  private def await[A](task: AsyncResult[A]): Result[A] = Await.result(task, 1.second)
+
+  // ---- AsyncResult constructors -------------------------------------------
+
+  test("AsyncResult.success wraps a value as a completed Right"):
+    assert(await(AsyncResult.success(42)) == Right(42))
+
+  test("AsyncResult.failure wraps a TermFlowError as a completed Left"):
+    val err = TermFlowError.Validation("bad")
+    assert(await(AsyncResult.failure(err)) == Left(err))
+
+  test("AsyncResult.fromResult preserves Right and Left without scheduling work"):
+    assert(await(AsyncResult.fromResult(Right(1))) == Right(1))
+    val err = TermFlowError.ConfigError("missing")
+    assert(await(AsyncResult.fromResult(Left(err))) == Left(err))
+
+  test("AsyncResult.fromFuture maps a successful Future to Right"):
+    assert(await(AsyncResult.fromFuture(Future.successful("ok"))) == Right("ok"))
+
+  test("AsyncResult.fromFuture maps a failed Future to a TermFlowError.Unexpected"):
+    val boom = new RuntimeException("boom")
+    val r    = await(AsyncResult.fromFuture(Future.failed[Int](boom)))
+    r match
+      case Left(TermFlowError.Unexpected(msg, Some(cause))) =>
+        assert(msg == "boom")
+        assert(cause eq boom)
+      case other => fail(s"expected Unexpected with cause, got $other")
+
+  // ---- Cmd.asyncResult dispatch -------------------------------------------
+
+  enum TestMsg:
+    case Loaded(value: Int)
+    case Failed(err: TermFlowError)
+
+  /**
+   * Dispatch the `toCmd` of an FCmd against a synthetic value to read the
+   *  resulting message — exercises the wiring without spinning the runtime.
+   */
+  private def runFCmd[A, M](cmd: Cmd[M], value: A): M =
+    cmd match
+      case Cmd.FCmd(_, toCmd, _) =>
+        toCmd.asInstanceOf[A => Cmd[M]](value) match
+          case Cmd.GCmd(msg) => msg
+          case other         => fail(s"expected GCmd, got $other")
+      case other => fail(s"expected FCmd, got $other")
+
+  test("Cmd.asyncResult routes Right values through onSuccess"):
+    val cmd = Cmd.asyncResult(
+      task = AsyncResult.success(10),
+      onSuccess = TestMsg.Loaded.apply,
+      onError = TestMsg.Failed.apply
+    )
+    assert(runFCmd[Result[Int], TestMsg](cmd, Right(10)) == TestMsg.Loaded(10))
+
+  test("Cmd.asyncResult routes Left values through onError"):
+    val err = TermFlowError.Validation("bad")
+    val cmd = Cmd.asyncResult(
+      task = AsyncResult.failure[Int](err),
+      onSuccess = TestMsg.Loaded.apply,
+      onError = TestMsg.Failed.apply
+    )
+    assert(runFCmd[Result[Int], TestMsg](cmd, Left(err)) == TestMsg.Failed(err))
+
+  test("Cmd.asyncResult forwards onEnqueue unchanged"):
+    val pending = TestMsg.Loaded(0)
+    val cmd = Cmd.asyncResult(
+      task = AsyncResult.success(1),
+      onSuccess = TestMsg.Loaded.apply,
+      onError = TestMsg.Failed.apply,
+      onEnqueue = Some(pending)
+    )
+    cmd match
+      case Cmd.FCmd(_, _, Some(`pending`)) => ()
+      case other                           => fail(s"expected onEnqueue=$pending, got $other")


### PR DESCRIPTION
## Summary

Closes the §10.1 effect-system open question on the roadmap with the smallest possible surface change. TermFlow stays on stdlib `Future` + `Result`, mirroring the llm4s core, and ships one ergonomic helper to make the pattern pleasant at the call site.

- Add `type AsyncResult[+A] = Future[Result[A]]` in `TuiPrelude`, identical to the llm4s alias so values cross between the two libraries without an adapter.
- Add `AsyncResult` companion with `success` / `failure` / `fromResult` / `fromFuture(...)` for lifting at the boundary.
- Add `Cmd.asyncResult(task, onSuccess, onError, onEnqueue?)` — wraps `Cmd.FCmd` so `Right` values flow through `onSuccess` and `Left` values through `onError`. `Future` failures still surface via `Cmd.TermFlowErrorCmd` automatically; no `recover` needed at the call site.
- Document the pattern in the README (new "Async Work" section) and `docs/DESIGN.md`. Mark the roadmap open question **decided** — explicitly **no** `termflow-effect-cats` / `termflow-effect-zio` modules.

## Why this and not a real effect system

- llm4s and termflow are both pragmatic stdlib; pulling cats-effect or ZIO into termflow would force llm4s users to depend transitively on something they deliberately rejected.
- Per-effect-system modules are real recurring tax: extra publish, MiMa story, docs, expert maintainer.
- The escape hatch is two characters: anyone using `IO`/`ZIO` calls `.unsafeToFuture()` at the `Cmd` boundary.

## Test plan

- [x] `sbt ciCheck` — scalafmt + scalafix + tests
- [x] 8 new `AsyncResultSpec` tests covering both the alias constructors and `Cmd.asyncResult` routing of `Right` / `Left` / `onEnqueue`
- [x] 601 total tests pass (up from 593)