### PR TITLE
feat: Tabs + LogView + Tree widgets + showcase wiring (Stage 3 §6.2)

### DIFF
--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -6,8 +6,18 @@ import termflow.tui.Tui.*
 import termflow.tui.TuiPrelude.*
 
 /**
- * One-screen showcase of every Stage 1 capability *plus* the user-visible
- * Stage 2 additions:
+ * Three-tab showcase of every shipped TermFlow feature.
+ *
+ * Tabs (switch with `1` / `2` / `3` or click the cell in the bar at row 2):
+ *
+ *   - **Showcase** — the Stage 1 + Stage 2 demo: capabilities, palette,
+ *     themes, borders, styles, unicode width, live input + dialogs.
+ *   - **Widgets** — the Tree widget over a sample file tree (arrow keys
+ *     navigate, Space / Enter toggles).
+ *   - **Help** — keybinding reference + about.
+ *
+ * Showcase tab features (every feature lands here unless it grows its own
+ * tab):
  *
  * **Stage 1**
  *   - **Color depth + capability detection** (PR #157 / issue #148): the
@@ -110,6 +120,65 @@ object Stage1ShowcaseApp:
   /** Max events kept in `Model.eventHistory` for the LogView in the live panel. */
   private val EventHistoryCap: Int = 50
 
+  /**
+   * Tab labels — each cell switches the body to a different demo. Order
+   * is the source of truth for the `1` / `2` / `3` keyboard shortcuts and
+   * for the `activeTab` indices in the model.
+   */
+  private val showcaseTabs: Vector[String] =
+    Vector("1 Showcase", "2 Widgets", "3 Help")
+
+  /**
+   * 0-based row of the Tabs bar inside the root frame. Used by both the
+   *  view (to render) and the mouse hit-test (to map clicks).
+   */
+  private val tabsRow: Int = 2
+
+  /** 0-based column of the first tab cell. Tabs is rendered at (2.x, 2.y). */
+  private val tabsCol: Int = 2
+
+  /**
+   * Tab index for the file-tree demo so the view function and the
+   *  dispatch agree on what `1` selects.
+   */
+  private val ShowcaseTabIdx: Int = 0
+  private val WidgetsTabIdx: Int  = 1
+  private val HelpTabIdx: Int     = 2
+
+  /**
+   * Sample file-tree used by the Widgets tab to demo the Tree widget.
+   * Plain ADT — the widget's `Children` instance traverses it.
+   */
+  sealed trait DemoNode:
+    def name: String
+  final case class DemoDir(name: String, kids: Vector[DemoNode]) extends DemoNode
+  final case class DemoFile(name: String)                        extends DemoNode
+
+  given widgets.Tree.Children[DemoNode, String] with
+    def id(n: DemoNode): String = n.name
+    def kids(n: DemoNode): Vector[DemoNode] = n match
+      case DemoDir(_, k) => k
+      case _: DemoFile   => Vector.empty
+
+  private val demoTree: Vector[DemoNode] = Vector(
+    DemoDir(
+      "termflow",
+      Vector(
+        DemoDir(
+          "tui",
+          Vector(
+            DemoFile("AnsiRenderer.scala"),
+            DemoFile("Layout.scala"),
+            DemoFile("Theme.scala"),
+            DemoDir("widgets", Vector(DemoFile("Tabs.scala"), DemoFile("LogView.scala"), DemoFile("Tree.scala")))
+          )
+        ),
+        DemoFile("README.md")
+      )
+    ),
+    DemoFile("build.sbt")
+  )
+
   enum Dialog:
     case None
     case ConfirmQuit(yesFocused: Boolean)
@@ -138,6 +207,12 @@ object Stage1ShowcaseApp:
     lastListPick: Option[String],
     /** Tick counter incremented by `tickSub`; drives the waiting spinner. */
     tick: Long,
+    /** 0-based index of the currently selected tab. See `showcaseTabs`. */
+    activeTab: Int,
+    /** Expanded ids in the Widgets tab's Tree. */
+    treeExpanded: Set[String],
+    /** Highlighted row index in the Widgets tab's Tree. */
+    treeSelected: Int,
     input: Sub[Msg],
     resize: Sub[Msg],
     tickSub: Sub[Msg]
@@ -158,6 +233,10 @@ object Stage1ShowcaseApp:
     case SelectThemeIdx(i: Int)
     case SelectBorderIdx(i: Int)
     case SelectListIdx(i: Int)
+    case SelectTab(idx: Int)
+    case ToggleTreeNode
+    case TreeUp
+    case TreeDown
     case OpenDialog
     case OpenTextInput
     case OpenListSelect
@@ -194,6 +273,9 @@ object Stage1ShowcaseApp:
         lastTextInput = None,
         lastListPick = None,
         tick = 0L,
+        activeTab = ShowcaseTabIdx,
+        treeExpanded = Set("termflow", "tui"),
+        treeSelected = 0,
         input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx),
         resize = Sub.TerminalResize[Msg](200, (w, h) => Resize(w, h), ctx),
         tickSub = Sub.Every(tickPeriodMs, () => Tick, ctx)
@@ -229,6 +311,24 @@ object Stage1ShowcaseApp:
             case Dialog.ListSelect(_) =>
               m.copy(dialog = Dialog.ListSelect(clampIdx(i, listSelectItems.size))).tui
             case _ => m.tui
+        case SelectTab(idx) =>
+          m.copy(activeTab = clampIdx(idx, showcaseTabs.size)).tui
+        case ToggleTreeNode =>
+          val rows = widgets.Tree.visibleRows(demoTree, m.treeExpanded)
+          if rows.isEmpty then m.tui
+          else
+            val row = rows(clampIdx(m.treeSelected, rows.size))
+            if !row.hasChildren then m.tui
+            else
+              val next =
+                if row.expanded then m.treeExpanded - row.id
+                else m.treeExpanded + row.id
+              m.copy(treeExpanded = next).tui
+        case TreeUp =>
+          m.copy(treeSelected = math.max(0, m.treeSelected - 1)).tui
+        case TreeDown =>
+          val rows = widgets.Tree.visibleRows(demoTree, m.treeExpanded)
+          m.copy(treeSelected = math.min(math.max(0, rows.size - 1), m.treeSelected + 1)).tui
         case Quit        => Tui(m, Cmd.Exit)
         case KeyError(_) => m.tui
         case Key(k)      =>
@@ -303,17 +403,62 @@ object Stage1ShowcaseApp:
             case _      => Cmd.NoCmd
 
         case Dialog.None =>
+          // Tab-switch shortcuts work on every tab.
           k match
