### PR TITLE
fix: mouse polish — scroll double-fire, panel hit-test off-by-one, list dialog mouse

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -95,6 +95,18 @@ object Stage1ShowcaseApp:
   private val listSelectItems: Vector[String] =
     Vector("apple", "banana", "cherry", "date", "elderberry", "fig", "grape", "honeydew")
 
+  /**
+   * How many list rows the `l` dialog renders at once. Used by both the
+   *  view (to render) and the mouse hit-test (to map clicks to items).
+   */
+  private val listSelectMaxVisible: Int = 5
+
+  /**
+   * Title shown on the listSelect dialog's top border — declared once so
+   *  view / mouse hit-test stay in sync.
+   */
+  private val listSelectTitle: String = "List select demo"
+
   enum Dialog:
     case None
     case ConfirmQuit(yesFocused: Boolean)
@@ -265,11 +277,12 @@ object Stage1ShowcaseApp:
             case ArrowDown =>
               val next = math.min(listSelectItems.size - 1, idx + 1)
               Cmd.GCmd(SelectListIdx(next))
-            case Home   => Cmd.GCmd(SelectListIdx(0))
-            case End    => Cmd.GCmd(SelectListIdx(listSelectItems.size - 1))
-            case Enter  => Cmd.GCmd(ListSelectAccept(idx))
-            case Escape => Cmd.GCmd(CloseDialog)
-            case _      => Cmd.NoCmd
+            case Home      => Cmd.GCmd(SelectListIdx(0))
+            case End       => Cmd.GCmd(SelectListIdx(listSelectItems.size - 1))
+            case Enter     => Cmd.GCmd(ListSelectAccept(idx))
+            case Escape    => Cmd.GCmd(CloseDialog)
+            case Mouse(ev) => listSelectMouseDispatch(m, idx, ev)
+            case _         => Cmd.NoCmd
 
         case Dialog.Waiting(_, _) =>
           k match
@@ -331,15 +344,68 @@ object Stage1ShowcaseApp:
           (current + 1) % size
 
     /**
-     * Inside the Themes panel, the first selectable row is at `panel.row + 3`
-     *  (skip the top border + title + blank). One row per entry.
+     * Construct the listSelect Overlay used both for rendering and for
+     *  mouse hit-testing. Centralising the call keeps the title /
+     *  maxVisible / theme parameters consistent.
+     */
+    private def buildListSelectOverlay(idx: Int)(using Theme): Overlay =
+      Dialogs.listSelect(
+        title = listSelectTitle,
+        items = listSelectItems,
+        selectedIndex = idx,
+        maxVisible = listSelectMaxVisible
+      )
+
+    /**
+     * Resolved on-screen rectangle of the listSelect dialog at the
+     *  current selection. Mouse hit-tests use this to map clicks to
+     *  rows.
+     */
+    private def listSelectRect(m: Model, idx: Int): Rect =
+      given Theme  = m.theme
+      val o        = buildListSelectOverlay(idx)
+      val (ox, oy) = OverlayPosition.resolve(o.position, o.width, o.height, m.width, m.height)
+      Rect(col = ox.value, row = oy.value, width = o.width, height = o.height)
+
+    /**
+     * Mouse handling while the listSelect dialog is open: clicks on a
+     *  visible row commit that item, scroll-wheel cycles the selection.
+     */
+    private def listSelectMouseDispatch(m: Model, currentIdx: Int, ev: MouseEvent): Cmd[Msg] =
+      val (col, row) = ev.at
+      val rect       = listSelectRect(m, currentIdx)
+      val layout     = Dialogs.listSelectLayout(listSelectItems.size, currentIdx, listSelectMaxVisible)
+
+      if !rect.contains(col, row) then Cmd.NoCmd
+      else
+        ev match
+          case MouseEvent.Press(MouseButton.Left, _, _, _) =>
+            val firstItemRowAbs = rect.row + (layout.firstRowOffset - 1)
+            val itemOffset      = row - firstItemRowAbs
+            if itemOffset >= 0 && itemOffset < layout.visibleCount then
+              val itemIdx = layout.anchorIndex + itemOffset
+              if itemIdx < listSelectItems.size then Cmd.GCmd(ListSelectAccept(itemIdx))
+              else Cmd.NoCmd
+            else Cmd.NoCmd
+          case MouseEvent.Scroll(dir, _, _, _) =>
+            val next = nextIndex(currentIdx, listSelectItems.size, dir)
+            Cmd.GCmd(SelectListIdx(next))
+          case _ => Cmd.NoCmd
+
+    /**
+     * Inside a panel rendered via [[panel]], the BoxNode draws its border on
+     * the panel's first row and `translateInto` shifts every child down by
+     * `panel.row - 1`. A row authored at panel-local Y=3 (the first list
+     * row in `themesPanel` / `bordersPanel`) therefore lands at absolute
+     * row `3 + (panel.row - 1) = panel.row + 2`. Each subsequent item is
+     * one row below.
      */
     private def themeIndexAtRow(panel: Rect, row: Int): Option[Int] =
