### PR TITLE
feat: SplitPane + Form + MenuBar + Autocomplete (Stage 3 §6.2 complete)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -424,16 +424,20 @@ The five shipped helpers cover the everyday cases. All five are
 exercised by `sbt showcase` (`d` = confirm, `i` = textInput, `l` =
 listSelect, `w` = waiting). Tests live in `DialogsSpec`.
 
-### 6.2 Additional widgets (P1, medium)
+### 6.2 Additional widgets (P1, medium) — **complete**
 
-- `CheckBox`, `RadioGroup`
-- `ComboBox` (closed) and `Autocomplete` (open)
-- `Tree[A]`
-- `Tabs` widget (we have a sample demo of this — promote to first-class)
-- `Menu` / `MenuBar` with chord support
-- `Form` builder — declarative composition of fields + validation
-- `SplitPane` (horizontal / vertical, resizable via mouse drag)
-- `LogView` — efficient append-only buffer with scrollback
+| Widget | Status |
+|---|---|
+| `CheckBox` | done (PR #169) — `☒` / `☐` glyphs with ASCII fallback. |
+| `RadioGroup` | done (PR #169) — `◉` / `○` markers; selected and focused are independent. |
+| `Tabs` | done (PR #170) — horizontal bar with `[ X ]` active cell; companion `width` + `hitTest`. |
+| `LogView` | done (PR #170) — append-only viewer with viewport scrolling; pure helpers (`wrapLine` / `viewport` / `maxScroll`) for hit-test math. |
+| `Tree[A]` | done (PR #170) — generic recursive tree via `Tree.Children[A, Id]` type-class; `▾` / `▸` chevrons + per-depth indent; companion `visibleRows` for hit-testing outside the widget. |
+| `ComboBox` (closed) | already shipped as `Select` since 0.2. |
+| `Autocomplete` (open) | done (PR #171) — `State[A]` holds input + options + selectedIdx; pluggable `matches` predicate; companion `handleKey` returns `(state, picked: Option[A])`. |
+| `Menu` / `MenuBar` | done (PR #171) — horizontal title bar + on-demand dropdown; pure `handleKey` dispatcher returns picked `(menuIdx, itemIdx)`; companion `hitTest` maps clicks to title cells or dropdown rows. |
+| `Form` builder | done (PR #171) — declarative `Vector[Form.Row]` of (id, label, widget render fn); pairs with `FocusManager` for navigation; per-row `errors: Map[FocusId, String]` annotations. |
+| `SplitPane` | done (PR #171) — horizontal / vertical two-pane layout at a configurable ratio; renderer callbacks receive resolved `(at, w, h)`. Drag-to-resize deferred to the mouse hit-test cache follow-up; companion `dividerRect` exposes the drag region for apps that want to wire it manually now. |
 
 ### 6.3 Keymap framework (P1, small)
 
@@ -615,18 +619,18 @@ mirror this in module layout (§4.6) and docs (§7.2).
 | Label | `TextNode` (implicit) | done |
 | Button | `Button` | done |
 | TextBox | `TextField` (single-line) | done; multi-line in Stage 3 |
-| CheckBox / RadioBoxList | — | Stage 3 |
-| ComboBox | `Select` | done (closed only); open variant Stage 3 |
+| CheckBox / RadioBoxList | `CheckBox` / `RadioGroup` | done (Stage 3 #169) |
+| ComboBox | `Select` (closed) / `Autocomplete` (open) | done |
 | ActionListBox | `ListView` (close enough) | done |
 | Table | `Table` | done |
 | ProgressBar | `ProgressBar` | done |
 | Spinner (AnimatedLabel) | `Spinner` | done |
-| ScrollBar | — | Stage 3 |
-| Separator | — | Stage 3 (trivial) |
-| Tree | — | Stage 3 |
-| SplitPanel | — | Stage 3 |
+| ScrollBar | — | not started |
+| Separator | — | trivial; deferred until a real use case |
+| Tree | `Tree` | done (Stage 3 #170) |
+| SplitPanel | `SplitPane` | done (Stage 3 #171) — drag-resize deferred |
 | Panel | `BoxNode` (close enough) | done |
-| MenuBar | — | Stage 3 |
+| MenuBar | `MenuBar` | done (Stage 3 #171) |
 | StatusBar | `StatusBar` | done — *not in Lanterna* |
 
 ### 9.4 Layout managers

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Autocomplete.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Autocomplete.scala
@@ -1,0 +1,179 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Open ComboBox: a single-line input field with a filtered dropdown
+ * underneath. The user types, the list narrows; Enter commits the
+ * selected item.
+ *
+ * Companion to [[Select]] (closed dropdown). Where Select shows a
+ * collapsed "current value" cell that opens on demand, Autocomplete
+ * is always-open — typing always filters, and the selection lives in
+ * the user's keystrokes.
+ *
+ * Filter strategy is supplied by the caller (`matches`). The default is
+ * case-insensitive `contains`. Apps that want fuzzy / prefix / fuzzy-
+ * weighted matching slot in their own predicate.
+ *
+ * State (input buffer, cursor, selected filtered index, raw option
+ * list) lives in the app's model, like every other widget here. The
+ * companion [[handleKey]] is a pure dispatcher that updates the state
+ * — apps fold it through their own update.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * val initial = Autocomplete.State.of(Vector("apple", "banana", "cherry"))
+ *
+ * // update:
+ * case Msg.Key(k) =>
+ *   val (next, picked) = Autocomplete.handleKey(model.ac, k)
+ *   model.copy(ac = next, lastPick = picked.orElse(model.lastPick)).tui
+ *
+ * // view:
+ * Autocomplete.view(model.ac, width = 24, maxVisible = 6)
+ * }}}
+ */
+object Autocomplete:
+
+  /**
+   * State for one Autocomplete.
+   *
+   * @param input        Current filter text + cursor.
+   * @param options      Full unfiltered options.
+   * @param selectedIdx  Index into the *filtered* list (clamped on
+   *                     every state transition so it always points at
+   *                     a visible row, or `0` when empty).
+   * @param matches      Filter predicate. Defaults to case-insensitive
+   *                     substring match on `option.toString`.
+   * @param render       Display function for an option. Defaults to
+   *                     `_.toString`.
+   */
+  final case class State[A](
+    input: Prompt.State,
+    options: Vector[A],
+    selectedIdx: Int = 0,
+    matches: (String, A) => Boolean = (q: String, a: A) => a.toString.toLowerCase.contains(q.toLowerCase),
+    render: A => String = (a: A) => a.toString
+  ):
+
+    /** Current input string. */
+    def query: String = input.buffer.mkString
+
+    /** Filtered, in-order subset of `options` that matches the query. */
+    def filtered: Vector[A] =
+      if query.isEmpty then options
+      else options.filter(a => matches(query, a))
+
+    /** Currently-selected filtered option (None when filter has no hits). */
+    def selected: Option[A] = filtered.lift(selectedIdx)
+
+    /** Clamp the selected index into the current filtered range. */
+    def clamped: State[A] =
+      val f = filtered
+      if f.isEmpty then copy(selectedIdx = 0)
+      else copy(selectedIdx = math.max(0, math.min(f.size - 1, selectedIdx)))
+
+  object State:
+    /** Build an empty-input state over `options`. */
+    def of[A](options: Vector[A]): State[A] = State(Prompt.State(), options)
+
+  /**
+   * Result of [[handleKey]]: updated state plus an optional "user
+   *  picked this item" event for the app to act on.
+   */
+  final case class KeyResult[A](state: State[A], picked: Option[A])
+
+  /**
+   * Pure key dispatcher. Apps fold their decoded
+   * `KeyDecoder.InputKey` through this. Bindings:
+   *
+   *   - `↑` / `↓`        — move filtered-list cursor (wraps at ends).
+   *   - `Enter`          — commit the current selection. Returns
+   *                        `picked = Some(item)`.
+   *   - any other key    — routed through [[Prompt.handleKey]] so
+   *                        printable characters edit the filter, etc.
+   */
+  def handleKey[A](state: State[A], key: KeyDecoder.InputKey): KeyResult[A] =
+    import KeyDecoder.InputKey.*
+    key match
+      case ArrowDown =>
+        val f = state.filtered
+        if f.isEmpty then KeyResult(state, None)
+        else
+          val next = (state.selectedIdx + 1) % f.size
+          KeyResult(state.copy(selectedIdx = next), None)
+
+      case ArrowUp =>
+        val f = state.filtered
+        if f.isEmpty then KeyResult(state, None)
+        else
+          val next = (state.selectedIdx - 1 + f.size) % f.size
+          KeyResult(state.copy(selectedIdx = next), None)
+
+      case Enter =>
+        KeyResult(state, state.selected)
+
+      case _ =>
+        // Route everything else through Prompt; reset selection to top
+        // when the input changes so the user doesn't keep an old index
+        // pointing into a now-empty filtered list.
+        val (nextInput, _) = Prompt.handleKey[Unit](state.input, key)(_ => Right(()))
+        val nextState =
+          if nextInput == state.input then state
+          else state.copy(input = nextInput, selectedIdx = 0)
+        KeyResult(nextState.clamped, None)
+
+  /**
+   * Render the input field on the first row plus the filtered list
+   * underneath (up to `maxVisible` rows). Returns:
+   *
+   *   - one [[InputNode]] for the prompt, plus
+   *   - one [[TextNode]] per visible filtered option.
+   *
+   * The InputNode's `cursor` reflects the current `Prompt.State.cursor`
+   * so the runtime parks the hardware cursor inside the field.
+   *
+   * @param state      The Autocomplete state.
+   * @param width      Cell width of the input field + dropdown.
+   * @param maxVisible Maximum dropdown rows. Defaults to 6.
+   * @param at         Top-left of the input field row.
+   * @param prefix     Optional fixed prefix (e.g. `"> "`) pinned to
+   *                   the left edge of the input viewport.
+   */
+  def view[A](
+    state: State[A],
+    width: Int,
+    maxVisible: Int = 6,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    prefix: String = ""
+  )(using theme: Theme): List[VNode] =
+    val rendered = Prompt.renderWithPrefix(state.input, prefix)
+    val inputNode = VNode.InputNode(
+      x = at.x,
+      y = at.y,
+      prompt = rendered.text,
+      style = Style(fg = theme.foreground, bg = theme.background),
+      cursor = rendered.cursorIndex,
+      lineWidth = math.max(1, width),
+      prefixLength = rendered.prefixLength
+    )
+    val visible = state.filtered.take(maxVisible)
+    val rows = visible.zipWithIndex.toList.map { case (item, i) =>
+      val isSelected = i == state.selectedIdx
+      val style =
+        if isSelected then Style(fg = theme.background, bg = theme.primary, bold = true)
+        else Style(fg = theme.foreground)
+      val marker = if isSelected then "▸ " else "  "
+      val label  = state.render(item)
+      val padded = s"$marker$label".take(math.max(1, width))
+      TextNode(at.x, at.y + (1 + i), List(Text(padded, style)))
+    }
+    inputNode :: rows
+
+  /**
+   * Total cell height the widget will take given `maxVisible`. The
+   *  filtered-list portion shrinks to the actual visible count.
+   */
+  def height(state: State[?], maxVisible: Int = 6): Int =
+    1 + math.min(maxVisible, state.filtered.size)

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/Form.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/Form.scala
@@ -1,0 +1,122 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+/**
+ * Declarative form layout — a vertical column of labelled rows where
+ * each row hosts an arbitrary widget that renders itself based on
+ * whether it currently owns focus.
+ *
+ * Form is presentation-only. Apps own the field state (the current
+ * value of each text field, checkbox, button, …) and a
+ * [[FocusManager]] that tracks which row owns focus. Form lays out
+ * the labels + widgets and asks each row's render callback to produce
+ * its `VNode`, passing the focused boolean so the widget renders the
+ * appropriate visual.
+ *
+ * Validation is also app-side: apps decide on submit (typically when a
+ * specific button row is activated) whether the field state is valid
+ * and what to do next. The `errors` parameter just controls per-row
+ * error messages drawn beneath each row.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * val NameId  = FocusId("name")
+ * val AgreeId = FocusId("agree")
+ * val SaveId  = FocusId("save")
+ *
+ * Form.column(
+ *   rows = Vector(
+ *     Form.Row(NameId, "Name:",  focused => widgets.Button(label = nameValue, focused = focused)),
+ *     Form.Row(AgreeId, "Agree:", focused => widgets.CheckBox("I accept", agree, focused)),
+ *     Form.Row(SaveId, "",       focused => widgets.Button("Save", focused))
+ *   ),
+ *   focusManager = model.fm,
+ *   at           = Coord(2.x, 4.y)
+ * )
+ * }}}
+ *
+ * @param id      Stable [[FocusId]] for the row — passed to the
+ *                FocusManager for navigation.
+ * @param label   Label rendered to the left of the widget. Empty
+ *                string yields no label cell, just the widget.
+ * @param widget  Render callback receiving `focused: Boolean` and
+ *                returning the row's `VNode`.
+ * @param height  Cell height the row will occupy. Defaults to `1`.
+ */
+object Form:
+
+  final case class Row(
+    id: FocusId,
+    label: String,
+    widget: Boolean => VNode,
+    height: Int = 1
+  )
+
+  /**
+   * Lay out a column of [[Row]]s. Returns one or more `VNode`s per row
+   * (label TextNode + widget VNode), positioned vertically starting at
+   * `at`.
+   *
+   * @param rows         The rows to render.
+   * @param focusManager Source of "is row N focused?".
+   * @param at           Top-left of the first row.
+   * @param labelWidth   Cells reserved for the left-hand label column.
+   *                     Each label is right-padded to this width so the
+   *                     widget column lines up. Set to `0` to omit the
+   *                     label column entirely.
+   * @param gap          Blank rows between fields. Defaults to `0`.
+   * @param errors       Optional per-row error messages keyed by
+   *                     [[FocusId.value]]. Drawn one row below the
+   *                     field in the theme's `error` slot, padding the
+   *                     row's effective height by 1.
+   */
+  def column(
+    rows: Vector[Row],
+    focusManager: FocusManager,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    labelWidth: Int = 12,
+    gap: Int = 0,
+    errors: Map[String, String] = Map.empty
+  )(using theme: Theme): List[VNode] =
+    val builder = List.newBuilder[VNode]
+    var row     = at.y.value
+    rows.foreach { r =>
+      val focused    = focusManager.isFocused(r.id)
+      val labelStyle = Style(fg = if focused then theme.primary else theme.foreground, bold = focused)
+      // Label column. Skipped when labelWidth = 0 or label is empty.
+      if labelWidth > 0 && r.label.nonEmpty then
+        val padded = r.label.padTo(labelWidth, ' ').take(labelWidth)
+        builder += TextNode(at.x, row.y, List(Text(padded, labelStyle)))
+      // Widget rendered at (at.x + labelWidth, row).
+      val widgetCol = if labelWidth > 0 then at.x + labelWidth else at.x
+      val widget    = r.widget(focused)
+      builder += Layout.translate(widget, dx = widgetCol.value - 1, dy = row - 1)
+
+      // Inline error row (one cell below the field) when present.
+      errors.get(r.id.value).foreach { msg =>
+        val errRow = row + r.height
+        builder += TextNode(at.x, errRow.y, List(Text(s"  $msg", Style(fg = theme.error))))
+      }
+
+      val errPad = if errors.contains(r.id.value) then 1 else 0
+      row = row + r.height + errPad + gap
+    }
+    builder.result()
+
+  /**
+   * Total height the form will occupy with the given rows + gap +
+   * error annotations. Useful for sizing a containing panel.
+   */
+  def totalHeight(
+    rows: Vector[Row],
+    gap: Int = 0,
+    errors: Map[String, String] = Map.empty
+  ): Int =
+    if rows.isEmpty then 0
+    else
+      val sum    = rows.map(_.height).sum
+      val errPad = rows.count(r => errors.contains(r.id.value))
+      val gapPad = (rows.size - 1) * gap
+      sum + errPad + gapPad

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/MenuBar.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/MenuBar.scala
@@ -1,0 +1,226 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Horizontal menu bar with optional dropdowns.
+ *
+ * Renders a single row of menu titles. When a menu is "open" the bar
+ * also draws its dropdown rows directly beneath the title. Apps drive
+ * navigation by updating [[MenuBar.State]] in their model — Form
+ * doesn't own a key dispatcher; instead it ships a [[handleKey]]
+ * helper that can be wired into the app's update.
+ *
+ * ## State model
+ *
+ *   - `menus: Vector[Menu]`  — the bar itself.
+ *   - `openIdx: Option[Int]` — index of the currently-open menu
+ *     (`None` = bar is collapsed).
+ *   - `cursor: Int`          — highlighted menu (when bar has focus
+ *     but nothing is open) OR highlighted item inside the open menu.
+ *
+ * The same `cursor` field doubles as both meanings depending on
+ * `openIdx` — cleanest from the model side, the widget interprets it
+ * appropriately when rendering.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * val initial = MenuBar.State(
+ *   menus = Vector(
+ *     MenuBar.Menu("File", Vector("New", "Open…", "Save", "Quit")),
+ *     MenuBar.Menu("Edit", Vector("Cut", "Copy", "Paste"))
+ *   )
+ * )
+ * }}}
+ */
+object MenuBar:
+
+  /** A single menu — a title plus its dropdown items. */
+  final case class Menu(title: String, items: Vector[String])
+
+  /** State for the bar. */
+  final case class State(
+    menus: Vector[Menu],
+    openIdx: Option[Int] = None,
+    cursor: Int = 0
+  ):
+    /** The currently-open menu, if any. */
+    def openMenu: Option[Menu] = openIdx.flatMap(menus.lift)
+
+    /** True when no menu is open and `cursor` selects the menu title row. */
+    def barFocused: Boolean = openIdx.isEmpty
+
+    /** True when `idx` is the currently-open menu. */
+    def isOpen(idx: Int): Boolean = openIdx.contains(idx)
+
+  /**
+   * Result of [[handleKey]]: the updated state plus an optional
+   *  "the user picked this item" event for the app to act on.
+   */
+  final case class KeyResult(state: State, picked: Option[(Int, Int)])
+
+  /**
+   * Pure key dispatcher. Apps fold their decoded `KeyDecoder.InputKey`
+   * through this to advance the bar's state.
+   *
+   * Bindings:
+   *   - `←` / `→`        — move cursor between menu titles (or close
+   *                        the open menu and move to the next/prev one)
+   *   - `↑` / `↓`        — when a menu is open, move the item cursor;
+   *                        when collapsed, opens the cursor menu (↓)
+   *                        or the previous menu (↑) — symmetry with
+   *                        most modal UIs.
+   *   - `Enter` / Space  — open the cursor menu, or pick the cursor
+   *                        item when a menu is open.
+   *   - `Esc`            — close the open menu (or no-op when bar is
+   *                        already collapsed).
+   *   - any other key    — leave state alone.
+   */
+  def handleKey(state: State, key: KeyDecoder.InputKey): KeyResult =
+    if state.menus.isEmpty then KeyResult(state, None)
+    else
+      import KeyDecoder.InputKey.*
+      key match
+        case ArrowLeft =>
+          // Open menu: close + move cursor left + reopen for symmetry.
+          val nextIdx = (state.cursor - 1 + state.menus.size) % state.menus.size
+          val nextOpen =
+            if state.openIdx.isDefined then Some(nextIdx) else None
+          KeyResult(state.copy(cursor = nextIdx, openIdx = nextOpen), None)
+
+        case ArrowRight =>
+          val nextIdx = (state.cursor + 1) % state.menus.size
+          val nextOpen =
+            if state.openIdx.isDefined then Some(nextIdx) else None
+          KeyResult(state.copy(cursor = nextIdx, openIdx = nextOpen), None)
+
+        case ArrowDown =>
+          state.openMenu match
+            case Some(menu) if menu.items.nonEmpty =>
+              val nextItem = (state.cursor + 1) % menu.items.size
+              KeyResult(state.copy(cursor = nextItem), None)
+            case _ =>
+              // Collapsed: open the menu under cursor at item 0.
+              KeyResult(state.copy(openIdx = Some(state.cursor), cursor = 0), None)
+
+        case ArrowUp =>
+          state.openMenu match
+            case Some(menu) if menu.items.nonEmpty =>
+              val nextItem = (state.cursor - 1 + menu.items.size) % menu.items.size
+              KeyResult(state.copy(cursor = nextItem), None)
+            case _ =>
+              KeyResult(state.copy(openIdx = Some(state.cursor), cursor = 0), None)
+
+        case Enter | CharKey(' ') =>
+          state.openMenu match
+            case Some(menu) if menu.items.nonEmpty =>
+              KeyResult(
+                state.copy(openIdx = None, cursor = state.openIdx.getOrElse(0)),
+                Some((state.openIdx.get, state.cursor))
+              )
+            case _ =>
+              KeyResult(state.copy(openIdx = Some(state.cursor), cursor = 0), None)
+
+        case Escape =>
+          if state.openIdx.isDefined then
+            KeyResult(state.copy(openIdx = None, cursor = state.openIdx.getOrElse(0)), None)
+          else KeyResult(state, None)
+
+        case _ => KeyResult(state, None)
+
+  /**
+   * Render the bar (and the open dropdown, if any).
+   *
+   * @param state   The bar state.
+   * @param at      Top-left of the menu-title row.
+   * @param focused Whether the bar itself owns focus (controls colour
+   *                of the cursor menu when no dropdown is open).
+   */
+  def apply(
+    state: State,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    focused: Boolean = true
+  )(using theme: Theme): List[VNode] =
+    val titleSegments: List[Text] =
+      state.menus.zipWithIndex.toList.flatMap { case (menu, i) =>
+        val isCursor  = focused && state.openIdx.isEmpty && i == state.cursor
+        val isOpen    = state.isOpen(i)
+        val highlight = isCursor || isOpen
+        val fg        = if highlight then theme.primary else theme.foreground
+        val bold      = highlight
+        val opener    = if isOpen then "[ " else "  "
+        val closer    = if isOpen then " ]" else "  "
+        val cell      = Text(s"$opener${menu.title}$closer", Style(fg = fg, bold = bold))
+        if i == state.menus.size - 1 then List(cell)
+        else List(cell, Text(" ", Style(fg = theme.border)))
+      }
+
+    val barNode = TextNode(at.x, at.y, titleSegments)
+
+    state.openIdx match
+      case None => List(barNode)
+      case Some(idx) =>
+        val menu = state.menus(idx)
+        val left = titleStartCol(state, idx)
+        val itemNodes = menu.items.zipWithIndex.toList.map { case (item, j) =>
+          val sel = j == state.cursor
+          val style =
+            if sel then Style(fg = theme.background, bg = theme.primary, bold = true)
+            else Style(fg = theme.foreground)
+          val padded = item.padTo(menu.items.map(_.length).max + 2, ' ')
+          TextNode(at.x + (left - 1), at.y + (1 + j), List(Text(padded, style)))
+        }
+        barNode :: itemNodes
+
+  /**
+   * Map a click `(col, row)` to a hit on either the menu titles or the
+   * open dropdown. Returns:
+   *
+   *   - `Some(Left(menuIdx))`      — click on a menu title cell.
+   *   - `Some(Right(itemIdx))`     — click on a row of the open dropdown.
+   *   - `None`                     — click outside.
+   */
+  def hitTest(
+    state: State,
+    at: Coord,
+    col: Int,
+    row: Int
+  ): Option[Either[Int, Int]] =
+    if row == at.y.value then
+      // Title row.
+      hitTestTitles(state, at.x.value, col).map(Left.apply)
+    else
+      state.openIdx match
+        case Some(idx) =>
+          val menu    = state.menus(idx)
+          val left    = at.x.value + titleStartCol(state, idx) - 1
+          val width   = menu.items.map(_.length).max + 2
+          val itemRow = row - (at.y.value + 1)
+          if itemRow < 0 || itemRow >= menu.items.size then None
+          else if col < left || col >= left + width then None
+          else Some(Right(itemRow))
+        case None => None
+
+  /**
+   * Column offset (1-based, relative to `at.x`) where the title cell
+   *  for `menuIdx` begins. Mirrors the rendering layout.
+   */
+  private def titleStartCol(state: State, menuIdx: Int): Int =
+    var col = 1
+    var i   = 0
+    while i < menuIdx do
+      val cellWidth = state.menus(i).title.length + 4 + 1 // "[ X ]" plus separator
+      col += cellWidth
+      i += 1
+    col
+
+  /** Hit-test for the title row. */
+  private def hitTestTitles(state: State, baseCol: Int, clickCol: Int): Option[Int] =
+    var col = baseCol
+    var i   = 0
+    while i < state.menus.size do
+      val cellWidth = state.menus(i).title.length + 4
+      if clickCol >= col && clickCol < col + cellWidth then return Some(i)
+      col += cellWidth + 1 // + separator
+      i += 1
+    None

--- a/modules/termflow/src/main/scala/termflow/tui/widgets/SplitPane.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/widgets/SplitPane.scala
@@ -1,0 +1,143 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Two-pane layout helper.
+ *
+ * Splits a rectangular region into two panes side-by-side
+ * ([[Direction.Horizontal]]) or stacked ([[Direction.Vertical]]) at a
+ * configurable `splitRatio`. Apps supply two render functions that
+ * receive the resolved `(at, width, height)` of their pane and return
+ * the `VNode`s to draw into it.
+ *
+ * Mouse-drag to resize the divider is not yet implemented — that needs
+ * the layout-pass hit-test cache (deferred to Stage 3 mouse follow-up).
+ * Until then apps drive `splitRatio` via their own keymap (or simply
+ * leave it fixed). Scaffolding for the divider rect is exposed via
+ * [[dividerRect]] so apps that want to wire mouse drag themselves can.
+ *
+ * {{{
+ * given Theme = Theme.dark
+ *
+ * SplitPane(
+ *   direction  = SplitPane.Direction.Horizontal,
+ *   width      = 80,
+ *   height     = 24,
+ *   splitRatio = 0.4,
+ *   first      = (at, w, h) => leftPane(at, w, h),
+ *   second     = (at, w, h) => rightPane(at, w, h)
+ * )
+ * }}}
+ *
+ * @param first      Renderer for the first pane (left or top).
+ * @param second     Renderer for the second pane (right or bottom).
+ * @param width      Total cell width of the splittable region.
+ * @param height     Total cell height of the splittable region.
+ * @param direction  [[Direction.Horizontal]] (side-by-side) or
+ *                   [[Direction.Vertical]] (stacked). Default horizontal.
+ * @param at         Top-left cell of the region. Defaults to `(1, 1)`.
+ * @param splitRatio Fraction of the major axis allocated to the first
+ *                   pane, clamped to `[minSizeRatio, 1 - minSizeRatio]`.
+ *                   Defaults to `0.5`.
+ * @param gap        Cells reserved between the two panes for the
+ *                   divider. `0` means flush.
+ */
+object SplitPane:
+
+  /** Direction of the split. */
+  enum Direction:
+    case Horizontal // first | second
+    case Vertical   // first
+    // ─────
+    // second
+
+  /**
+   * Both panes are guaranteed to be at least this fraction of the
+   *  major axis. Stops `splitRatio = 0.0 / 1.0` from collapsing one
+   *  pane to nothing.
+   */
+  val MinSizeRatio: Double = 0.05
+
+  /**
+   * A pane's resolved rectangle. Returned from [[layout]] for apps
+   *  that want to compute hit-tests outside the widget.
+   */
+  final case class Pane(at: Coord, width: Int, height: Int)
+
+  /**
+   * First / second / divider rectangles for the given configuration.
+   *  Pure — no rendering side-effects.
+   */
+  final case class Layout(first: Pane, second: Pane, divider: Option[Pane])
+
+  /**
+   * Resolve the split into pane rectangles. Apps that need to map
+   * mouse coordinates to a pane (or to the divider for drag-resize)
+   * call this once per frame and reuse the result.
+   */
+  def layout(
+    direction: Direction,
+    width: Int,
+    height: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    splitRatio: Double = 0.5,
+    gap: Int = 0
+  ): Layout =
+    val major =
+      if direction == Direction.Horizontal then math.max(0, width)
+      else math.max(0, height)
+    val gapClamped = math.max(0, math.min(gap, math.max(0, major - 2)))
+    val available  = math.max(0, major - gapClamped)
+    val ratio      = math.max(MinSizeRatio, math.min(1.0 - MinSizeRatio, splitRatio))
+    val firstSize  = math.max(1, (available * ratio).round.toInt)
+    val secondSize = math.max(1, available - firstSize)
+
+    direction match
+      case Direction.Horizontal =>
+        val firstPane   = Pane(at, firstSize, height)
+        val dividerPane = if gapClamped > 0 then Some(Pane(at + (firstSize, 0), gapClamped, height)) else None
+        val secondAt    = at + (firstSize + gapClamped, 0)
+        val secondPane  = Pane(secondAt, secondSize, height)
+        Layout(firstPane, secondPane, dividerPane)
+      case Direction.Vertical =>
+        val firstPane   = Pane(at, width, firstSize)
+        val dividerPane = if gapClamped > 0 then Some(Pane(at + (0, firstSize), width, gapClamped)) else None
+        val secondAt    = at + (0, firstSize + gapClamped)
+        val secondPane  = Pane(secondAt, width, secondSize)
+        Layout(firstPane, secondPane, dividerPane)
+
+  /**
+   * Resolved divider rectangle, if `gap > 0`. Convenience for callers
+   *  that only care about the drag region.
+   */
+  def dividerRect(
+    direction: Direction,
+    width: Int,
+    height: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    splitRatio: Double = 0.5,
+    gap: Int = 0
+  ): Option[Pane] =
+    layout(direction, width, height, at, splitRatio, gap).divider
+
+  /**
+   * Render both panes. The renderer functions are called with the
+   * resolved `(at, width, height)` of their pane.
+   */
+  def apply(
+    first: (Coord, Int, Int) => List[VNode],
+    second: (Coord, Int, Int) => List[VNode],
+    width: Int,
+    height: Int,
+    direction: Direction = Direction.Horizontal,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    splitRatio: Double = 0.5,
+    gap: Int = 0
+  ): List[VNode] =
+    val l = layout(direction, width, height, at, splitRatio, gap)
+    first(l.first.at, l.first.width, l.first.height) ++
+      second(l.second.at, l.second.width, l.second.height)
+
+  // Coord arithmetic for the local layout math.
+  extension (c: Coord) private def +(d: (Int, Int)): Coord = Coord(c.x + d._1, c.y + d._2)

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/AutocompleteSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/AutocompleteSpec.scala
@@ -1,0 +1,98 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class AutocompleteSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private val initial = Autocomplete.State.of(Vector("apple", "banana", "cherry", "blueberry"))
+
+  // ---- filtered + selected ------------------------------------------------
+
+  test("empty query returns all options in order") {
+    assert(initial.filtered == Vector("apple", "banana", "cherry", "blueberry"))
+  }
+
+  test("filtered uses case-insensitive contains by default") {
+    val withQuery = initial.copy(input = Prompt.State("BAN".toVector, cursor = 3))
+    assert(withQuery.filtered == Vector("banana"))
+  }
+
+  test("custom matches predicate is honoured") {
+    val state = initial.copy(
+      input = Prompt.State("a".toVector, cursor = 1),
+      matches = (q, a) => a.startsWith(q)
+    )
+    assert(state.filtered == Vector("apple"), s"prefix-match should pick only apple, got ${state.filtered}")
+  }
+
+  test("clamped resets selectedIdx into the visible range") {
+    val state   = initial.copy(input = Prompt.State("ber".toVector, cursor = 3), selectedIdx = 99)
+    val clamped = state.clamped
+    assert(clamped.selectedIdx == 0, "out-of-range index clamped down")
+    assert(clamped.selected == Some("blueberry"))
+  }
+
+  // ---- handleKey ----------------------------------------------------------
+
+  test("typing a printable key narrows the filter and resets selectedIdx") {
+    val r = Autocomplete.handleKey(initial.copy(selectedIdx = 3), KeyDecoder.InputKey.CharKey('b'))
+    assert(r.state.query == "b")
+    assert(r.state.selectedIdx == 0, "filter change must reset cursor to top")
+    assert(r.state.filtered == Vector("banana", "blueberry"))
+  }
+
+  test("ArrowDown moves the selection (wraps)") {
+    val r1 = Autocomplete.handleKey(initial, KeyDecoder.InputKey.ArrowDown)
+    assert(r1.state.selectedIdx == 1)
+    // From idx 3 (last) wraps to 0.
+    val r2 = Autocomplete.handleKey(initial.copy(selectedIdx = 3), KeyDecoder.InputKey.ArrowDown)
+    assert(r2.state.selectedIdx == 0)
+  }
+
+  test("ArrowUp wraps to the bottom from idx 0") {
+    val r = Autocomplete.handleKey(initial, KeyDecoder.InputKey.ArrowUp)
+    assert(r.state.selectedIdx == 3)
+  }
+
+  test("Enter returns picked = Some(currentSelected)") {
+    val r = Autocomplete.handleKey(initial.copy(selectedIdx = 2), KeyDecoder.InputKey.Enter)
+    assert(r.picked == Some("cherry"))
+  }
+
+  test("Enter when filter has no matches returns picked = None") {
+    val empty = initial.copy(input = Prompt.State("xyz".toVector, cursor = 3))
+    val r     = Autocomplete.handleKey(empty, KeyDecoder.InputKey.Enter)
+    assert(r.picked.isEmpty)
+  }
+
+  test("Backspace narrows the input through Prompt and re-clamps the selection") {
+    val state = initial.copy(input = Prompt.State("be".toVector, cursor = 2), selectedIdx = 0)
+    val r     = Autocomplete.handleKey(state, KeyDecoder.InputKey.Backspace)
+    assert(r.state.query == "b")
+    assert(r.state.selectedIdx == 0)
+  }
+
+  // ---- view ---------------------------------------------------------------
+
+  test("view emits an InputNode + one row per visible filtered option") {
+    val nodes = Autocomplete.view(initial, width = 16, maxVisible = 6)
+    assert(nodes.head.isInstanceOf[VNode.InputNode], "first node must be the InputNode")
+    assert(nodes.tail.size == 4, "all 4 items fit under maxVisible = 6")
+  }
+
+  test("view truncates the dropdown to maxVisible rows") {
+    val many  = Autocomplete.State.of((1 to 20).map(i => s"item-$i").toVector)
+    val nodes = Autocomplete.view(many, width = 12, maxVisible = 5)
+    assert(nodes.tail.size == 5)
+  }
+
+  test("Autocomplete.height = 1 + min(maxVisible, filtered.size)") {
+    assert(Autocomplete.height(initial, maxVisible = 6) == 1 + 4)
+    assert(Autocomplete.height(initial, maxVisible = 2) == 1 + 2)
+    val empty = initial.copy(input = Prompt.State("xyz".toVector, cursor = 3))
+    assert(Autocomplete.height(empty, maxVisible = 6) == 1)
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/FormSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/FormSpec.scala
@@ -1,0 +1,74 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class FormSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private val NameId = FocusId("name")
+  private val OkId   = FocusId("ok")
+  private val NoteId = FocusId("note")
+
+  private val sampleRows: Vector[Form.Row] = Vector(
+    Form.Row(NameId, "Name:", focused => Button("Alice", focused)),
+    Form.Row(OkId, "Agree:", focused => Button("OK", focused)),
+    Form.Row(NoteId, "", focused => Button("Save", focused))
+  )
+
+  // ---- column rendering ---------------------------------------------------
+
+  test("column renders a label TextNode + widget VNode for each row") {
+    val fm    = FocusManager(Vector(NameId, OkId, NoteId))
+    val nodes = Form.column(sampleRows, fm)
+    // 3 rows with labels for the first two: 2 label + 3 widget = 5 nodes.
+    assert(nodes.size == 5, s"expected 5 nodes, got ${nodes.size}")
+  }
+
+  test("rows with empty label produce only a widget node") {
+    val fm    = FocusManager(Vector(NoteId))
+    val rows  = Vector(Form.Row(NoteId, "", focused => Button("Save", focused)))
+    val nodes = Form.column(rows, fm)
+    assert(nodes.size == 1)
+  }
+
+  test("rows are positioned vertically with the configured gap") {
+    val fm    = FocusManager(Vector(NameId, OkId, NoteId))
+    val nodes = Form.column(sampleRows, fm, at = Coord(2.x, 5.y), gap = 1)
+    val ys    = nodes.collect { case TextNode(_, y, _) => y.value }
+    // The label TextNodes should be at y=5 (Name) and y=7 (Agree, after gap of 1).
+    assert(ys.contains(5))
+    assert(ys.contains(7))
+  }
+
+  test("focused row's widget receives focused = true") {
+    val fm                            = FocusManager(Vector(NameId, OkId, NoteId), current = Some(OkId))
+    var seen: Set[(FocusId, Boolean)] = Set.empty
+    val rows = Vector(
+      Form.Row(NameId, "A", focused => { seen += ((NameId, focused)); Button("a", focused) }),
+      Form.Row(OkId, "B", focused => { seen += ((OkId, focused)); Button("b", focused) }),
+      Form.Row(NoteId, "C", focused => { seen += ((NoteId, focused)); Button("c", focused) })
+    )
+    Form.column(rows, fm)
+    assert(seen == Set((NameId, false), (OkId, true), (NoteId, false)))
+  }
+
+  test("error rows are drawn one row beneath the field, in the theme error slot") {
+    val fm     = FocusManager(Vector(NameId))
+    val rows   = Vector(Form.Row(NameId, "Name:", focused => Button("a", focused)))
+    val errors = Map("name" -> "is required")
+    val nodes  = Form.column(rows, fm, errors = errors)
+    val errNode = nodes.collectFirst {
+      case TextNode(_, _, runs) if runs.exists(_.txt.contains("is required")) => runs.head
+    }
+    assert(errNode.isDefined, "expected an error TextNode")
+  }
+
+  test("totalHeight sums row heights, gaps, and error annotations") {
+    assert(Form.totalHeight(sampleRows) == 3) // 3 rows of height 1, no gap, no errors
+    assert(Form.totalHeight(sampleRows, gap = 1) == 5)
+    assert(Form.totalHeight(sampleRows, errors = Map("name" -> "x")) == 4)
+    assert(Form.totalHeight(Vector.empty[Form.Row]) == 0)
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/MenuBarSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/MenuBarSpec.scala
@@ -1,0 +1,120 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class MenuBarSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private val sample = MenuBar.State(
+    menus = Vector(
+      MenuBar.Menu("File", Vector("New", "Open", "Save", "Quit")),
+      MenuBar.Menu("Edit", Vector("Cut", "Copy", "Paste"))
+    )
+  )
+
+  // ---- handleKey ----------------------------------------------------------
+
+  test("ArrowRight on the bar moves the cursor between menus (no menu open)") {
+    val a = MenuBar.handleKey(sample, KeyDecoder.InputKey.ArrowRight)
+    assert(a.state.cursor == 1)
+    assert(a.state.openIdx.isEmpty)
+    val b = MenuBar.handleKey(a.state, KeyDecoder.InputKey.ArrowRight)
+    assert(b.state.cursor == 0, "wrap around to first menu")
+  }
+
+  test("ArrowDown when nothing is open opens the cursor menu at item 0") {
+    val r = MenuBar.handleKey(sample, KeyDecoder.InputKey.ArrowDown)
+    assert(r.state.openIdx.contains(0))
+    assert(r.state.cursor == 0)
+  }
+
+  test("ArrowDown inside an open menu moves the item cursor (wraps)") {
+    val opened = sample.copy(openIdx = Some(0), cursor = 0)
+    val a      = MenuBar.handleKey(opened, KeyDecoder.InputKey.ArrowDown)
+    assert(a.state.cursor == 1)
+    val n = MenuBar.handleKey(opened.copy(cursor = 3), KeyDecoder.InputKey.ArrowDown)
+    assert(n.state.cursor == 0, "wrap from last back to first")
+  }
+
+  test("ArrowLeft / ArrowRight inside an open menu moves to the next menu and reopens") {
+    val opened = sample.copy(openIdx = Some(0), cursor = 2)
+    val r      = MenuBar.handleKey(opened, KeyDecoder.InputKey.ArrowRight)
+    assert(r.state.openIdx.contains(1), "moving sideways should re-open the new menu")
+    assert(r.state.cursor == 1)
+  }
+
+  test("Enter inside an open menu picks the highlighted item and closes the menu") {
+    val opened = sample.copy(openIdx = Some(1), cursor = 2)
+    val r      = MenuBar.handleKey(opened, KeyDecoder.InputKey.Enter)
+    assert(r.picked == Some((1, 2)))
+    assert(r.state.openIdx.isEmpty)
+  }
+
+  test("Escape closes the open menu and parks the cursor on its title") {
+    val opened = sample.copy(openIdx = Some(1), cursor = 2)
+    val r      = MenuBar.handleKey(opened, KeyDecoder.InputKey.Escape)
+    assert(r.state.openIdx.isEmpty)
+    assert(r.state.cursor == 1)
+  }
+
+  test("handleKey on an empty MenuBar is a no-op") {
+    val empty = MenuBar.State(Vector.empty)
+    val r     = MenuBar.handleKey(empty, KeyDecoder.InputKey.ArrowRight)
+    assert(r == MenuBar.KeyResult(empty, None))
+  }
+
+  // ---- view ---------------------------------------------------------------
+
+  test("apply renders the title row only when no menu is open") {
+    val nodes = MenuBar(sample)
+    assert(nodes.size == 1)
+    nodes.head match
+      case TextNode(_, _, runs) =>
+        val s = runs.map(_.txt).mkString
+        assert(s.contains("File"))
+        assert(s.contains("Edit"))
+      case _ => fail()
+  }
+
+  test("apply renders the dropdown rows when a menu is open") {
+    val opened = sample.copy(openIdx = Some(0), cursor = 1)
+    val nodes  = MenuBar(opened)
+    // 1 title row + 4 item rows for File menu = 5 nodes.
+    assert(nodes.size == 5, s"expected 5 nodes for opened File menu, got ${nodes.size}")
+  }
+
+  test("the cursor item in an open menu is rendered with the primary background") {
+    val opened = sample.copy(openIdx = Some(0), cursor = 2) // "Save" is selected
+    val nodes  = MenuBar(opened)
+    val saveRow = nodes.collectFirst {
+      case TextNode(_, _, runs) if runs.exists(_.txt.contains("Save")) => runs.head
+    }
+    assert(saveRow.exists(_.style.bold), "selected item must be bold")
+  }
+
+  // ---- hitTest ------------------------------------------------------------
+
+  test("hitTest on a title cell returns Left(menuIdx)") {
+    val at = Coord(1.x, 1.y)
+    // "[ File ]" / "  File  " is 8 cells (4 padding + 4 chars). Title starts at col 1.
+    assert(MenuBar.hitTest(sample, at, col = 1, row = 1) == Some(Left(0)))
+    // Edit starts at col 1 + 8 + 1 (separator) = col 10.
+    assert(MenuBar.hitTest(sample, at, col = 10, row = 1) == Some(Left(1)))
+  }
+
+  test("hitTest on an open menu's item row returns Right(itemIdx)") {
+    val opened = sample.copy(openIdx = Some(0))
+    val at     = Coord(1.x, 1.y)
+    // Items render at row 2 (1 + 1) onward. "New" is item 0.
+    val r = MenuBar.hitTest(opened, at, col = 2, row = 2)
+    assert(r == Some(Right(0)), s"got $r")
+  }
+
+  test("hitTest outside any cell returns None") {
+    val at = Coord(1.x, 1.y)
+    assert(MenuBar.hitTest(sample, at, col = 999, row = 1).isEmpty)
+    assert(MenuBar.hitTest(sample, at, col = 1, row = 99).isEmpty)
+  }

--- a/modules/termflow/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
@@ -1,0 +1,72 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.TuiPrelude.*
+
+class SplitPaneSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  // ---- layout (horizontal) -------------------------------------------------
+
+  test("horizontal split at 0.5 splits a width=10 region into 5 + 5") {
+    val l = SplitPane.layout(SplitPane.Direction.Horizontal, width = 10, height = 3)
+    assert(l.first.width == 5)
+    assert(l.second.width == 5)
+    assert(l.first.height == 3)
+    assert(l.second.height == 3)
+    assert(l.first.at.x.value == 1)
+    assert(l.second.at.x.value == 6)
+    assert(l.divider.isEmpty)
+  }
+
+  test("horizontal split with gap reserves a divider rect") {
+    val l = SplitPane.layout(SplitPane.Direction.Horizontal, width = 10, height = 3, splitRatio = 0.5, gap = 2)
+    assert(l.divider.isDefined)
+    val d = l.divider.get
+    assert(d.width == 2)
+    assert(d.at.x.value == l.first.at.x.value + l.first.width)
+    assert(l.second.at.x.value == d.at.x.value + d.width)
+  }
+
+  test("split clamps splitRatio to [MinSizeRatio, 1 - MinSizeRatio]") {
+    val a = SplitPane.layout(SplitPane.Direction.Horizontal, width = 100, height = 10, splitRatio = 0.0)
+    val b = SplitPane.layout(SplitPane.Direction.Horizontal, width = 100, height = 10, splitRatio = 1.0)
+    assert(a.first.width >= 5, "first pane must be at least MinSizeRatio of total")
+    assert(b.second.width >= 5, "second pane must be at least MinSizeRatio of total")
+  }
+
+  test("vertical split at 0.5 splits a height=10 region into 5 + 5") {
+    val l = SplitPane.layout(SplitPane.Direction.Vertical, width = 10, height = 10)
+    assert(l.first.height == 5)
+    assert(l.second.height == 5)
+    assert(l.first.width == 10)
+    assert(l.second.width == 10)
+    assert(l.first.at.y.value == 1)
+    assert(l.second.at.y.value == 6)
+  }
+
+  test("dividerRect returns the divider when gap > 0 and None otherwise") {
+    val withGap = SplitPane.dividerRect(SplitPane.Direction.Horizontal, width = 20, height = 5, gap = 1)
+    val without = SplitPane.dividerRect(SplitPane.Direction.Horizontal, width = 20, height = 5, gap = 0)
+    assert(withGap.isDefined)
+    assert(without.isEmpty)
+  }
+
+  // ---- apply (rendering) --------------------------------------------------
+
+  test("apply dispatches each pane's render with the resolved geometry") {
+    val seen   = scala.collection.mutable.ListBuffer.empty[(String, Int, Int)]
+    val first  = (_: Coord, w: Int, h: Int) => { seen += (("first", w, h)); Nil }
+    val second = (_: Coord, w: Int, h: Int) => { seen += (("second", w, h)); Nil }
+    SplitPane(first, second, width = 12, height = 4)
+    assert(seen.toList == List(("first", 6, 4), ("second", 6, 4)))
+  }
+
+  test("apply concatenates VNodes from both pane renderers") {
+    val n1    = TextNode(1.x, 1.y, List(Text("L", Style())))
+    val n2    = TextNode(1.x, 1.y, List(Text("R", Style())))
+    val nodes = SplitPane((_, _, _) => List(n1), (_, _, _) => List(n2), width = 6, height = 1)
+    assert(nodes == List(n1, n2))
+  }


### PR DESCRIPTION
## Summary

Closes out Stage 3 §6.2 with the four remaining widgets. Combined with the already-shipped widgets (`Button`, `TextField`, `ListView`, `Table`, `Select`, `Spinner`, `ProgressBar`, `StatusBar` from 0.2; `CheckBox` / `RadioGroup` in #169; `Tabs` / `LogView` / `Tree` in #170), the catalogue is feature-complete.

### `SplitPane`
- Two-pane layout (`Direction.Horizontal` | `Vertical`) at a configurable `splitRatio` (clamped to `[0.05, 0.95]` so neither pane collapses).
- Apps supply two render functions taking the resolved `(at, w, h)` of their pane.
- Optional `gap` reserves a divider rect — exposed via `dividerRect` for apps that want to wire mouse drag now (the framework cache for drag-resize lands in the mouse follow-up).
- Pure `layout` returns `Pane` rectangles; `apply` calls the renderers.

### `Form`
- Declarative `Vector[Form.Row]` of `(id, label, widget render fn, height)`.
- `Form.column(rows, focusManager, ...)` lays out labels + widgets in a column, passing `focused: Boolean` to each row's render so the widget highlights itself when the `FocusManager` points at its id.
- Optional per-row `errors: Map[String, String]` annotations drawn beneath the field in the theme's error slot.
- `totalHeight` for sizing parent panels. Validation is app-side — this is presentation only.

### `MenuBar`
- Horizontal menu titles + on-demand dropdown for the open menu.
- `State(menus, openIdx, cursor)`; `cursor` doubles as the highlighted menu (when collapsed) or the highlighted item (when a menu is open).
- Pure `handleKey` dispatcher: `←/→` moves between titles (re-opening the new menu when one was already open), `↑/↓` scrolls items or opens the cursor menu when collapsed, `Enter`/`Space` picks an item or opens the menu, `Esc` closes. Returns `picked = Some((menuIdx, itemIdx))`.
- `hitTest(at, col, row)` returns `Either[Int, Int]` for clicks on a title cell or an open dropdown row.

### `Autocomplete`
- Open ComboBox: always-shown filtered dropdown. Companion to `Select` (closed).
- `State[A]` holds `Prompt` input + options + selectedIdx + pluggable `matches` predicate (default case-insensitive contains) + render fn.
- Pure `handleKey` routes printable keys through `Prompt.handleKey`, arrow keys move filtered cursor, `Enter` returns `picked = Some(item)`.
- `view` emits an `InputNode` + one `TextNode` per visible filtered option.

### Roadmap

§6.2 status table now marks all 10 widgets done. §9.3 Lanterna comparison table updated — CheckBox/RadioGroup, Autocomplete, Tree, SplitPanel, MenuBar all flipped from "Stage 3" to "done".

## Test plan

- [x] `sbt ciCheck` — scalafmt + scalafix + tests
- [x] **39 new widget tests** across 4 specs:
  - `SplitPaneSpec` (7): horizontal / vertical split math, ratio clamping, divider gap, renderer dispatch + concatenation
  - `FormSpec` (6): label + widget rendering, empty-label rows, vertical positioning + gap, focus-passing, error-row rendering, `totalHeight` math
  - `MenuBarSpec` (13): handleKey for every binding (←/→/↑/↓/Enter/Space/Esc with various open/closed states), title-only vs dropdown rendering, selected-item bold, hitTest on titles + dropdown items + outside the bar
  - `AutocompleteSpec` (13): empty / full / case-insensitive / custom-predicate filtering, clamped selection, ArrowDown/Up/Enter, Backspace narrows + re-clamps, view structure, `height` math
- [x] **661 total tests pass** (495 termflow + 118 sample + 48 testkit)

## Notes

- Branched off main (currently at #168). PRs #169 (CheckBox/RadioGroup) and #170 (Tabs/LogView/Tree) are still open in parallel; this PR doesn't touch the same widget files, so a clean rebase is straightforward when those merge.
- All widgets follow the existing convention: companion `apply`, themed colours, ASCII fallback for non-UTF-8 backends where applicable, focus + state independent so siblings never reflow on focus change. State (where applicable) lives in the app's model — widgets are pure presentation + pure key dispatchers.