-            case CharKey('b') | CharKey('B') => Cmd.GCmd(CycleBorder)
-            case CharKey('t') | CharKey('T') => Cmd.GCmd(CycleTheme)
-            case CharKey('d') | CharKey('D') => Cmd.GCmd(OpenDialog)
-            case CharKey('i') | CharKey('I') => Cmd.GCmd(OpenTextInput)
-            case CharKey('l') | CharKey('L') => Cmd.GCmd(OpenListSelect)
-            case CharKey('w') | CharKey('W') => Cmd.GCmd(OpenWaiting)
-            case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
-            case Escape                      => Cmd.GCmd(OpenDialog)
-            case Mouse(ev)                   => mouseDispatch(m, ev)
-            case _                           => Cmd.NoCmd
+            case CharKey('1') => Cmd.GCmd(SelectTab(0))
+            case CharKey('2') => Cmd.GCmd(SelectTab(1))
+            case CharKey('3') => Cmd.GCmd(SelectTab(2))
+            case _            =>
+              // Per-tab key bindings.
+              m.activeTab match
+                case WidgetsTabIdx => widgetsTabKey(k, m)
+                case HelpTabIdx    => helpTabKey(k)
+                case _             => showcaseTabKey(k, m)
+
+    /** Key bindings for the main "Showcase" tab — the original Stage 1+2 demo. */
+    private def showcaseTabKey(k: KeyDecoder.InputKey, m: Model): Cmd[Msg] =
+      import KeyDecoder.InputKey.*
+      k match
+        case CharKey('b') | CharKey('B') => Cmd.GCmd(CycleBorder)
+        case CharKey('t') | CharKey('T') => Cmd.GCmd(CycleTheme)
+        case CharKey('d') | CharKey('D') => Cmd.GCmd(OpenDialog)
+        case CharKey('i') | CharKey('I') => Cmd.GCmd(OpenTextInput)
+        case CharKey('l') | CharKey('L') => Cmd.GCmd(OpenListSelect)
+        case CharKey('w') | CharKey('W') => Cmd.GCmd(OpenWaiting)
+        case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
+        case Escape                      => Cmd.GCmd(OpenDialog)
+        case Mouse(ev)                   => mouseDispatch(m, ev)
+        case _                           => Cmd.NoCmd
+
+    /** Key bindings for the Widgets tab — tree navigation. */
+    private def widgetsTabKey(k: KeyDecoder.InputKey, m: Model): Cmd[Msg] =
+      import KeyDecoder.InputKey.*
+      k match
+        case ArrowUp                     => Cmd.GCmd(TreeUp)
+        case ArrowDown                   => Cmd.GCmd(TreeDown)
+        case Enter | CharKey(' ')        => Cmd.GCmd(ToggleTreeNode)
+        case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
+        case Escape                      => Cmd.GCmd(OpenDialog)
+        case Mouse(ev)                   => tabBarMouseDispatch(ev)
+        case _                           => Cmd.NoCmd
+
+    /** Key bindings for the Help tab. */
+    private def helpTabKey(k: KeyDecoder.InputKey): Cmd[Msg] =
+      import KeyDecoder.InputKey.*
+      k match
+        case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
+        case Escape                      => Cmd.GCmd(OpenDialog)
+        case _                           => Cmd.NoCmd
+
+    /**
+     * Mouse handling reduced to just the tabs bar — for the non-Showcase
+     *  tabs that don't have any mouse-targetable panels of their own.
+     */
+    private def tabBarMouseDispatch(ev: MouseEvent): Cmd[Msg] =
+      ev match
+        case MouseEvent.Press(MouseButton.Left, col, row, _) =>
+          tabHitTest(col, row).map(idx => Cmd.GCmd[Msg](SelectTab(idx))).getOrElse(Cmd.NoCmd)
+        case _ => Cmd.NoCmd
 
     /**
      * Map a [[MouseEvent]] to a model command using static panel rects.
@@ -332,11 +477,16 @@ object Stage1ShowcaseApp:
 
       ev match
         case MouseEvent.Press(MouseButton.Left, _, _, _) =>
-          if themesR.contains(col, row) then
-            themeIndexAtRow(themesR, row).map(i => Cmd.GCmd[Msg](SelectThemeIdx(i))).getOrElse(Cmd.NoCmd)
-          else if bordersR.contains(col, row) then
-            borderIndexAtRow(bordersR, row).map(i => Cmd.GCmd[Msg](SelectBorderIdx(i))).getOrElse(Cmd.NoCmd)
-          else Cmd.NoCmd
+          // Tab bar takes priority — clicks on a tab cell switch tabs
+          // regardless of which content tab is currently shown.
+          tabHitTest(col, row) match
+            case Some(idx) => Cmd.GCmd(SelectTab(idx))
+            case None =>
+              if themesR.contains(col, row) then
+                themeIndexAtRow(themesR, row).map(i => Cmd.GCmd[Msg](SelectThemeIdx(i))).getOrElse(Cmd.NoCmd)
+              else if bordersR.contains(col, row) then
+                borderIndexAtRow(bordersR, row).map(i => Cmd.GCmd[Msg](SelectBorderIdx(i))).getOrElse(Cmd.NoCmd)
+              else Cmd.NoCmd
 
         case MouseEvent.Scroll(dir, _, _, _) =>
           if themesR.contains(col, row) then
@@ -420,6 +570,15 @@ object Stage1ShowcaseApp:
     private def borderIndexAtRow(panel: Rect, row: Int): Option[Int] =
       val offset = row - (panel.row + 2)
       if offset >= 0 && offset < borderStyles.size then Some(offset) else None
+
+    /**
+     * Map a click `(col, row)` to a tab index when it lands on the Tabs
+     * bar at row 2. Returns `None` when the click is on a separator,
+     * outside the bar, or on a different row.
+     */
+    private def tabHitTest(col: Int, row: Int): Option[Int] =
+      if row != tabsRow then None
+      else widgets.Tabs.hitTest(showcaseTabs, colOffset = col - tabsCol)
 
     private def themesRect(m: Model): Rect =
       Rect(col = m.width - themesPanelWidth, row = topRowY, width = themesPanelWidth, height = topPanelHeight)
@@ -521,53 +680,60 @@ object Stage1ShowcaseApp:
         )
       )
 
-      val helpNode = TextNode(
-        2.x,
-        (m.height - 1).y,
-        List(
-          " click ".themed(_.primary),
-          "/scroll Themes & Borders  ".text,
-          " b ".themed(_.primary),
-          "border  ".text,
-          " t ".themed(_.primary),
-          "theme  ".text,
-          " d ".themed(_.primary),
-          "confirm  ".text,
-          " i ".themed(_.primary),
-          "input  ".text,
-          " l ".themed(_.primary),
-          "list  ".text,
-          " w ".themed(_.primary),
-          "wait  ".text,
-          " q ".themed(_.primary),
-          "quit ".text
-        )
+      // Tab-aware help footer — common bindings on the left, then per-tab
+      // hints on the right.
+      val tabSwitch = List[Text](
+        " 1/2/3 ".themed(_.primary),
+        "switch tab  ".text,
+        " click tab ".themed(_.primary),
+        "  ".text
       )
+      val perTab: List[Text] = m.activeTab match
+        case WidgetsTabIdx =>
+          List(
+            " ↑/↓ ".themed(_.primary),
+            "move  ".text,
+            " Space ".themed(_.primary),
+            "toggle  ".text
+          )
+        case HelpTabIdx =>
+          List(" press 1 / 2 to leave Help ".themed(_.info), "  ".text)
+        case _ =>
+          List(
+            " b ".themed(_.primary),
+            "border  ".text,
+            " t ".themed(_.primary),
+            "theme  ".text,
+            " d ".themed(_.primary),
+            "confirm  ".text,
+            " i ".themed(_.primary),
+            "input  ".text,
+            " l ".themed(_.primary),
+            "list  ".text,
+            " w ".themed(_.primary),
+            "wait  ".text
+          )
+      val tail     = List[Text](" q ".themed(_.primary), "quit ".text)
+      val helpNode = TextNode(2.x, (m.height - 1).y, tabSwitch ++ perTab ++ tail)
 
-      // Static stage Tabs bar — sits on row 2, between the title row and
-      // the panels (which start at topRowY = 3). The active tab marks the
-      // current development stage. Renders the real Tabs widget so the
-      // showcase exercises every shipped widget end-to-end.
+      // Interactive Tabs bar at row 2 — click a cell or press 1/2/3 to
+      // switch the body. The hit-test in mouseDispatch / tabBarMouseDispatch
+      // routes clicks against the same `showcaseTabs` labels.
       val tabsNode = widgets.Tabs(
-        labels = showcaseStageTabs,
-        activeIndex = showcaseStageTabs.size - 1
+        labels = showcaseTabs,
+        activeIndex = m.activeTab,
+        at = Coord(tabsCol.x, tabsRow.y)
       )
-      val stageTabs = Layout.translate(tabsNode, dx = 1, dy = 1) // anchor at (2, 2)
 
-      val panels: List[VNode] = List(
-        capabilitiesPanel(m, capsRect),
-        palettePanel(m, paletteRect(m)),
-        themesPanel(m, themesRect(m)),
-        bordersPanel(m, bordersRect(m)),
-        stylesPanel(stylesRect),
-        unicodePanel(unicodeRect(m)),
-        liveInputPanel(m, liveInputRect(m))
-      )
+      val body: List[VNode] = m.activeTab match
+        case WidgetsTabIdx => widgetsTabBody(m)
+        case HelpTabIdx    => helpTabBody(m)
+        case _             => showcaseTabBody(m)
 
       val baseRoot = RootNode(
         width = math.max(60, m.width),
         height = math.max(20, m.height),
-        children = (titleNode :: stageTabs :: panels) ++ List(helpNode),
+        children = (titleNode :: tabsNode :: body) ++ List(helpNode),
         input = None
       )
 
@@ -719,6 +885,66 @@ object Stage1ShowcaseApp:
 
     private def truncate(s: String, max: Int): String =
       if s.length <= max then s else s.take(max - 1) + "…"
+
+    /**
+     * Body content for the main "Showcase" tab — the original 7-panel
+     *  Stage 1 + 2 demo.
+     */
+    private def showcaseTabBody(m: Model)(using theme: Theme): List[VNode] = List(
+      capabilitiesPanel(m, capsRect),
+      palettePanel(m, paletteRect(m)),
+      themesPanel(m, themesRect(m)),
+      bordersPanel(m, bordersRect(m)),
+      stylesPanel(stylesRect),
+      unicodePanel(unicodeRect(m)),
+      liveInputPanel(m, liveInputRect(m))
+    )
+
+    /**
+     * Body content for the "Widgets" tab — a single full-width panel
+     *  showing the Tree widget over a sample file tree, with arrow-key
+     *  navigation and Space/Enter to expand/collapse.
+     */
+    private def widgetsTabBody(m: Model)(using theme: Theme): List[VNode] =
+      val r     = widgetsTabRect(m)
+      val title = TextNode(2.x, 1.y, List(" Tree widget demo ".themed(_.primary)))
+      val intro = TextNode(2.x, 3.y, List("Arrow keys move; Space/Enter toggles a node.".text))
+      val treeRows = widgets.Tree(
+        roots = demoTree,
+        expanded = m.treeExpanded,
+        selectedIndex = m.treeSelected,
+        render = (_: DemoNode).name,
+        at = Coord(2.x, 5.y)
+      )
+      List(panel(r, theme, title :: intro :: treeRows))
+
+    /** Body content for the "Help" tab — keybinding reference + about info. */
+    private def helpTabBody(m: Model)(using theme: Theme): List[VNode] =
+      val r     = widgetsTabRect(m)
+      val title = TextNode(2.x, 1.y, List(" Keybindings & help ".themed(_.primary)))
+      val rows = List(
+        TextNode(2.x, 3.y, List(" 1 / 2 / 3 ".themed(_.primary), "  switch tab".text)),
+        TextNode(2.x, 5.y, List(" Showcase tab".themed(_.success))),
+        TextNode(2.x, 6.y, List("   b  cycle border style".text)),
+        TextNode(2.x, 7.y, List("   t  cycle theme".text)),
+        TextNode(2.x, 8.y, List("   d  open confirm dialog".text)),
+        TextNode(2.x, 9.y, List("   i  open text-input dialog".text)),
+        TextNode(2.x, 10.y, List("   l  open list-select dialog".text)),
+        TextNode(2.x, 11.y, List("   w  open waiting dialog".text)),
+        TextNode(2.x, 13.y, List(" Widgets tab".themed(_.success))),
+        TextNode(2.x, 14.y, List("   ↑/↓  move tree selection".text)),
+        TextNode(2.x, 15.y, List("   Space/Enter  toggle node".text)),
+        TextNode(2.x, 17.y, List(" Anywhere".themed(_.success))),
+        TextNode(2.x, 18.y, List("   q / Esc  open quit confirmation".text)),
+        TextNode(2.x, 19.y, List("   click on Tabs bar  switch tab".text))
+      )
+      List(panel(r, theme, title :: rows))
+
+    /** Rect that fills the area below the Tabs bar to the help footer. */
+    private def widgetsTabRect(m: Model): Rect =
+      val top    = topRowY
+      val bottom = math.max(top + 5, m.height - 2) // leave row m.height-1 for footer
+      Rect(col = 1, row = top, width = math.max(60, m.width), height = bottom - top + 1)
 
     /** Bordered panel positioned at `r` with the theme's border style. */
     private def panel(r: Rect, theme: Theme, children: List[VNode]): VNode =

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -107,6 +107,9 @@ object Stage1ShowcaseApp:
    */
   private val listSelectTitle: String = "List select demo"
 
+  /** Max events kept in `Model.eventHistory` for the LogView in the live panel. */
+  private val EventHistoryCap: Int = 50
+
   enum Dialog:
     case None
     case ConfirmQuit(yesFocused: Boolean)
@@ -124,6 +127,11 @@ object Stage1ShowcaseApp:
     termName: String,
     /** Most recent input event, formatted for display in the live panel. */
     lastEvent: Option[String],
+    /**
+     * Bounded history of recent events fed to the live-input panel via the
+     * LogView widget. Latest events live at the tail.
+     */
+    eventHistory: Vector[String],
     /** Last value submitted from a textInput dialog (rendered in Live input). */
     lastTextInput: Option[String],
     /** Last item picked from a listSelect dialog. */
@@ -182,6 +190,7 @@ object Stage1ShowcaseApp:
         capabilities = ctx.terminal.capabilities,
         termName = sys.env.getOrElse("TERM", "?"),
         lastEvent = None,
+        eventHistory = Vector.empty,
         lastTextInput = None,
         lastListPick = None,
         tick = 0L,
@@ -225,7 +234,11 @@ object Stage1ShowcaseApp:
         case Key(k)      =>
           // Dialog.TextInput edits its prompt state through Prompt.handleKey
           // before dispatch. Other dialogs / the base view route through dispatch.
-          val withEvent = m.copy(lastEvent = Some(formatEvent(k)))
+          val formatted = formatEvent(k)
+          val withEvent = m.copy(
+            lastEvent = Some(formatted),
+            eventHistory = (m.eventHistory :+ formatted).takeRight(EventHistoryCap)
+          )
           withEvent.dialog match
             case Dialog.TextInput(state, focus) =>
               val (nextState, maybeCmd) =
@@ -531,6 +544,16 @@ object Stage1ShowcaseApp:
         )
       )
 