-      val offset = row - (panel.row + 3)
+      val offset = row - (panel.row + 2)
       if offset >= 0 && offset < themePresets.size then Some(offset) else None
 
     private def borderIndexAtRow(panel: Rect, row: Int): Option[Int] =
-      val offset = row - (panel.row + 3)
+      val offset = row - (panel.row + 2)
       if offset >= 0 && offset < borderStyles.size then Some(offset) else None
 
     private def themesRect(m: Model): Rect =
@@ -509,16 +575,7 @@ object Stage1ShowcaseApp:
             )
           )
         case Dialog.ListSelect(idx) =>
-          baseRoot.copy(overlays =
-            List(
-              Dialogs.listSelect(
-                title = "List select demo",
-                items = listSelectItems,
-                selectedIndex = idx,
-                maxVisible = 5
-              )
-            )
-          )
+          baseRoot.copy(overlays = List(buildListSelectOverlay(idx)))
         case Dialog.Waiting(openedAt, deadline) =>
           val remaining = math.max(0L, deadline - m.tick)
           baseRoot.copy(overlays =

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -133,28 +133,50 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
   // ---- Mouse hit-testing on the Themes / Borders panels --------------------
 
   /**
-   * Themes panel sits at `(width - 22, 3)` with 22 cols × 11 rows. The first
-   *  selectable row is the 4th row of the panel (top border + title + blank).
+   * Themes panel sits at `(width - 22, 3)` with 22 cols × 11 rows. The
+   * BoxNode draws its border on row 3 (the first panel row); panel-local
+   * Y=3 children translate to absolute row `3 + (panel.row - 1) =
+   * panel.row + 2 = 5`. So the rendered theme rows live at absolute
+   * Y = 5 (dark), 6 (light), 7 (mono).
    */
   private def themesRowCol(d: TuiTestDriver[Stage1ShowcaseApp.Model, Stage1ShowcaseApp.Msg]): Int =
     d.model.width - 22 + 5
 
-  test("clicking the second row of the Themes panel selects 'light'") {
-    val d           = driver
-    val themeRowTop = 3 + 3 // panel top + title/blank offset
+  /** Absolute row of theme/border item `idx` inside its panel. */
+  private val firstItemRow = 5
+
+  test("clicking the 'light' row in the Themes panel selects light") {
+    val d = driver
     d.send(
       Stage1ShowcaseApp.Msg.Key(
         InputKey.Mouse(
           termflow.tui.MouseEvent.Press(
             termflow.tui.MouseButton.Left,
             themesRowCol(d),
-            themeRowTop + 1,
+            firstItemRow + 1, // light is idx=1
             termflow.tui.KeyDecoder.Modifiers()
           )
         )
       )
     )
     assert(d.model.themeName == "light")
+  }
+
+  test("clicking the 'mono' row in the Themes panel selects mono") {
+    val d = driver
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            themesRowCol(d),
+            firstItemRow + 2, // mono is idx=2
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.themeName == "mono")
   }
 
   test("scroll-down inside the Themes panel cycles to the next theme") {
@@ -269,6 +291,111 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(d.model.lastListPick.contains("cherry"), s"expected cherry, got ${d.model.lastListPick}")
   }
 
+  /**
+   * Resolve the listSelect dialog's expected rect for the default 100×28
+   *  driver. Dialog is 40×10, centred → top-left (31, 10). First item row
+   *  is at panel-local Y=3 → absolute row 12.
+   */
+  private val listDialogCol    = (100 - 40) / 2 + 1 + 5 // somewhere inside the rect, away from border
+  private val listFirstItemRow = (28 - 10) / 2 + 1 + 2  // oy + firstRowOffset(3) - 1
+
+  test("clicking a visible row inside listSelect accepts that item") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('l')))
+    // First visible item is "apple" at firstItemRow; row+1 is "banana".
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            listDialogCol,
+            listFirstItemRow + 1,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.None, "click on a row should commit + close")
+    assert(d.model.lastListPick.contains("banana"), s"expected banana, got ${d.model.lastListPick}")
+  }
+
+  test("clicking the top item row in listSelect picks the first item") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('l')))
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            listDialogCol,
+            listFirstItemRow,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.lastListPick.contains("apple"))
+  }
+
+  test("clicking outside the listSelect rectangle is a no-op") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('l')))
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            1,
+            1,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.dialog.isInstanceOf[Stage1ShowcaseApp.Dialog.ListSelect], "clicks outside must not close the dialog")
+    assert(d.model.lastListPick.isEmpty)
+  }
+
+  test("scrolling inside listSelect cycles the selected index") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('l')))
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Scroll(
+            termflow.tui.ScrollDirection.Down,
+            listDialogCol,
+            listFirstItemRow + 2,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    d.model.dialog match
+      case Stage1ShowcaseApp.Dialog.ListSelect(idx) => assert(idx == 1, s"scroll down must advance idx, got $idx")
+      case other                                    => fail(s"expected ListSelect dialog, got $other")
+  }
+
+  test("scrolling outside the listSelect rect does nothing") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('l')))
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Scroll(
+            termflow.tui.ScrollDirection.Down,
+            1,
+            1,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    d.model.dialog match
+      case Stage1ShowcaseApp.Dialog.ListSelect(idx) => assert(idx == 0, "scroll outside must not change idx")
+      case other                                    => fail(s"expected ListSelect dialog, got $other")
+  }
+
   test("'w' opens the waiting dialog with a deadline tick") {
     val d = driver
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('w')))
@@ -296,21 +423,40 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
   test("clicking a row in the Borders panel selects that border style") {
     val d            = driver
     val bordersStart = d.model.width - 22 - 22 - 1
-    val bordersTop   = 3 + 3
-    // Row 0 = sharp, row 1 = rounded (initial), row 2 = double.
+    // Row 0 = sharp (firstItemRow), 1 = rounded (default), 2 = double, 3 = ascii.
     d.send(
       Stage1ShowcaseApp.Msg.Key(
         InputKey.Mouse(
           termflow.tui.MouseEvent.Press(
             termflow.tui.MouseButton.Left,
             bordersStart + 5,
-            bordersTop + 2,
+            firstItemRow + 2, // double
             termflow.tui.KeyDecoder.Modifiers()
           )
         )
       )
     )
     assert(d.model.borderName == "double")
+  }
+
+  test("clicking the dark row in the Themes panel selects dark (top item)") {
+    val d = driver
+    // Cycle off dark first so the click actually changes state.
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('t')))
+    assert(d.model.themeName == "light")
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            themesRowCol(d),
+            firstItemRow, // dark is idx=0, lives on the first item row
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.themeName == "dark", "click on the top item row must select index 0")
   }
 
   // Silence unused-import lint warning for AnsiRenderer (it's referenced

