### PR TITLE
feat: CheckBox + RadioGroup widgets (Stage 3 §6.2)

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -623,26 +623,27 @@ object Stage1ShowcaseApp:
 
     private def themesPanel(m: Model, r: Rect)(using theme: Theme): VNode =
       val title = TextNode(2.x, 1.y, List(" Themes (click) ".themed(_.primary)))
-      val rows = themePresets.zipWithIndex.toList.map { case ((name, _), i) =>
-        renderableRow(2, 3 + i, name, selected = i == m.themeIdx, theme)
-      }
+      // Use the RadioGroup widget instead of hand-rolled rows so the
+      // showcase exercises the real widget API.
+      val rows = widgets.RadioGroup(
+        options = themePresets.map(_._1),
+        selectedIndex = m.themeIdx,
+        focusedIndex = m.themeIdx,
+        at = Coord(2.x, 3.y)
+      )
       val hint = TextNode(2.x, (3 + themePresets.size + 1).y, List("scroll to cycle".themed(_.info)))
       panel(r, theme, (title :: rows) :+ hint)
 
     private def bordersPanel(m: Model, r: Rect)(using theme: Theme): VNode =
       val title = TextNode(2.x, 1.y, List(" Borders (click) ".themed(_.primary)))
-      val rows = borderStyles.zipWithIndex.toList.map { case ((name, _), i) =>
-        renderableRow(2, 3 + i, name, selected = i == m.borderIdx, theme)
-      }
+      val rows = widgets.RadioGroup(
+        options = borderStyles.map(_._1),
+        selectedIndex = m.borderIdx,
+        focusedIndex = m.borderIdx,
+        at = Coord(2.x, 3.y)
+      )
       val hint = TextNode(2.x, (3 + borderStyles.size + 1).y, List("scroll to cycle".themed(_.info)))
       panel(r, theme, (title :: rows) :+ hint)
-
-    private def renderableRow(col: Int, row: Int, name: String, selected: Boolean, theme: Theme): VNode =
-      val marker = if selected then "▸ " else "  "
-      val style =
-        if selected then Style(fg = theme.background, bg = theme.primary, bold = true)
-        else Style(fg = theme.foreground)
-      TextNode(col.x, row.y, List(Text(s"$marker$name", style)))
 
     private def stylesPanel(r: Rect)(using theme: Theme): VNode =
       val title = TextNode(2.x, 1.y, List(" Styles ".themed(_.primary)))
@@ -654,11 +655,12 @@ object Stage1ShowcaseApp:
         TextNode(2.x, 7.y, List(Text("reverse", Style(fg = theme.primary, reverse = true)))),
         TextNode(2.x, 8.y, List(Text("strike", Style(fg = theme.primary, strikethrough = true)))),
         TextNode(2.x, 9.y, List(Text("blink", Style(fg = theme.primary, blink = true)))),
-        TextNode(
-          2.x,
-          11.y,
-          List(Text("combo", Style(fg = theme.success, bold = true, italic = true, underline = true)))
-        )
+        // Quick CheckBox demo — three states rendered through the real
+        // widget so visual differences (theme.success on the checked
+        // marker, bold on focus) are visible at a glance.
+        widgets.CheckBox(label = "off", checked = false, focused = false, at = Coord(2.x, 10.y)),
+        widgets.CheckBox(label = "on", checked = true, focused = false, at = Coord(2.x, 11.y)),
+        widgets.CheckBox(label = "focus", checked = true, focused = true, at = Coord(2.x, 12.y))
       )
       panel(r, theme, title :: rows)
 

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -459,6 +459,23 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(d.model.themeName == "dark", "click on the top item row must select index 0")
   }
 