+      // Static stage Tabs bar — sits on row 2, between the title row and
+      // the panels (which start at topRowY = 3). The active tab marks the
+      // current development stage. Renders the real Tabs widget so the
+      // showcase exercises every shipped widget end-to-end.
+      val tabsNode = widgets.Tabs(
+        labels = showcaseStageTabs,
+        activeIndex = showcaseStageTabs.size - 1
+      )
+      val stageTabs = Layout.translate(tabsNode, dx = 1, dy = 1) // anchor at (2, 2)
+
       val panels: List[VNode] = List(
         capabilitiesPanel(m, capsRect),
         palettePanel(m, paletteRect(m)),
@@ -544,7 +567,7 @@ object Stage1ShowcaseApp:
       val baseRoot = RootNode(
         width = math.max(60, m.width),
         height = math.max(20, m.height),
-        children = titleNode :: panels ++ List(helpNode),
+        children = (titleNode :: stageTabs :: panels) ++ List(helpNode),
         input = None
       )
 
@@ -675,21 +698,24 @@ object Stage1ShowcaseApp:
       panel(r, theme, List(title, ruler, cjk, full, emoji, mixed, hint))
 
     private def liveInputPanel(m: Model, r: Rect)(using theme: Theme): VNode =
-      val title    = TextNode(2.x, 1.y, List(" Live input ".themed(_.primary)))
-      val intro    = TextNode(2.x, 3.y, List("Most recent decoded event:".text))
-      val event    = m.lastEvent.getOrElse("(press a key, click, or paste)")
-      val eventTxt = TextNode(2.x, 5.y, List(event.themed(_.success)))
-      val txt      = m.lastTextInput.map(s => s"\"${truncate(s, 24)}\"").getOrElse("—")
-      val pick     = m.lastListPick.getOrElse("—")
+      val title = TextNode(2.x, 1.y, List(" Live input ".themed(_.primary)))
+      val intro = TextNode(2.x, 3.y, List("Recent events (LogView, scrollable):".text))
+      // LogView for the rolling event history. Five rows fit cleanly under
+      // the intro inside the 13-row bottom panel.
+      val historyRows = widgets.LogView(
+        lines = m.eventHistory,
+        width = r.width - 4,
+        height = 5,
+        at = Coord(2.x, 4.y),
+        style = Some(Style(fg = theme.success))
+      )
+      val txt  = m.lastTextInput.map(s => s"\"${truncate(s, 24)}\"").getOrElse("—")
+      val pick = m.lastListPick.getOrElse("—")
       val results = List(
-        TextNode(2.x, 7.y, List("Last text input: ".text, txt.themed(_.info))),
-        TextNode(2.x, 8.y, List("Last list pick:  ".text, pick.themed(_.info)))
+        TextNode(2.x, 10.y, List("Last text input: ".text, txt.themed(_.info))),
+        TextNode(2.x, 11.y, List("Last list pick:  ".text, pick.themed(_.info)))
       )
-      val tips = List(
-        TextNode(2.x, 10.y, List("• i / l / w opens dialog helpers".text)),
-        TextNode(2.x, 11.y, List("• Scroll-wheel cycles Themes/Borders".text))
-      )
-      panel(r, theme, List(title, intro, eventTxt) ++ results ++ tips)
+      panel(r, theme, (title :: intro :: historyRows) ++ results)
 
     private def truncate(s: String, max: Int): String =
       if s.length <= max then s else s.take(max - 1) + "…"

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -448,7 +448,10 @@ object Stage1ShowcaseApp:
       k match
         case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
         case Escape                      => Cmd.GCmd(OpenDialog)
-        case _                           => Cmd.NoCmd
+        // Route mouse so clicks on the Tabs bar still switch tabs from
+        // here — without this, the Help tab traps the user.
+        case Mouse(ev) => tabBarMouseDispatch(ev)
+        case _         => Cmd.NoCmd
 
     /**
      * Mouse handling reduced to just the tabs bar — for the non-Showcase
@@ -940,11 +943,17 @@ object Stage1ShowcaseApp:
       )
       List(panel(r, theme, title :: rows))
 
-    /** Rect that fills the area below the Tabs bar to the help footer. */
+    /**
+     * Rect that fills the area below the Tabs bar to the help footer.
+     *  Leaves a 1-cell margin on the right (matching the Showcase tab's
+     *  rightmost panel layout) so the box's right border doesn't get
+     *  clipped or scroll the terminal.
+     */
     private def widgetsTabRect(m: Model): Rect =
       val top    = topRowY
       val bottom = math.max(top + 5, m.height - 2) // leave row m.height-1 for footer
-      Rect(col = 1, row = top, width = math.max(60, m.width), height = bottom - top + 1)
+      val width  = math.max(60, m.width) - 1
+      Rect(col = 1, row = top, width = width, height = bottom - top + 1)
 
     /** Bordered panel positioned at `r` with the theme's border style. */
     private def panel(r: Rect, theme: Theme, children: List[VNode]): VNode =

--- a/modules/termflow-sample/src/main/scala/termflow/apps/tabs/TabsDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/tabs/TabsDemoApp.scala
@@ -126,13 +126,14 @@ object TabsDemoApp:
       val notesRows      = math.max(1, boxHeight - 12)
       val notes          = active.notes.take(notesRows)
 
-      val tabBar = m.tabs.zipWithIndex
-        .map { case (tab, idx) =>
-          if idx == m.activeTab then s"[${idx + 1}:${tab.name}]"
-          else s" ${idx + 1}:${tab.name} "
-        }
-        .mkString(" ")
-      val tabBarFit  = if tabBar.length <= innerWidth then tabBar else tabBar.take(innerWidth)
+      // Tab bar rendered through the real Tabs widget. Themed via the
+      // ambient Theme; we override the colours below to match the demo's
+      // existing palette.
+      given Theme = Theme.dark.copy(primary = Magenta, foreground = White, border = Magenta)
+      val tabsNode = widgets.Tabs(
+        labels = m.tabs.map(t => s"${m.tabs.indexOf(t) + 1}:${t.name}"),
+        activeIndex = m.activeTab
+      )
       val statusFit  = if m.status.length <= innerWidth then m.status else m.status.take(innerWidth)
       val headerText = s"Active: ${active.name} | counter=${active.counter}"
       val headerFit  = if headerText.length <= innerWidth then headerText else headerText.take(innerWidth)
@@ -142,7 +143,7 @@ object TabsDemoApp:
         gap = 0,
         children = List(
           Layout.Elem(TextNode(1.x, 1.y, List(Text("Tabs Demo", Style(fg = Yellow, bold = true, underline = true))))),
-          Layout.Elem(TextNode(1.x, 1.y, List(Text(tabBarFit, Style(fg = Magenta, bold = true))))),
+          Layout.Elem(tabsNode),
           Layout.Elem(TextNode(1.x, 1.y, List(Text(headerFit, Style(fg = Cyan))))),
           Layout.Elem(TextNode(1.x, 1.y, List(Text("-" * innerWidth, Style(fg = Blue)))))
         )

--- a/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/home-with-note.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/home-with-note.golden
@@ -2,7 +2,7 @@
 # cursor=6,16
 |┌──────────────────────────────────────────────────────┐    |
 |│Tabs Demo                                             │    |
-|│[1:Home]  2:Work   3:Notes                            │    |
+|│[ 1:Home ]   2:Work     3:Notes                       │    |
 |│Active: Home | counter=0                              │    |
 |│Notes (per-tab persistent):---------------------------│    |
 |│- hello world                                         │    |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/initial-home.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/initial-home.golden
@@ -2,7 +2,7 @@
 # cursor=6,16
 |┌──────────────────────────────────────────────────────┐    |
 |│Tabs Demo                                             │    |
-|│[1:Home]  2:Work   3:Notes                            │    |
+|│[ 1:Home ]   2:Work     3:Notes                       │    |
 |│Active: Home | counter=0                              │    |
 |│Notes (per-tab persistent):---------------------------│    |
 |│(none)                                                │    |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/notes-tab-counter-2.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/notes-tab-counter-2.golden
@@ -2,7 +2,7 @@
 # cursor=6,16
 |┌──────────────────────────────────────────────────────┐    |
 |│Tabs Demo                                             │    |
-|│ 1:Home   2:Work  [3:Notes]                           │    |
+|│  1:Home     2:Work   [ 3:Notes ]                     │    |
 |│Active: Notes | counter=2                             │    |
 |│Notes (per-tab persistent):---------------------------│    |
 |│(none)                                                │    |

--- a/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/work-tab.golden
+++ b/modules/termflow-sample/src/test/resources/termflow/golden/TabsDemoAppSnapshotSpec/work-tab.golden
@@ -2,7 +2,7 @@
 # cursor=6,16
 |┌──────────────────────────────────────────────────────┐    |
 |│Tabs Demo                                             │    |
-|│ 1:Home  [2:Work]  3:Notes                            │    |
+|│  1:Home   [ 2:Work ]   3:Notes                       │    |
 |│Active: Work | counter=0                              │    |
 |│Notes (per-tab persistent):---------------------------│    |
 |│(none)                                                │    |

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -476,6 +476,24 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(rendered.contains("focus"), "focused CheckBox label should appear in the frame")
   }
 