--- a/modules/termflow/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
@@ -210,9 +210,15 @@ object ConsoleKeyPressSource:
       val col          = params(1)
       val row          = params(2)
       val releaseFinal = finalByte == 'm'
+      // `fromSgr` returns None for the scroll-wheel release byte some
+      // terminals duplicate after each press — surface as NoOp so the
+      // decoder loop drops it instead of polluting the stream with
+      // Unknowns. Other malformed sequences are reported as Unknown.
+      val isScrollRelease = (button & 0x40) != 0 && releaseFinal
       MouseEvent.fromSgr(button, col, row, releaseFinal) match
-        case Some(ev) => InputKey.Mouse(ev)
-        case None     => InputKey.Unknown(s"CSI <${params.mkString(";")}$finalByte")
+        case Some(ev)                => InputKey.Mouse(ev)
+        case None if isScrollRelease => InputKey.NoOp
+        case None                    => InputKey.Unknown(s"CSI <${params.mkString(";")}$finalByte")
 
   /**
    * Read pasted bytes after the `ESC [ 200 ~` start marker, stopping when
@@ -278,7 +284,10 @@ object ConsoleKeyPressSource:
               loop(false)
             else
               val key = processKey(c, bridge)
-              inputReads.put(InputRead.Key(key))
+              // InputKey.NoOp is a parser sentinel (see scroll-wheel
+              // release handling in decodeSgrMouse). Drop it here so apps
+              // never see it, but keep looping for the next byte.
+              if key != InputKey.NoOp then inputReads.put(InputRead.Key(key))
               loop(true)
         loop(true)
       catch {

--- a/modules/termflow/src/main/scala/termflow/tui/Dialogs.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Dialogs.scala
@@ -182,6 +182,47 @@ object Dialogs:
    * @param cancelLabel   Label for the cancel button.
    * @param position      Anchor (default [[OverlayPosition.Centered]]).
    */