+  test("Themes panel renders RadioGroup markers (◉ for selected, ○ for unselected)") {
+    val d        = driver
+    val frame    = d.frame
+    val rendered = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("◉"), "selected RadioGroup marker should appear in the frame")
+    assert(rendered.contains("○"), "unselected RadioGroup marker should appear in the frame")
+  }
+
+  test("Styles panel renders CheckBox demo (☐ off and ☒ on)") {
+    val d        = driver
+    val frame    = d.frame
+    val rendered = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("☐"), "unchecked CheckBox glyph should appear in the frame")
+    assert(rendered.contains("☒"), "checked CheckBox glyph should appear in the frame")
+    assert(rendered.contains("focus"), "focused CheckBox label should appear in the frame")
+  }
+
   // Silence unused-import lint warning for AnsiRenderer (it's referenced
   // implicitly through TuiTestDriver, but the file would warn otherwise).
   private val _ = AnsiRenderer.getClass

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/CheckBox.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/CheckBox.scala
@@ -1,0 +1,75 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Inline-styled checkbox rendered as `☒ Label` (checked) or `☐ Label`
+ * (unchecked). When the active terminal does not advertise UTF-8 the
+ * widget falls back to ASCII `[x]` / `[ ]` so it stays readable on
+ * dumb terminals.
+ *
+ * `focused` and `checked` are independent — focus is communicated via
+ * colour and boldness, the check state via the marker glyph. The shape
+ * never changes on focus, so siblings don't have to reflow.
+ *
+ * Natural width is `markerWidth + 1 + label.length`. Height is always 1.
+ *
+ * Apps drive the toggle from their own keymap (typically Space or Enter
+ * on the focused checkbox); this helper only renders the visual.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Layout.column(gap = 0)(
+ *   CheckBox("Enable autosave", checked = true,  focused = false),
+ *   CheckBox("Show line numbers", checked = false, focused = true)
+ * )
+ * }}}
+ *
+ * @param label    Text rendered to the right of the marker.
+ * @param checked  Whether the checkbox is in the "on" state.
+ * @param focused  Whether the checkbox owns focus.
+ * @param at       Top-left cell. Defaults to `(1, 1)` for layout use.
+ * @param unicode  Whether to emit Unicode glyphs (default true) or ASCII
+ *                 fallback. Apps that read this from the active
+ *                 [[Capabilities.unicode]] flag can pass it through
+ *                 explicitly.
+ */
+object CheckBox:
+
+  /** Unicode marker glyphs — used when `unicode = true`. */
+  private val checkedGlyph   = "☒"
+  private val uncheckedGlyph = "☐"
+
+  /** ASCII fallback glyphs — used when `unicode = false`. */
+  private val checkedAscii   = "[x]"
+  private val uncheckedAscii = "[ ]"
+
+  def apply(
+    label: String,
+    checked: Boolean,
+    focused: Boolean = false,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    unicode: Boolean = true
+  )(using theme: Theme): VNode =
+    val fg     = if focused then theme.primary else theme.foreground
+    val marker = glyph(checked, unicode)
+    TextNode(
+      at.x,
+      at.y,
+      List(
+        Text(marker, Style(fg = if checked then theme.success else fg, bold = focused)),
+        Text(s" $label", Style(fg = fg, bold = focused))
+      )
+    )
+
+  /** Marker glyph for a (checked, unicode) combination. */
+  def glyph(checked: Boolean, unicode: Boolean = true): String =
+    (checked, unicode) match
+      case (true, true)   => checkedGlyph
+      case (false, true)  => uncheckedGlyph
+      case (true, false)  => checkedAscii
+      case (false, false) => uncheckedAscii
+
+  /** Natural cell width of a checkbox rendering `label`. */
+  def width(label: String, unicode: Boolean = true): Int =
+    glyph(checked = true, unicode).length + 1 + label.length

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/RadioGroup.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/RadioGroup.scala
@@ -1,0 +1,89 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Vertical single-select widget. Renders one row per option with a
+ * `◉` (selected) or `○` (unselected) marker, falling back to ASCII
+ * `(*)` / `( )` when `unicode = false`.
+ *
+ * `selectedIndex` is the model truth — exactly one row is "on" at a
+ * time. `focusedIndex` is independent: it controls which row currently
+ * owns keyboard focus and is rendered in the theme's primary slot. A
+ * row can be focused without being selected (the user has moved the
+ * highlight but not yet pressed Space/Enter to commit).
+ *
+ * Apps drive arrow-key navigation by updating `focusedIndex` and
+ * commit a selection by setting `selectedIndex = focusedIndex` on
+ * Space/Enter — that pattern keeps every state transition pure and
+ * testable.
+ *
+ * The rendered group is `options.size` rows tall and as wide as the
+ * longest `marker + space + label`. Returned as a list of `VNode`s so
+ * it composes inside [[Layout.Column]] without an extra wrapper.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Layout.column(gap = 0)(
+ *   RadioGroup(
+ *     options = Seq("Light", "Dark", "Mono"),
+ *     selectedIndex = 1,
+ *     focusedIndex  = 1
+ *   ): _*
+ * )
+ * }}}
+ *
+ * @param options       Display strings for each option.
+ * @param selectedIndex Index of the option that is currently selected.
+ * @param focusedIndex  Index of the focused row. `-1` means no row has
+ *                      focus (e.g. focus has moved away from the group).
+ * @param at            Top-left cell of the first row.
+ * @param unicode       Whether to emit Unicode marker glyphs (default
+ *                      true) or ASCII `(*)` / `( )` fallback.
+ */
+object RadioGroup:
+
+  private val selectedGlyph   = "◉"
+  private val unselectedGlyph = "○"
+  private val selectedAscii   = "(*)"
+  private val unselectedAscii = "( )"
+
+  def apply(
+    options: Seq[String],
+    selectedIndex: Int,
+    focusedIndex: Int = -1,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    unicode: Boolean = true
+  )(using theme: Theme): List[VNode] =
+    options.zipWithIndex.toList.map { case (label, i) =>
+      val selected = i == selectedIndex
+      val focused  = i == focusedIndex
+      val fg       = if focused then theme.primary else theme.foreground
+      val marker   = glyph(selected, unicode)
+      TextNode(
+        at.x,
+        at.y + i,
+        List(
+          Text(marker, Style(fg = if selected then theme.success else fg, bold = focused)),
+          Text(s" $label", Style(fg = fg, bold = focused))
+        )
+      )
+    }
+
+  /** Marker glyph for a (selected, unicode) combination. */
+  def glyph(selected: Boolean, unicode: Boolean = true): String =
+    (selected, unicode) match
+      case (true, true)   => selectedGlyph
+      case (false, true)  => unselectedGlyph
+      case (true, false)  => selectedAscii
+      case (false, false) => unselectedAscii
+
+  /** Natural cell width — wide enough to fit the longest `marker label`. */
+  def width(options: Seq[String], unicode: Boolean = true): Int =
+    if options.isEmpty then 0
+    else
+      val markerLen = glyph(selected = true, unicode).length
+      markerLen + 1 + options.map(_.length).max
+
+  /** Cell height — one row per option. */
+  def height(options: Seq[String]): Int = options.size

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/CheckBoxSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/CheckBoxSpec.scala
@@ -1,0 +1,70 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class CheckBoxSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private def textOf(node: VNode): String = node match
+    case TextNode(_, _, runs) => runs.map(_.txt).mkString
+    case _                    => fail(s"expected TextNode, got $node")
+
+  test("checked Unicode renders ☒ and the label") {
+    val cb = CheckBox(label = "Autosave", checked = true)
+    val s  = textOf(cb)
+    assert(s.contains("☒"))
+    assert(s.contains("Autosave"))
+  }
+
+  test("unchecked Unicode renders ☐ and the label") {
+    val cb = CheckBox(label = "Autosave", checked = false)
+    val s  = textOf(cb)
+    assert(s.contains("☐"))
+  }
+
+  test("ASCII fallback renders [x] / [ ]") {
+    val on  = CheckBox("On", checked = true, unicode = false)
+    val off = CheckBox("Off", checked = false, unicode = false)
+    assert(textOf(on).contains("[x]"))
+    assert(textOf(off).contains("[ ]"))
+  }
+
+  test("focused checkbox bolds its label") {
+    val cb = CheckBox("X", checked = false, focused = true)
+    cb match
+      case TextNode(_, _, runs) =>
+        // The label run (after the marker + space) should be bold.
+        assert(runs.last.style.bold, s"focused label should be bold, got ${runs.last.style}")
+      case other => fail(s"unexpected node: $other")
+  }
+
+  test("unfocused checkbox does not bold its label") {
+    val cb = CheckBox("X", checked = false, focused = false)
+    cb match
+      case TextNode(_, _, runs) => assert(!runs.last.style.bold)
+      case other                => fail(s"unexpected node: $other")
+  }
+
+  test("CheckBox.glyph maps every (checked, unicode) combo") {
+    assert(CheckBox.glyph(checked = true) == "☒")
+    assert(CheckBox.glyph(checked = false) == "☐")
+    assert(CheckBox.glyph(checked = true, unicode = false) == "[x]")
+    assert(CheckBox.glyph(checked = false, unicode = false) == "[ ]")
+  }
+
+  test("CheckBox.width accounts for the marker glyph plus space plus label") {
+    assert(CheckBox.width("hi") == 1 + 1 + 2)                  // ☒ + ' ' + 'hi'
+    assert(CheckBox.width("hi", unicode = false) == 3 + 1 + 2) // [x] + ' ' + 'hi'
+  }
+
+  test("CheckBox is positioned at the supplied coordinate") {
+    val cb = CheckBox("x", checked = false, at = Coord(10.x, 5.y))
+    cb match
+      case TextNode(x, y, _) =>
+        assert(x.value == 10)
+        assert(y.value == 5)
+      case other => fail(s"unexpected node: $other")
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/RadioGroupSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/RadioGroupSpec.scala
@@ -1,0 +1,84 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class RadioGroupSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private def textsOf(nodes: List[VNode]): List[String] = nodes.map {
+    case TextNode(_, _, runs) => runs.map(_.txt).mkString
+    case other                => fail(s"expected TextNode, got $other")
+  }
+
+  test("renders one row per option with correct selected/unselected markers") {
+    val nodes = RadioGroup(Seq("Light", "Dark", "Mono"), selectedIndex = 1)
+    val texts = textsOf(nodes)
+    assert(texts.length == 3)
+    assert(texts(0).contains("○") && texts(0).contains("Light"))
+    assert(texts(1).contains("◉") && texts(1).contains("Dark"))
+    assert(texts(2).contains("○") && texts(2).contains("Mono"))
+  }
+
+  test("ASCII fallback uses (*) and ( ) markers") {
+    val nodes = RadioGroup(Seq("On", "Off"), selectedIndex = 0, unicode = false)
+    val texts = textsOf(nodes)
+    assert(texts(0).contains("(*)"))
+    assert(texts(1).contains("( )"))
+  }
+
+  test("focusedIndex bolds only that row") {
+    val nodes = RadioGroup(Seq("a", "b", "c"), selectedIndex = 0, focusedIndex = 2)
+    val rows = nodes.map {
+      case TextNode(_, _, runs) => runs.last.style.bold
+      case _                    => fail("expected TextNode")
+    }
+    assert(rows == List(false, false, true))
+  }
+
+  test("focusedIndex == -1 means no row is focused") {
+    val nodes = RadioGroup(Seq("a", "b"), selectedIndex = 0, focusedIndex = -1)
+    nodes.foreach {
+      case TextNode(_, _, runs) => assert(!runs.last.style.bold)
+      case _                    => fail("expected TextNode")
+    }
+  }
+
+  test("rows are positioned vertically starting at `at` and one row apart") {
+    val nodes = RadioGroup(Seq("a", "b", "c"), selectedIndex = 0, at = Coord(4.x, 7.y))
+    val ys = nodes.map {
+      case TextNode(_, y, _) => y.value
+      case _                 => fail("expected TextNode")
+    }
+    val xs = nodes.map {
+      case TextNode(x, _, _) => x.value
+      case _                 => fail("expected TextNode")
+    }
+    assert(ys == List(7, 8, 9))
+    assert(xs.forall(_ == 4))
+  }
+
+  test("RadioGroup.glyph maps every (selected, unicode) combo") {
+    assert(RadioGroup.glyph(selected = true) == "◉")
+    assert(RadioGroup.glyph(selected = false) == "○")
+    assert(RadioGroup.glyph(selected = true, unicode = false) == "(*)")
+    assert(RadioGroup.glyph(selected = false, unicode = false) == "( )")
+  }
+
+  test("RadioGroup.width is marker + space + longest label") {
+    assert(RadioGroup.width(Seq("ab", "xyz", "x")) == 1 + 1 + 3)     // ◉ + ' ' + 'xyz'
+    assert(RadioGroup.width(Seq("a"), unicode = false) == 3 + 1 + 1) // (*) + ' ' + 'a'
+    assert(RadioGroup.width(Seq.empty[String]) == 0, "empty group has zero width")
+  }
+
+  test("RadioGroup.height equals the option count") {
+    assert(RadioGroup.height(Seq("a", "b", "c")) == 3)
+    assert(RadioGroup.height(Seq.empty[String]) == 0)
+  }
+
+  test("empty options produces an empty list") {
+    val nodes = RadioGroup(Seq.empty[String], selectedIndex = 0)
+    assert(nodes.isEmpty)
+  }


### PR DESCRIPTION
## Summary

Two new widgets that fit the existing `widgets/*` convention (companion `apply`, themed colours, focus + state independent, ASCII fallback for non-UTF-8 backends).

### `CheckBox`
- Renders `☒` / `☐` + label (ASCII `[x]` / `[ ]` when `unicode = false`)
- Focus communicated via colour + bold; checked state via marker glyph in `theme.success` — independent so siblings never reflow on focus change
- `glyph(checked, unicode)` and `width(label, unicode)` helpers for layout / hit-test

### `RadioGroup`
- Vertical single-select rendering `◉` / `○` + label per option (ASCII `(*)` / `( )` fallback)
- `selectedIndex` and `focusedIndex` are independent — apps can move the highlight (arrow keys) before committing the selection (Space/Enter)
- Returns `List[VNode]` so it composes inside `Layout.column` without an extra wrapper
- Companion `glyph` / `width` / `height` helpers

### Showcase
- **Themes** and **Borders** panels now render via the real `RadioGroup` widget instead of the hand-rolled `renderableRow` (deleted). Existing mouse hit-test math is unchanged because rows still live at panel-local `Y=3+i`.
- **Styles** panel grew a three-state `CheckBox` demo (off / on / focus) at panel-local rows 10/11/12, replacing the redundant `combo` row that duplicated the individual style demonstrations above.
- Two new showcase tests pin the rendered `RadioGroup` and `CheckBox` glyphs in the frame.

### Roadmap

§6.2 status table now distinguishes done (`CheckBox`, `RadioGroup`) from not-started (`Tabs` promotion, `ComboBox`, `Tree`, `Menu`/`MenuBar`, `Form` builder, `SplitPane`, `LogView`). §9.3 Lanterna comparison row updated.

## Test plan

- [x] `sbt ciCheck` — scalafmt + scalafix + tests
- [x] **651 total tests pass** (up from 632)
  - 17 new widget tests across `CheckBoxSpec` / `RadioGroupSpec` covering glyph mapping, focus highlighting, ASCII fallback, width / height helpers, empty inputs, position handling
  - 2 new showcase tests verifying both widgets appear in the rendered frame