+  test("eventHistory grows on each key, capped at the configured maximum") {
+    val d = driver
+    assert(d.model.eventHistory.isEmpty)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('a')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('b')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('c')))
+    assert(d.model.eventHistory.length == 3)
+    assert(d.model.eventHistory.last.contains("'c'"), s"latest event must be at the tail: ${d.model.eventHistory}")
+  }
+
+  test("LogView in the live-input panel renders the most recent events") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('z')))
+    val frame    = d.frame
+    val rendered = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("'z'"), "LogView should render the just-pressed key event")
+  }
+
   // Silence unused-import lint warning for AnsiRenderer (it's referenced
   // implicitly through TuiTestDriver, but the file would warn otherwise).
   private val _ = AnsiRenderer.getClass

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -476,6 +476,79 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(rendered.contains("focus"), "focused CheckBox label should appear in the frame")
   }
 
+  test("the Tabs bar appears on row 2 with showcase / widgets / help labels") {
+    val d        = driver
+    val frame    = d.frame
+    val rendered = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("1 Showcase"), "Tabs widget should render Showcase tab")
+    assert(rendered.contains("2 Widgets"), "Tabs widget should render Widgets tab")
+    assert(rendered.contains("3 Help"), "Tabs widget should render Help tab")
+    // Default active tab (0) should be bracketed by the Tabs widget.
+    assert(rendered.contains("[ 1 Showcase ]"), s"default active tab should be bracketed; rendered:\n$rendered")
+  }
+
+  // ---- Interactive tab switching ------------------------------------------
+
+  test("pressing 1 / 2 / 3 switches the active tab") {
+    val d = driver
+    assert(d.model.activeTab == 0)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('2')))
+    assert(d.model.activeTab == 1)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('3')))
+    assert(d.model.activeTab == 2)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('1')))
+    assert(d.model.activeTab == 0)
+  }
+
+  test("clicking a tab cell on row 2 switches to that tab") {
+    val d = driver
+    // First tab " 1 Showcase " is 12 cells wide starting at col 2 — col 7 is mid-tab.
+    // Second tab starts at col 2 + 12 + 1 (separator) = col 15.
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            18,
+            2,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.activeTab == 1, "click on the Widgets tab cell should select it")
+  }
+
+  test("Widgets tab renders the Tree widget") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('2')))
+    val frame    = d.frame
+    val rendered = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("Tree widget demo"), "Widgets tab title should appear")
+    assert(rendered.contains("termflow"), "Tree should render the root node label")
+  }
+
+  test("Widgets tab: ↓ moves selection, Space toggles a node") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('2')))
+    assert(d.model.treeSelected == 0)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.ArrowDown))
+    assert(d.model.treeSelected == 1)
+    // Toggle the currently-selected row (which is "tui" — already expanded).
+    val before = d.model.treeExpanded
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey(' ')))
+    assert(d.model.treeExpanded != before, "Space on an internal node should flip its expanded state")
+  }
+
+  test("Help tab renders keybinding reference") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('3')))
+    val frame    = d.frame
+    val rendered = (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")
+    assert(rendered.contains("Keybindings"), s"Help tab title missing in:\n$rendered")
+    assert(rendered.contains("switch tab"), "Help should document tab switching")
+  }
+
   test("eventHistory grows on each key, capped at the configured maximum") {
     val d = driver
     assert(d.model.eventHistory.isEmpty)

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -549,6 +549,67 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(rendered.contains("switch tab"), "Help should document tab switching")
   }
 