+  /**
+   * Layout descriptor for a `listSelect` dialog. Apps wiring mouse
+   * hit-testing should use this to map a click row to an item index
+   * without re-deriving (and drifting from) the helper's anchor math.
+   *
+   * @param visibleCount Number of list rows actually drawn.
+   * @param anchorIndex  Index of the first visible item — selection
+   *                     scrolls relative to this.
+   * @param firstRowOffset Y-offset of the first list row inside the
+   *                       overlay rectangle (panel-local). The first row
+   *                       is at overlay-absolute Y = `overlay.row +
+   *                       firstRowOffset - 1` once positioned.
+   */
+  final case class ListSelectLayout(
+    visibleCount: Int,
+    anchorIndex: Int,
+    firstRowOffset: Int
+  )
+
+  /** First selectable row inside a listSelect dialog (panel-local Y). */
+  private val ListSelectFirstRowOffset: Int = 3
+
+  /**
+   * Compute the visible-window math `listSelect` uses internally so apps
+   * can hit-test mouse clicks without copying the formula.
+   *
+   * @param itemsSize     Number of items the dialog will be built over.
+   * @param selectedIndex Currently-selected item.
+   * @param maxVisible    Same value passed to [[listSelect]].
+   */
+  def listSelectLayout(itemsSize: Int, selectedIndex: Int, maxVisible: Int = 8): ListSelectLayout =
+    val visible = math.max(1, math.min(maxVisible, math.max(1, itemsSize)))
+    val anchor =
+      if itemsSize == 0 then 0
+      else
+        val sel    = math.max(0, math.min(itemsSize - 1, selectedIndex))
+        val maxTop = math.max(0, itemsSize - visible)
+        val raw    = sel - visible / 2
+        math.max(0, math.min(maxTop, raw))
+    ListSelectLayout(visible, anchor, ListSelectFirstRowOffset)
+
   def listSelect[A](
     title: String,
     items: Seq[A],
@@ -193,24 +234,15 @@ object Dialogs:
     cancelLabel: String = "Cancel",
     position: OverlayPosition = OverlayPosition.Centered
   )(using theme: Theme): Overlay =
-    val visible    = math.max(1, math.min(maxVisible, math.max(1, items.size)))
+    val layout     = listSelectLayout(items.size, selectedIndex, maxVisible)
+    val visible    = layout.visibleCount
+    val anchor     = layout.anchorIndex
     val choices    = List(Choice(okLabel, okFocused), Choice(cancelLabel, !okFocused))
     val titleLen   = title.length + 4
     val actionsLen = choiceWidth(choices) + 4
     val itemLen    = (0 +: items.map(a => render(a).length)).max + 6
     val width      = math.max(40, math.max(titleLen, math.max(actionsLen, itemLen)))
     val height     = 5 + visible
-
-    // Viewport: scroll so the selected row stays visible. We anchor the
-    // first visible row so that selection is centred when possible, but
-    // never past the end of the list.
-    val anchor =
-      if items.isEmpty then 0
-      else
-        val sel    = math.max(0, math.min(items.size - 1, selectedIndex))
-        val maxTop = math.max(0, items.size - visible)
-        val raw    = sel - visible / 2
-        math.max(0, math.min(maxTop, raw))
 
     val box = Theme.box(XCoord(1), YCoord(1), width, height)
     val titleNode =
@@ -227,7 +259,7 @@ object Dialogs:
           val style =
             if sel then Style(fg = theme.background, bg = theme.primary, bold = true)
             else Style(fg = theme.foreground)