+  test("clicking a tab cell from inside the Help tab still switches tabs") {
+    // Regression: helpTabKey originally had no Mouse handler, trapping
+    // the user on tab 3.
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('3')))
+    assert(d.model.activeTab == 2)
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            6, // anywhere inside the first tab cell
+            2,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.activeTab == 0, "click on tab 1 from Help tab should switch to Showcase")
+  }
+
+  test("clicking a tab cell from inside the Widgets tab still switches tabs") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('2')))
+    assert(d.model.activeTab == 1)
+    // Tab cells (separator " ", padding 4):
+    //   "1 Showcase" cols 2..15, sep 16, "2 Widgets" 17..29, sep 30, "3 Help" 31..40.
+    d.send(
+      Stage1ShowcaseApp.Msg.Key(
+        InputKey.Mouse(
+          termflow.tui.MouseEvent.Press(
+            termflow.tui.MouseButton.Left,
+            35, // mid-"3 Help" cell
+            2,
+            termflow.tui.KeyDecoder.Modifiers()
+          )
+        )
+      )
+    )
+    assert(d.model.activeTab == 2, "click on tab 3 from Widgets tab should switch to Help")
+  }
+
+  test("Widgets / Help tab body keeps a 1-cell right margin") {
+    // Regression: widgetsTabRect originally extended to col m.width, so
+    // the right border landed on the very last column and got clipped on
+    // narrower terminals.
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('2')))
+    val frame    = d.frame
+    val rightCol = d.model.width
+    // The last column should NOT contain a vertical border glyph from the
+    // Widgets-tab box (some renderers may also pad with spaces; either is
+    // fine — the assertion is "no border at the screen edge").
+    val borderChars  = Set('│', '┃', '║', '|')
+    val lastColCells = (0 until frame.height).map(r => frame.cells(r)(rightCol - 1).ch).filter(borderChars.contains)
+    assert(
+      lastColCells.isEmpty,
+      s"expected no panel border in the rightmost column ($rightCol); found: ${lastColCells.mkString(",")}"
+    )
+  }
+
   test("eventHistory grows on each key, capped at the configured maximum") {
     val d = driver
     assert(d.model.eventHistory.isEmpty)

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/LogView.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/LogView.scala
@@ -1,0 +1,129 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Append-only scrollback viewer for log lines, REPL output, chat
+ * transcripts, and similar streams.
+ *
+ * The widget renders a fixed-size viewport into a longer line buffer.
+ * Apps own the buffer (typically a bounded `Vector[String]` or a
+ * ring-buffer) and a `scrollOffset` counted in *display lines* from the
+ * bottom — `0` is "tail of the buffer pinned to the last row" (the
+ * common live-feed view), positive values scroll back into history.
+ *
+ * Long lines are wrapped to fit `width` when `wrap = true` (default),
+ * or truncated with a trailing `…` when `wrap = false`. Wrapping is
+ * computed by [[wrap]]; the visible window is sliced by [[viewport]].
+ * Both helpers are public so apps can pre-compute display lines once
+ * per buffer change instead of every frame.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Layout.column(gap = 0)(
+ *   LogView(
+ *     lines        = chatBuffer,
+ *     width        = 60,
+ *     height       = 12,
+ *     scrollOffset = 0   // pinned to live tail
+ *   ): _*
+ * )
+ * }}}
+ *
+ * @param lines        The raw line buffer. The widget does not mutate
+ *                     it.
+ * @param width        Cell width of the viewport.
+ * @param height       Cell height (number of rows rendered).
+ * @param scrollOffset Number of display lines scrolled up from the
+ *                     tail. `0` keeps the latest line on the last row.
+ *                     Negative values are treated as `0`.
+ * @param at           Top-left cell of the viewport.
+ * @param wrap         Whether to wrap long lines to fit `width` (default
+ *                     true) or truncate with `…`.
+ * @param style        Optional style override for the rendered rows.
+ *                     Defaults to the theme's `foreground` slot.
+ */
+object LogView:
+
+  /** Truncation glyph used when `wrap = false`. */
+  private val ellipsis = "…"
+
+  def apply(
+    lines: Seq[String],
+    width: Int,
+    height: Int,
+    scrollOffset: Int = 0,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    wrap: Boolean = true,
+    style: Option[Style] = None
+  )(using theme: Theme): List[VNode] =
+    val effectiveWidth  = math.max(1, width)
+    val effectiveHeight = math.max(0, height)
+    val displayLines    = expand(lines, effectiveWidth, wrap)
+    val visible         = viewport(displayLines, effectiveHeight, scrollOffset)
+    val rowStyle        = style.getOrElse(Style(fg = theme.foreground))
+    visible.zipWithIndex.toList.map { case (line, i) =>
+      TextNode(at.x, at.y + i, List(Text(line, rowStyle)))
+    }
+
+  /**
+   * Expand a raw line buffer into the display-line representation that
+   * the viewport will scroll over. Wrapped lines become multiple
+   * display lines; truncated lines become one. Empty input lines stay
+   * as empty display lines.
+   */
+  def expand(lines: Seq[String], width: Int, wrap: Boolean): Vector[String] =
+    val w = math.max(1, width)
+    lines.foldLeft(Vector.empty[String]) { (acc, line) =>
+      if wrap then acc ++ wrapLine(line, w)
+      else acc :+ truncateLine(line, w)
+    }
+
+  /** Wrap a single line into chunks of at most `width` columns. */
+  def wrapLine(line: String, width: Int): Vector[String] =
+    val w = math.max(1, width)
+    if line.isEmpty then Vector("")
+    else
+      val builder = Vector.newBuilder[String]
+      var i       = 0
+      while i < line.length do
+        val end = math.min(line.length, i + w)
+        builder += line.substring(i, end)
+        i = end
+      builder.result()
+
+  /** Truncate a single line to `width`, appending `…` if it doesn't fit. */
+  def truncateLine(line: String, width: Int): String =
+    val w = math.max(1, width)
+    if line.length <= w then line
+    else if w == 1 then ellipsis
+    else line.substring(0, w - 1) + ellipsis
+
+  /**
+   * Slice `displayLines` into the visible window: `height` lines anchored
+   * at `scrollOffset` from the tail. The result is padded on top with
+   * blank rows when the buffer is shorter than the viewport, so apps can
+   * draw a fixed-height region without conditional logic.
+   */
+  def viewport(displayLines: Seq[String], height: Int, scrollOffset: Int): Vector[String] =
+    val h     = math.max(0, height)
+    val total = displayLines.size
+    if h == 0 then Vector.empty
+    else
+      val offset    = math.max(0, math.min(math.max(0, total - h), scrollOffset))
+      val tailIndex = math.max(0, total - h - offset)
+      val available = displayLines.slice(tailIndex, tailIndex + h).toVector
+      val pad       = h - available.size
+      if pad > 0 then Vector.fill(pad)("") ++ available
+      else available
+
+  /** Number of display lines `lines` would expand to at this width. */
+  def displayLineCount(lines: Seq[String], width: Int, wrap: Boolean): Int =
+    expand(lines, width, wrap).size
+
+  /**
+   * Maximum scroll offset for `lines` at this viewport size. Apps can
+   * use this to clamp scroll input from arrow keys or wheel events.
+   */
+  def maxScroll(lines: Seq[String], width: Int, height: Int, wrap: Boolean): Int =
+    math.max(0, displayLineCount(lines, width, wrap) - math.max(1, height))

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Tabs.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Tabs.scala
@@ -1,0 +1,104 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Horizontal tab bar rendered as a single row.
+ *
+ * Each tab gets a `[ Label ]` (active) or `  Label  ` (inactive) box;
+ * the active tab uses the theme's `primary` slot bold, focused-but-
+ * inactive tabs use `primary` not bold, plain inactive tabs use
+ * `foreground`. The shape doesn't change on focus — tabs always render
+ * with two cells of padding on each side — so siblings never reflow when
+ * focus or active state moves.
+ *
+ * Active and focused are independent. `activeIndex` is the truth (which
+ * tab's content is being shown); `focusedIndex` controls which header
+ * cell currently owns keyboard focus. A tab can be focused without
+ * being active — the user has moved the highlight but not yet pressed
+ * Enter / clicked to commit.
+ *
+ * Apps drive arrow-left / right (or Tab) navigation by updating
+ * `focusedIndex` and commit the tab switch by setting
+ * `activeIndex = focusedIndex` on Enter / Space.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Tabs(
+ *   labels        = Seq("Home", "Work", "Notes"),
+ *   activeIndex   = 1,
+ *   focusedIndex  = 1
+ * )
+ * }}}
+ *
+ * @param labels       One label per tab, drawn left-to-right.
+ * @param activeIndex  Index of the active tab (`-1` for none).
+ * @param focusedIndex Index of the focused tab. `-1` means no header
+ *                     row owns focus (focus has moved into the body).
+ * @param at           Top-left cell of the tab row.
+ * @param separator    String drawn between adjacent tab cells. Use
+ *                     `" "` for a quiet bar, `" │ "` for a vertical
+ *                     divider, `""` to render tabs flush against each
+ *                     other.
+ */
+object Tabs:
+
+  /** Width of the constant padding (`[` + space + label + space + `]`). */
+  private val Padding: Int = 4
+
+  def apply(
+    labels: Seq[String],
+    activeIndex: Int,
+    focusedIndex: Int = -1,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    separator: String = " "
+  )(using theme: Theme): VNode =
+    val segments: List[Text] =
+      labels.zipWithIndex.toList.flatMap { case (label, i) =>
+        val isActive  = i == activeIndex
+        val isFocused = i == focusedIndex
+        val fg =
+          if isActive then theme.primary
+          else if isFocused then theme.primary
+          else theme.foreground
+        val bold   = isActive || isFocused
+        val opener = if isActive then "[ " else "  "
+        val closer = if isActive then " ]" else "  "
+        val cell   = Text(s"$opener$label$closer", Style(fg = fg, bold = bold))
+        val gap =
+          if i == labels.size - 1 || separator.isEmpty then None
+          else Some(Text(separator, Style(fg = theme.border)))
+        cell :: gap.toList
+      }
+    TextNode(at.x, at.y, segments)
+
+  /**
+   * Cell width of a tab bar rendering `labels` with `separator` between
+   * them. Each tab takes `label.length + 4` cells (the constant `[ ` /
+   * `  ` padding); separators sit between tabs.
+   */
+  def width(labels: Seq[String], separator: String = " "): Int =
+    if labels.isEmpty then 0
+    else labels.map(_.length + Padding).sum + (labels.size - 1) * separator.length
+
+  /**
+   * Map an absolute click column to the tab index it landed on. Returns
+   * `None` if the column is outside any tab cell (for example, on a
+   * separator).
+   *
+   * Apps with mouse hit-testing pass the click column relative to the
+   * same `at.x` they used to render the bar — i.e. `mouseCol - at.x.value`.
+   *
+   * @param colOffset 0-based offset into the tab row.
+   */
+  def hitTest(labels: Seq[String], separator: String = " ", colOffset: Int): Option[Int] =
+    if colOffset < 0 then None
+    else
+      var i      = 0
+      var cursor = 0
+      while i < labels.size do
+        val cellEnd = cursor + labels(i).length + Padding
+        if colOffset >= cursor && colOffset < cellEnd then return Some(i)
+        cursor = cellEnd + separator.length
+        i += 1
+      None

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Tree.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Tree.scala
@@ -1,0 +1,163 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Generic tree-view widget. Renders a collapsible hierarchy as a flat
+ * list of rows, one per visible node.
+ *
+ * The widget is structure-agnostic: apps describe their own tree by
+ * implementing [[Tree.Children]] (or supplying a function), label nodes
+ * via a `render` callback, and own the expanded / selected state. The
+ * widget walks the structure each frame and produces the visible row
+ * list — no internal state, no in-place mutation.
+ *
+ * ## Conventions
+ *
+ *   - **Indentation.** Each level adds two cells of left padding so
+ *     ancestor relationships are visually obvious. Override with
+ *     `indentWidth`.
+ *   - **Markers.** Internal nodes (those with children) get a `▾`
+ *     (expanded) or `▸` (collapsed) chevron, two columns wide
+ *     (chevron + space). Leaves get two spaces. ASCII fallbacks are
+ *     `v ` / `> ` / `  ` when `unicode = false`.
+ *   - **Selection.** The row at `selectedIndex` (an index into the
+ *     *visible* row list) is highlighted in the theme's primary slot,
+ *     bolded.
+ *   - **Identity.** Apps decide what an "expanded" node is via
+ *     [[Tree.Children.id]] (a stable key) and a `Set[Id]` of expanded
+ *     ids. Re-using the same id across frames is what keeps state
+ *     stable as the tree changes shape.
+ *
+ * ## Example
+ *
+ * {{{
+ * given Theme = Theme.dark
+ *
+ * sealed trait Node:
+ *   def name: String
+ * case class Dir(name: String, kids: Vector[Node]) extends Node
+ * case class File(name: String) extends Node
+ *
+ * given Tree.Children[Node, String] with
+ *   def id(n: Node): String = n.name
+ *   def kids(n: Node): Vector[Node] = n match
+ *     case Dir(_, k) => k
+ *     case _: File   => Vector.empty
+ *
+ * Tree(
+ *   roots         = Vector(Dir("src", Vector(File("Main.scala")))),
+ *   expanded      = Set("src"),
+ *   selectedIndex = 0,
+ *   render        = _.name
+ * )
+ * }}}
+ */
+object Tree:
+
+  /** Row that the widget renders for each visible node. */
+  final case class Row[A](
+    /**
+     * Original node — useful if the app wants the full node back from
+     *  a click position.
+     */
+    node: A,
+    /** Stable id (per [[Children.id]]). */
+    id: String,
+    /** Indent depth — `0` for root entries. */
+    depth: Int,
+    /** True if the node has any children at all. */
+    hasChildren: Boolean,
+    /** True if `id` is in the `expanded` set. */
+    expanded: Boolean
+  )
+
+  /** Type-class describing how to traverse a custom tree structure. */
+  trait Children[A, Id]:
+    def id(node: A): Id
+    def kids(node: A): Vector[A]
+
+  /**
+   * Walk the tree honouring the expanded set; produce the flat row list
+   *  the widget renders. Public so apps can pre-compute it (e.g. for
+   *  click-to-row mapping outside the widget itself).
+   */
+  def visibleRows[A, Id](
+    roots: Vector[A],
+    expanded: Set[Id]
+  )(using c: Children[A, Id]): Vector[Row[A]] =
+    val builder = Vector.newBuilder[Row[A]]
+    def walk(node: A, depth: Int): Unit =
+      val kids   = c.kids(node)
+      val nodeId = c.id(node)
+      val isOpen = expanded.contains(nodeId)
+      builder += Row(
+        node = node,
+        id = nodeId.toString,
+        depth = depth,
+        hasChildren = kids.nonEmpty,
+        expanded = isOpen
+      )
+      if isOpen then kids.foreach(k => walk(k, depth + 1))
+    roots.foreach(walk(_, 0))
+    builder.result()
+
+  // Marker glyphs.
+  private val expandedGlyph       = "▾ "
+  private val collapsedGlyph      = "▸ "
+  private val leafGlyph           = "  "
+  private val expandedGlyphAscii  = "v "
+  private val collapsedGlyphAscii = "> "
+  private val leafGlyphAscii      = "  "
+
+  /**
+   * Render the tree as a list of `TextNode`s.
+   *
+   * @param roots         Root nodes drawn in document order.
+   * @param expanded      Set of expanded node ids.
+   * @param selectedIndex Visible-row index of the highlighted row, or
+   *                      `-1` for no selection.
+   * @param render        Label for a node.
+   * @param at            Top-left cell of the first row.
+   * @param indentWidth   Cells added per depth level (default 2).
+   * @param unicode       Whether to emit Unicode chevrons or ASCII
+   *                      `v ` / `> ` fallbacks.
+   */
+  def apply[A, Id](
+    roots: Vector[A],
+    expanded: Set[Id],
+    selectedIndex: Int,
+    render: A => String,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    indentWidth: Int = 2,
+    unicode: Boolean = true
+  )(using c: Children[A, Id], theme: Theme): List[VNode] =
+    val rows = visibleRows(roots, expanded)
+    rows.zipWithIndex.toList.map { case (row, i) =>
+      val isSelected = i == selectedIndex
+      val style =
+        if isSelected then Style(fg = theme.background, bg = theme.primary, bold = true)
+        else Style(fg = theme.foreground)
+      val pad = " " * (row.depth * indentWidth)
+      val marker =
+        if !row.hasChildren then leafFor(unicode)
+        else if row.expanded then expandedFor(unicode)
+        else collapsedFor(unicode)
+      TextNode(at.x, at.y + i, List(Text(s"$pad$marker${render(row.node)}", style)))
+    }
+
+  /** Marker glyph for an expanded internal node. */
+  def expandedFor(unicode: Boolean = true): String =
+    if unicode then expandedGlyph else expandedGlyphAscii
+
+  /** Marker glyph for a collapsed internal node. */
+  def collapsedFor(unicode: Boolean = true): String =
+    if unicode then collapsedGlyph else collapsedGlyphAscii
+
+  /** Padding used in place of a marker for leaf nodes. */
+  def leafFor(unicode: Boolean = true): String =
+    if unicode then leafGlyph else leafGlyphAscii
+
+  /** Cell width of a tree row at `depth` carrying the given label. */
+  def rowWidth(label: String, depth: Int, indentWidth: Int = 2, unicode: Boolean = true): Int =
+    depth * indentWidth + leafFor(unicode).length + label.length

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/LogViewSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/LogViewSpec.scala
@@ -1,0 +1,126 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class LogViewSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  // ---- wrapLine -----------------------------------------------------------
+
+  test("wrapLine returns one chunk for short input") {
+    assert(LogView.wrapLine("hello", width = 10) == Vector("hello"))
+  }
+
+  test("wrapLine breaks at exact column boundaries") {
+    assert(LogView.wrapLine("abcdef", width = 2) == Vector("ab", "cd", "ef"))
+  }
+
+  test("wrapLine of an empty line yields one empty chunk") {
+    assert(LogView.wrapLine("", width = 10) == Vector(""))
+  }
+
+  test("wrapLine clamps width to a minimum of 1") {
+    assert(LogView.wrapLine("abc", width = 0) == Vector("a", "b", "c"))
+  }
+
+  // ---- truncateLine -------------------------------------------------------
+
+  test("truncateLine returns the input when it fits") {
+    assert(LogView.truncateLine("hi", width = 5) == "hi")
+  }
+
+  test("truncateLine appends an ellipsis when it doesn't fit") {
+    assert(LogView.truncateLine("abcdef", width = 4) == "abc…")
+  }
+
+  test("truncateLine handles width = 1 with the ellipsis alone") {
+    assert(LogView.truncateLine("abcdef", width = 1) == "…")
+  }
+
+  // ---- expand -------------------------------------------------------------
+
+  test("expand wraps long lines into multiple display rows") {
+    val out = LogView.expand(Seq("abcde", "fg"), width = 2, wrap = true)
+    assert(out == Vector("ab", "cd", "e", "fg"))
+  }
+
+  test("expand truncates instead of wrapping when wrap = false") {
+    val out = LogView.expand(Seq("hello world"), width = 5, wrap = false)
+    assert(out == Vector("hell…"))
+  }
+
+  // ---- viewport -----------------------------------------------------------
+
+  test("viewport returns the last `height` lines when scrollOffset is 0") {
+    val display = (1 to 5).map(_.toString).toVector
+    assert(LogView.viewport(display, height = 3, scrollOffset = 0) == Vector("3", "4", "5"))
+  }
+
+  test("viewport scrolls up by scrollOffset display lines") {
+    val display = (1 to 5).map(_.toString).toVector
+    assert(LogView.viewport(display, height = 3, scrollOffset = 1) == Vector("2", "3", "4"))
+    assert(LogView.viewport(display, height = 3, scrollOffset = 2) == Vector("1", "2", "3"))
+  }
+
+  test("viewport clamps scrollOffset at the top of the buffer") {
+    val display = (1 to 5).map(_.toString).toVector
+    assert(LogView.viewport(display, height = 3, scrollOffset = 999) == Vector("1", "2", "3"))
+    assert(LogView.viewport(display, height = 3, scrollOffset = -10) == Vector("3", "4", "5"))
+  }
+
+  test("viewport pads short buffers with leading blank rows") {
+    val display = Vector("only-line")
+    assert(LogView.viewport(display, height = 3, scrollOffset = 0) == Vector("", "", "only-line"))
+  }
+
+  test("viewport with height = 0 returns empty") {
+    assert(LogView.viewport(Vector("a"), height = 0, scrollOffset = 0).isEmpty)
+  }
+
+  // ---- maxScroll ----------------------------------------------------------
+
+  test("maxScroll is 0 when the buffer fits in the viewport") {
+    assert(LogView.maxScroll(Seq("a", "b"), width = 10, height = 5, wrap = true) == 0)
+  }
+
+  test("maxScroll is total - height when the buffer overflows") {
+    // 10 raw lines @ width 10 wrap = 10 display lines; height 4 → max = 6.
+    val lines = (1 to 10).map(i => s"l$i").toSeq
+    assert(LogView.maxScroll(lines, width = 10, height = 4, wrap = true) == 6)
+  }
+
+  // ---- apply --------------------------------------------------------------
+
+  test("apply renders one TextNode per row, positioned vertically") {
+    val nodes = LogView(
+      lines = Seq("one", "two", "three"),
+      width = 10,
+      height = 3,
+      at = Coord(2.x, 4.y)
+    )
+    assert(nodes.length == 3)
+    val ys = nodes.map { case TextNode(_, y, _) => y.value; case _ => fail() }
+    assert(ys == List(4, 5, 6))
+  }
+
+  test("apply pads the top of the viewport when the buffer is shorter than height") {
+    val nodes = LogView(lines = Seq("only"), width = 10, height = 3)
+    val texts = nodes.map { case TextNode(_, _, runs) => runs.map(_.txt).mkString; case _ => fail() }
+    assert(texts == List("", "", "only"))
+  }
+
+  test("apply with height = 0 produces no nodes") {
+    assert(LogView(lines = Seq("a"), width = 10, height = 0).isEmpty)
+  }
+
+  test("apply respects the supplied row style override") {
+    val custom = Style(fg = Color.Red, bold = true)
+    val nodes  = LogView(Seq("hello"), width = 10, height = 1, style = Some(custom))
+    nodes.head match
+      case TextNode(_, _, runs) =>
+        assert(runs.head.style == custom)
+      case _ => fail()
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/TabsSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/TabsSpec.scala
@@ -1,0 +1,79 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class TabsSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private def textOf(node: VNode): String = node match
+    case TextNode(_, _, runs) => runs.map(_.txt).mkString
+    case _                    => fail(s"expected TextNode, got $node")
+
+  test("renders one cell per tab plus separators") {
+    val node = Tabs(Seq("Home", "Work", "Notes"), activeIndex = 0)
+    val s    = textOf(node)
+    assert(s.contains("Home"))
+    assert(s.contains("Work"))
+    assert(s.contains("Notes"))
+  }
+
+  test("active tab is wrapped in [ ] and unfocused tabs use spaces") {
+    val s = textOf(Tabs(Seq("A", "B"), activeIndex = 1))
+    assert(s.contains("[ B ]"), s"active tab should be bracketed: $s")
+    assert(s.contains("  A  "), s"inactive tab should be padded: $s")
+  }
+
+  test("focused-but-inactive tab uses primary colour and bold") {
+    val node = Tabs(Seq("A", "B"), activeIndex = 0, focusedIndex = 1)
+    node match
+      case TextNode(_, _, runs) =>
+        // Run 0 = active "[ A ]", run 1 = separator, run 2 = focused " B "
+        val focusedRun = runs(2)
+        assert(focusedRun.style.bold, "focused tab label should be bold")
+      case _ => fail("expected TextNode")
+  }
+
+  test("custom separator appears between tabs but not after the last") {
+    val s   = textOf(Tabs(Seq("X", "Y", "Z"), activeIndex = 0, separator = " | "))
+    val occ = s.split(" \\| ").length - 1
+    assert(occ == 2, s"expected 2 separators between 3 tabs, got $occ in: $s")
+  }
+
+  test("empty separator produces no inter-tab gap") {
+    val s = textOf(Tabs(Seq("AB", "CD"), activeIndex = 0, separator = ""))
+    // active "[ AB ]" + inactive "  CD  " concatenated with no space.
+    assert(s == "[ AB ]  CD  ", s"got '$s'")
+  }
+
+  test("Tabs.width sums tab cells + separators") {
+    assert(Tabs.width(Seq("Home", "Work")) == ("Home".length + 4) + ("Work".length + 4) + 1)
+    assert(Tabs.width(Seq("a"), separator = "") == 5) // "[ a ]" or "  a  "
+    assert(Tabs.width(Seq.empty[String]) == 0)
+  }
+
+  test("hitTest maps a column offset to its tab index") {
+    val labels = Seq("Home", "Work", "Notes")
+    // Tab cell widths: 8, 8, 9. Separator length 1 (default " ").
+    // [Home: 0..7] [sep: 8] [Work: 9..16] [sep: 17] [Notes: 18..26]
+    assert(Tabs.hitTest(labels, colOffset = 0).contains(0))
+    assert(Tabs.hitTest(labels, colOffset = 7).contains(0))
+    assert(Tabs.hitTest(labels, colOffset = 8).isEmpty, "click on the separator should miss")
+    assert(Tabs.hitTest(labels, colOffset = 9).contains(1))
+    assert(Tabs.hitTest(labels, colOffset = 16).contains(1))
+    assert(Tabs.hitTest(labels, colOffset = 18).contains(2))
+    assert(Tabs.hitTest(labels, colOffset = 26).contains(2))
+    assert(Tabs.hitTest(labels, colOffset = 27).isEmpty, "click past the last tab should miss")
+    assert(Tabs.hitTest(labels, colOffset = -1).isEmpty)
+  }
+
+  test("Tabs is positioned at the supplied coordinate") {
+    val node = Tabs(Seq("X"), activeIndex = 0, at = Coord(10.x, 4.y))
+    node match
+      case TextNode(x, y, _) =>
+        assert(x.value == 10)
+        assert(y.value == 4)
+      case _ => fail("expected TextNode")
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/TreeSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/TreeSpec.scala
@@ -1,0 +1,157 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class TreeSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  /** A tiny tree shape for the tests. */
+  sealed trait Node:
+    def name: String
+  final case class Branch(name: String, kids: Vector[Node]) extends Node
+  final case class Leaf(name: String)                       extends Node
+
+  given Tree.Children[Node, String] with
+    def id(n: Node): String = n.name
+    def kids(n: Node): Vector[Node] = n match
+      case Branch(_, k) => k
+      case _: Leaf      => Vector.empty
+
+  private val sampleTree: Vector[Node] = Vector(
+    Branch(
+      "src",
+      Vector(
+        Leaf("Main.scala"),
+        Branch("util", Vector(Leaf("Helpers.scala")))
+      )
+    ),
+    Leaf("README.md")
+  )
+
+  private def textsOf(nodes: List[VNode]): List[String] = nodes.map {
+    case TextNode(_, _, runs) => runs.map(_.txt).mkString
+    case other                => fail(s"expected TextNode, got $other")
+  }
+
+  // ---- visibleRows --------------------------------------------------------
+
+  test("visibleRows shows only roots when nothing is expanded") {
+    val rows = Tree.visibleRows(sampleTree, expanded = Set.empty[String])
+    assert(rows.map(_.id) == Vector("src", "README.md"))
+    assert(rows.head.depth == 0)
+    assert(rows.head.hasChildren)
+    assert(!rows.head.expanded)
+  }
+
+  test("visibleRows expands a single node when its id is in the expanded set") {
+    val rows = Tree.visibleRows(sampleTree, expanded = Set("src"))
+    assert(rows.map(_.id) == Vector("src", "Main.scala", "util", "README.md"))
+    assert(rows(2).depth == 1)
+    assert(rows(2).hasChildren)
+    assert(!rows(2).expanded)
+  }
+
+  test("visibleRows expands transitively when ancestors are open") {
+    val rows = Tree.visibleRows(sampleTree, expanded = Set("src", "util"))
+    assert(rows.map(_.id) == Vector("src", "Main.scala", "util", "Helpers.scala", "README.md"))
+    assert(rows.find(_.id == "Helpers.scala").exists(_.depth == 2))
+  }
+
+  test("visibleRows reports leaf nodes as hasChildren = false") {
+    val rows = Tree.visibleRows(Vector[Node](Leaf("only")), expanded = Set.empty[String])
+    assert(!rows.head.hasChildren)
+  }
+
+  // ---- apply --------------------------------------------------------------
+
+  test("apply renders one row per visible node with the right indentation + chevron") {
+    val nodes = Tree(
+      roots = sampleTree,
+      expanded = Set("src"),
+      selectedIndex = -1,
+      render = (_: Node).name
+    )
+    val texts = textsOf(nodes)
+    assert(texts(0) == "▾ src")
+    assert(texts(1) == "    Main.scala", s"expected leaf indented + leaf glyph, got: '${texts(1)}'")
+    assert(texts(2) == "  ▸ util")
+    assert(texts(3) == "  README.md")
+  }
+
+  test("ASCII fallback uses v / > / `  ` markers") {
+    val nodes = Tree(
+      roots = sampleTree,
+      expanded = Set("src"),
+      selectedIndex = -1,
+      render = (_: Node).name,
+      unicode = false
+    )
+    val texts = textsOf(nodes)
+    assert(texts(0).startsWith("v src"))
+    assert(texts(2).contains("> util"), s"got: '${texts(2)}'")
+  }
+
+  test("selectedIndex highlights exactly one row in the theme primary slot") {
+    val nodes = Tree(
+      roots = sampleTree,
+      expanded = Set.empty[String],
+      selectedIndex = 1,
+      render = (_: Node).name
+    )
+    val styles = nodes.map {
+      case TextNode(_, _, runs) => runs.head.style
+      case _                    => fail("expected TextNode")
+    }
+    assert(!styles(0).bold, "non-selected row stays unbold")
+    assert(styles(1).bold, "selected row is bold")
+  }
+
+  test("selectedIndex out of range produces no highlighted rows") {
+    val nodes = Tree(
+      roots = Vector[Node](Leaf("only")),
+      expanded = Set.empty[String],
+      selectedIndex = 99,
+      render = (_: Node).name
+    )
+    nodes.foreach {
+      case TextNode(_, _, runs) => assert(!runs.head.style.bold)
+      case _                    => fail("expected TextNode")
+    }
+  }
+
+  test("rows are positioned at `at` and one row apart") {
+    val nodes = Tree(
+      roots = sampleTree,
+      expanded = Set.empty[String],
+      selectedIndex = -1,
+      render = (_: Node).name,
+      at = Coord(5.x, 9.y)
+    )
+    val ys = nodes.map { case TextNode(_, y, _) => y.value; case _ => fail() }
+    val xs = nodes.map { case TextNode(x, _, _) => x.value; case _ => fail() }
+    assert(ys == List(9, 10))
+    assert(xs.forall(_ == 5))
+  }
+
+  test("custom indentWidth changes the per-level padding") {
+    val nodes = Tree(
+      roots = sampleTree,
+      expanded = Set("src"),
+      selectedIndex = -1,
+      render = (_: Node).name,
+      indentWidth = 4
+    )
+    val texts = textsOf(nodes)
+    // Level 1 nodes (Main.scala, util) should now have 4 spaces of indent.
+    assert(texts(1).startsWith("    "), s"expected 4-space indent, got: '${texts(1)}'")
+  }
+
+  // ---- companions ---------------------------------------------------------
+
+  test("Tree.rowWidth = depth*indent + marker + label") {
+    assert(Tree.rowWidth("name", depth = 0) == 0 + 2 + 4)
+    assert(Tree.rowWidth("name", depth = 2, indentWidth = 4) == 8 + 2 + 4)
+  }


### PR DESCRIPTION
## Summary

Three new first-class widgets plus the showcase integration that demonstrates them visually.

### `Tabs`
- Horizontal single-row tab bar; active cell wrapped in `[ X ]`, inactive in `  X  ` so the shape never shifts on focus or active changes (siblings don't reflow).
- `activeIndex` and `focusedIndex` are independent — a tab can carry focus before the user commits the switch.
- Customisable `separator` (default `\" \"`, supports `\" | \"` or `\"\"` for flush).
- Companion `width(labels, separator)` and `hitTest(labels, separator, colOffset)` helpers for layout and mouse routing — `hitTest` returns `None` on separators and outside the bar.
- **TabsDemoApp** rewritten to use the real widget instead of the bespoke string render. Goldens refreshed to match the slightly wider `[ N:Name ]` cells.

### `LogView`
- Append-only viewer with viewport scrolling; `scrollOffset` is in display lines from the tail — `0` keeps the latest line pinned (the live-feed convention).
- `wrap = true` (default) wraps long lines; `wrap = false` truncates with `…`.
- Returns `List[VNode]` so it composes inside `Layout.column` without an extra wrapper.
- Public companions for the wrap / viewport math: `wrapLine`, `truncateLine`, `expand`, `viewport`, `displayLineCount`, `maxScroll`. Apps pre-compute display lines once per buffer change.

### `Tree[A]`
- Generic recursive tree widget. Apps describe their own tree shape via a `Tree.Children[A, Id]` type-class — the widget never owns a Node ADT.
- Renders one row per visible node with per-depth indentation and `▾` / `▸` chevrons (ASCII `v` / `>` fallback).
- `expanded: Set[Id]` controls which subtrees are open; `selectedIndex` is a visible-row offset highlighted in the theme primary slot.
- Public `visibleRows(roots, expanded)` walks the structure so apps can map mouse rows back to nodes outside the widget.

### Showcase wiring
- New static **Tabs bar at row 2** above the panels (`Stage 1 ✓ / Stage 2 ✓ / Stage 3 ◆`) using the real Tabs widget.
- Live-input panel converted from a single \"Most recent event\" line to a **5-row LogView** of rolling event history (capped at 50 events).
- 3 new showcase tests pin the new visual integration.

### Roadmap

§6.2 status table updated:
- Tabs / LogView / Tree → done
- `Select` already covers the closed-ComboBox case (since 0.2)
- Autocomplete, Menu / MenuBar, Form builder, SplitPane → not started

## Test plan

- [x] `sbt ciCheck` — scalafmt + scalafix + tests
- [x] **664 total tests pass**
  - 39 new widget tests (8 Tabs + 20 LogView + 11 Tree)
  - 3 new showcase tests
- [x] `TabsDemoApp` goldens refreshed; snapshot tests pass

## Notes

Branched off main. PRs #168 (mouse polish) and #169 (CheckBox / RadioGroup) are still open in parallel; this PR doesn't touch the same widget files, so a clean rebase is straightforward when those merge.