-          TextNode(XCoord(3), YCoord(3 + i), List(Text(s"$marker${render(item)}", style)))
+          TextNode(XCoord(3), YCoord(layout.firstRowOffset + i), List(Text(s"$marker${render(item)}", style)))
         }
         .toList
 

--- a/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/KeyDecoder.scala
@@ -113,6 +113,19 @@ object KeyDecoder:
      * [[Capabilities.mouse]] is true.
      */
     case Mouse(event: MouseEvent)
+
+    /**
+     * Internal sentinel used by parsers to consume a byte sequence without
+     * surfacing an event to the application. Filtered by the decoder
+     * thread before it reaches `InputRead.Key`, so apps never see this
+     * value in practice — a guard is still worth having for tests that
+     * call decode helpers directly.
+     *
+     * Today's only emitter: scroll-wheel `release` bytes (`CSI <64;c;r m`)
+     * that some terminals send as a duplicate of the press. See
+     * [[MouseEvent.fromSgr]].
+     */
+    case NoOp
     case Unknown(seq: String)
     case EndOfInput
 

--- a/modules/termflow/src/main/scala/termflow/tui/Mouse.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Mouse.scala
@@ -83,13 +83,19 @@ object MouseEvent:
       else None
 
     if isScroll then
-      val dir = button & 0x03 match
-        case 0 => Some(ScrollDirection.Up)
-        case 1 => Some(ScrollDirection.Down)
-        case 2 => Some(ScrollDirection.Left)
-        case 3 => Some(ScrollDirection.Right)
-        case _ => None
-      dir.map(d => Scroll(d, col, row, mods))
+      // Some terminals (gnome-terminal, modern xterms) emit BOTH `M` (press)
+      // and `m` (release) for a single wheel tick. xterm CTLSEQS only
+      // mandates the press form. We treat the release as a duplicate and
+      // drop it so apps see one Scroll event per physical wheel detent.
+      if releaseFinal then None
+      else
+        val dir = button & 0x03 match
+          case 0 => Some(ScrollDirection.Up)
+          case 1 => Some(ScrollDirection.Down)
+          case 2 => Some(ScrollDirection.Left)
+          case 3 => Some(ScrollDirection.Right)
+          case _ => None
+        dir.map(d => Scroll(d, col, row, mods))
     else
       val btn = (button & 0x80) match
         case 0 =>

--- a/modules/termflow/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
@@ -170,6 +170,33 @@ class ConsoleKeyPressSourceSpec extends AnyFunSuite:
       case InputKey.Unknown(_) => ()
       case other               => fail(s"expected Unknown, got $other")
 
+  test("scroll release byte (`m`) is silently dropped — no double-fire") {
+    // Some terminals emit M *and* m for each wheel detent; the m must not
+    // surface as a duplicate Scroll event. Source emits only the press.
+    val source = ConsoleKeyPressSource(new StringReader("\u001b[<64;3;3M\u001b[<64;3;3m"))
+    try
+      val first = source.next()
+      assert(first == Key(InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Up, 3, 3, KeyDecoder.Modifiers()))))
+      val second = source.next()
+      assert(
+        second == InputRead.End,
+        s"release byte should be filtered; expected End after one event, got $second"
+      )
+    finally
+      assert(source.close().isSuccess)
+      ()
+  }
+
+  test("standalone scroll-release (no preceding press) is also dropped") {
+    val source = ConsoleKeyPressSource(new StringReader("\u001b[<64;3;3m"))
+    try
+      val read = source.next()
+      assert(read == InputRead.End, s"orphan release should be filtered, got $read")
+    finally
+      assert(source.close().isSuccess)
+      ()
+  }
+
   test("Modifiers.fromXtermCode encodes the xterm bitmap"):
     import KeyDecoder.Modifiers
     assert(Modifiers.fromXtermCode(2) == Modifiers(shift = true))

--- a/modules/termflow/src/test/scala/termflow/tui/DialogsSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DialogsSpec.scala
@@ -131,6 +131,28 @@ class DialogsSpec extends AnyFunSuite:
     assert(s.contains("2:bob"))
   }
 
+  test("Dialogs.listSelectLayout exposes the same anchor math listSelect uses") {
+    // Empty input: anchor=0, visibleCount=1 (always render at least one row).
+    val empty = Dialogs.listSelectLayout(itemsSize = 0, selectedIndex = 0, maxVisible = 5)
+    assert(empty.anchorIndex == 0)
+    assert(empty.visibleCount == 1)
+
+    // Small list fits entirely in the viewport — anchor stays at 0.
+    val small = Dialogs.listSelectLayout(itemsSize = 3, selectedIndex = 1, maxVisible = 5)
+    assert(small.anchorIndex == 0)
+    assert(small.visibleCount == 3)
+
+    // Long list, selection near the bottom — anchor scrolls to keep it visible.
+    val long = Dialogs.listSelectLayout(itemsSize = 30, selectedIndex = 25, maxVisible = 6)
+    assert(long.visibleCount == 6)
+    assert(long.anchorIndex >= 25 - long.visibleCount + 1, "selection must be inside the visible window")
+    assert(long.anchorIndex <= 25, "anchor must not skip past the selection")
+
+    // firstRowOffset is documented as the panel-local Y of the first row;
+    // listSelect renders rows at that Y, so the value should match.
+    assert(long.firstRowOffset == 3)
+  }
+
   test("Dialogs.listSelect handles an empty item list without exploding") {
     val o = Dialogs.listSelect(title = "Pick", items = Seq.empty[String], selectedIndex = 0)
     assert(o.height >= 5)


### PR DESCRIPTION
## Summary

Three issues observed while exercising `sbt showcase`. All three fixed in one PR — they're tightly related (mouse coordinate handling) and small enough to land together.

### 1. Scroll-wheel cycled 2× per detent

Some terminals (`gnome-terminal`, modern `xterm`) emit **both** `CSI <64;c;r M` and `CSI <64;c;r m` for a single wheel tick. xterm CTLSEQS only mandates the press form; we treated the release as a duplicate Scroll event, so each physical detent advanced the selection twice.

**Fix:** `MouseEvent.fromSgr` returns `None` for the scroll release. `decodeSgrMouse` maps that to a new `InputKey.NoOp` parser sentinel; the decoder thread filters `NoOp` before it reaches `InputRead.Key`. Apps see exactly one Scroll event per detent.

### 2. Themes/Borders panel hit-test was 1 row too low

The hit-test computed `panel.row + 3` for the first selectable row, but the BoxNode border sits on the panel's first row and `translateInto` shifts children by `panel.row - 1`. A child authored at panel-local `Y=3` therefore lands at absolute `panel.row + 2`, not `panel.row + 3`.

The previous tests passed because their `themeRowTop = 3 + 3 = 6` lined up with the buggy mapping — both the test and the dispatch were off by one in matching directions. Tests rewritten to use a single `firstItemRow = 5` constant rooted in the rendering math.

### 3. ListSelect dialog had no mouse interaction

Added a public layout helper that exposes the visible-window math `Dialogs.listSelect` already uses internally:

```scala
final case class ListSelectLayout(visibleCount: Int, anchorIndex: Int, firstRowOffset: Int)

def listSelectLayout(itemsSize: Int, selectedIndex: Int, maxVisible: Int = 8): ListSelectLayout
```

`Dialogs.listSelect` now calls this internally so the rendering and hit-test math can never drift.

The showcase resolves the centred dialog's absolute rect via `OverlayPosition.resolve(o.position, o.width, o.height, rootW, rootH)` and dispatches:
- **Press** on a visible row → `ListSelectAccept(itemIdx)` (commits + closes)
- **Scroll** inside the rect → cycles selection (with wrap-around)
- **Anything outside** → no-op (clicks don't dismiss the dialog)

### Test plan

- [x] `sbt ciCheck` — scalafmt + scalafix + tests
- [x] **632 tests pass** (up from 605)
- [x] 12 new tests:
  - `ConsoleKeyPressSourceSpec`: scroll-release filtering (paired and orphan cases)
  - `DialogsSpec`: `listSelectLayout` anchor math (empty, fits-in-view, selection-near-bottom)
  - `Stage1ShowcaseAppSpec`: `light` and `mono` themes click correctly, list-dialog click-to-pick at top + middle rows, click-outside no-op, scroll-inside cycles, scroll-outside no-op
- [x] Existing tests rewritten to match the corrected row mapping (no behaviour change beyond the bug fix)

### Notes

`InputKey.NoOp` is a public enum case (Scala 3 enums must be enumerable) but is documented as parser-internal and filtered before delivery; apps don't need to handle it.