### PR TITLE
feat: KeySim + MouseSim testkit helpers (Stage 3 §6.4)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -467,21 +467,29 @@ pieces:
 The single-key `Keymap` API is unchanged, and `ChordKeymap.fromKeymap`
 promotes it for free, so existing apps don't need to migrate.
 
-### 6.4 Testkit module (P1, small)
+### 6.4 Testkit module (P1, small) — **complete**
 
-Promote `termflow.testkit.*` to a published artifact `termflow-testkit`.
+Promoted `termflow.testkit.*` to a published artifact `termflow-testkit`.
 Public API:
 
 - `TuiTestDriver[Model, Msg]` — drives an app deterministically, captures
   frames.
-- `Golden` — `assertGolden(driver, "name.golden")`, with
-  `-Dtermflow.update-goldens=true`.
-- `VirtualTerminalBackend` — first-class.
-- `KeySim` — `KeySim.type("hello\n")` → seq of `KeyEvent`s.
-- `MouseSim` — `MouseSim.click(2, 3)`, `MouseSim.scrollUp(10, 10, 3)`.
+- `GoldenSupport` — `assertGoldenFrame(frame, "name")`, with
+  `-Dtermflow.update-goldens=true` (or `UPDATE_GOLDENS=1`).
+- `TestRuntimeCtx` + `TestTerminalBackend` — virtual backend wired up by
+  default; subscriptions stay dormant for determinism.
+- `KeySim` — `KeySim.typeString("hi\n")`, `KeySim.f(5)`,
+  `KeySim.ctrlShift(KeySim.ArrowLeft)`, `KeySim.paste(text)`.
+- `MouseSim` — `MouseSim.click(2, 3)`, `MouseSim.scrollDown(10, 10, ticks = 3)`,
+  `MouseSim.dragGesture(2, 2, 8, 4)`, `MouseSim.clickPair(c, r)`.
+
+Helpers return plain `InputKey` values so apps wrap them in their own
+`Msg.Key(...)` envelope before feeding through `TuiTestDriver.send`. CRLF
+in `typeString` collapses into a single `Enter`; `dragGesture` samples a
+straight Bresenham-ish path so hit-tests can validate intermediate
+coordinates.
 
 This is **TermFlow's unique selling point** — no Java TUI library has it.
-Make it discoverable.
 
 ### 6.5 Definition of done for Stage 3
 
@@ -787,6 +795,15 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
   loses the prefix/no-match distinction the dispatcher needs. Same PR
   migrates `forms/FormDemoApp` to use the `Form.column` builder
   shipped in #171, completing the Stage 3 DoD on that demo.
+- *2026-04-28* — Stage 3 §6.4 testkit completed. `KeySim` and `MouseSim`
+  ship as factory objects returning plain `InputKey` values (mouse events
+  flow through `InputKey.Mouse(...)` per Stage 2 §5.1). Helpers are
+  deliberately stateless — apps wrap them in their app-specific `Msg`
+  before `driver.send` — so the same test code works for any app shape
+  without requiring the testkit to know the message envelope. CRLF
+  collapses to a single `Enter` in `typeString` to match real terminal
+  behaviour, and `MouseSim.dragGesture` samples intermediate drag points
+  so hit-tests can be validated mid-gesture.
 
 ---
 

--- a/modules/termflow-testkit/src/main/scala/termflow/testkit/KeySim.scala
+++ b/modules/termflow-testkit/src/main/scala/termflow/testkit/KeySim.scala
@@ -1,0 +1,157 @@
+package termflow.testkit
+
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+
+/**
+ * Factory helpers for synthesising [[InputKey]] events in tests.
+ *
+ * `KeySim` exists so test bodies don't have to spell out the full
+ * `KeyDecoder.InputKey.CharKey('h')` / `Modified(ArrowUp, Modifiers(...))`
+ * incantations every time. The helpers return plain `InputKey` values, so
+ * apps wrap them in their own `Msg.Key(...)` (or whatever name they use) and
+ * feed through [[TuiTestDriver.send]].
+ *
+ * {{{
+ * import termflow.testkit.KeySim
+ *
+ * KeySim.typeString("hello\n").foreach(k => driver.send(Msg.Key(k)))
+ * driver.send(Msg.Key(KeySim.ctrlShift(KeySim.ArrowLeft)))
+ * driver.send(Msg.Key(KeySim.f(5)))
+ * }}}
+ *
+ * Pairs with [[MouseSim]], which produces `InputKey.Mouse(...)` values for
+ * the same input pipeline.
+ */
+object KeySim:
+
+  // ---- Named keys ---------------------------------------------------------
+
+  /**
+   * Re-export of the literal `InputKey` enum cases as fields so callers
+   * can write `KeySim.Enter` without importing `KeyDecoder.InputKey.*`.
+   */
+  val Enter: InputKey      = InputKey.Enter
+  val Escape: InputKey     = InputKey.Escape
+  val Backspace: InputKey  = InputKey.Backspace
+  val Delete: InputKey     = InputKey.Delete
+  val Insert: InputKey     = InputKey.Insert
+  val Home: InputKey       = InputKey.Home
+  val End: InputKey        = InputKey.End
+  val PageUp: InputKey     = InputKey.PageUp
+  val PageDown: InputKey   = InputKey.PageDown
+  val ArrowUp: InputKey    = InputKey.ArrowUp
+  val ArrowDown: InputKey  = InputKey.ArrowDown
+  val ArrowLeft: InputKey  = InputKey.ArrowLeft
+  val ArrowRight: InputKey = InputKey.ArrowRight
+  val BackTab: InputKey    = InputKey.BackTab
+  val Tab: InputKey        = InputKey.CharKey('\t')
+
+  // ---- Character + control ------------------------------------------------
+
+  /** Plain printable character keystroke. */
+  def char(c: Char): InputKey = InputKey.CharKey(c)
+
+  /** Ctrl-modified character (e.g. `Ctrl+C` is `ctrl('C')`). */
+  def ctrl(c: Char): InputKey = InputKey.Ctrl(c)
+
+  /** Function key by 1-based index in `[1, 12]`. */
+  def f(n: Int): InputKey = n match
+    case 1  => InputKey.F1
+    case 2  => InputKey.F2
+    case 3  => InputKey.F3
+    case 4  => InputKey.F4
+    case 5  => InputKey.F5
+    case 6  => InputKey.F6
+    case 7  => InputKey.F7
+    case 8  => InputKey.F8
+    case 9  => InputKey.F9
+    case 10 => InputKey.F10
+    case 11 => InputKey.F11
+    case 12 => InputKey.F12
+    case _ =>
+      throw new IllegalArgumentException(s"KeySim.f only supports F1..F12; got F$n")
+
+  /** Bracketed-paste payload — a single event carrying the whole pasted text. */
+  def paste(text: String): InputKey = InputKey.Paste(text)
+
+  // ---- Modifiers ----------------------------------------------------------
+
+  /**
+   * Wrap `key` in [[InputKey.Modified]] with the given modifier flags.
+   *
+   * Bare keys (no modifiers) are returned unchanged so the same convention
+   * the parser uses — never wrap an unmodified key — is preserved. Wrapping
+   * an already-modified key merges the new flags into the existing set.
+   */
+  def modified(
+    key: InputKey,
+    shift: Boolean = false,
+    alt: Boolean = false,
+    ctrl: Boolean = false,
+    meta: Boolean = false
+  ): InputKey =
+    val incoming = Modifiers(shift = shift, alt = alt, ctrl = ctrl, meta = meta)
+    if incoming.isEmpty then key
+    else
+      key match
+        case InputKey.Modified(inner, existing) =>
+          InputKey.Modified(
+            inner,
+            Modifiers(
+              shift = existing.shift || incoming.shift,
+              alt = existing.alt || incoming.alt,
+              ctrl = existing.ctrl || incoming.ctrl,
+              meta = existing.meta || incoming.meta
+            )
+          )
+        case other => InputKey.Modified(other, incoming)
+
+  /** Shorthand: shift-modify a key. */
+  def shift(key: InputKey): InputKey = modified(key, shift = true)
+
+  /** Shorthand: alt-modify a key. */
+  def alt(key: InputKey): InputKey = modified(key, alt = true)
+
+  /** Shorthand: ctrl-modify a key. Use [[ctrl(Char)]] for control characters. */
+  def ctrlMod(key: InputKey): InputKey = modified(key, ctrl = true)
+
+  /** Shorthand: meta-modify a key. */
+  def meta(key: InputKey): InputKey = modified(key, meta = true)
+
+  /** Shorthand: shift+ctrl-modify a key. */
+  def ctrlShift(key: InputKey): InputKey = modified(key, ctrl = true, shift = true)
+
+  /** Shorthand: shift+alt-modify a key. */
+  def altShift(key: InputKey): InputKey = modified(key, alt = true, shift = true)
+
+  // ---- Strings ------------------------------------------------------------
+
+  /**
+   * Convert a string into a sequence of keystrokes, one [[InputKey]] per
+   * character.
+   *
+   * Newlines (`\n`, `\r\n`, `\r`) become [[InputKey.Enter]] events;
+   * everything else — including `\t` — becomes [[InputKey.CharKey]]. To
+   * emulate a paste (one event for the whole payload), use [[paste]]
+   * instead.
+   *
+   * Returns a `Vector` so callers can `foreach` or splice without
+   * exhausting an iterator.
+   */
+  def typeString(s: String): Vector[InputKey] =
+    val builder = Vector.newBuilder[InputKey]
+    var i       = 0
+    while i < s.length do
+      val ch = s.charAt(i)
+      ch match
+        case '\r' =>
+          builder += InputKey.Enter
+          // Consume the paired LF in CRLF so we don't emit two Enters.
+          if i + 1 < s.length && s.charAt(i + 1) == '\n' then i += 1
+        case '\n' =>
+          builder += InputKey.Enter
+        case other =>
+          builder += InputKey.CharKey(other)
+      i += 1
+    builder.result()

--- a/modules/termflow-testkit/src/main/scala/termflow/testkit/MouseSim.scala
+++ b/modules/termflow-testkit/src/main/scala/termflow/testkit/MouseSim.scala
@@ -1,0 +1,156 @@
+package termflow.testkit
+
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+import termflow.tui.MouseButton
+import termflow.tui.MouseEvent
+import termflow.tui.ScrollDirection
+
+/**
+ * Factory helpers for synthesising mouse events in tests.
+ *
+ * Mouse events are multiplexed onto the key stream as
+ * `InputKey.Mouse(MouseEvent)` (Stage 2 §5.1), so every helper here returns
+ * an [[InputKey]] ready to drop into the same `Msg.Key(...)` handler that
+ * receives keyboard events.
+ *
+ * {{{
+ * import termflow.testkit.MouseSim
+ *
+ * driver.send(Msg.Key(MouseSim.click(col = 7, row = 3)))
+ * MouseSim.scrollDown(col = 10, row = 10, ticks = 3)
+ *   .foreach(k => driver.send(Msg.Key(k)))
+ * }}}
+ *
+ * Coordinates follow the rest of the library: 1-based, with `(1, 1)` at the
+ * top-left cell.
+ */
+object MouseSim:
+
+  /** No modifiers — convenience alias for the common case. */
+  val NoMods: Modifiers = Modifiers.none
+
+  // ---- Single events ------------------------------------------------------
+
+  /**
+   * Synthesise a left-button click — a [[MouseEvent.Press]] / `InputKey.Mouse`
+   * pair. Most apps consume `Press` directly; if your handler waits for
+   * `Release`, use [[clickPair]] to get both events.
+   */
+  def click(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    press(col, row, button, mods)
+
+  /** Press event for `button` at `(col, row)`. */
+  def press(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Press(button, col, row, mods))
+
+  /** Release event for `button` at `(col, row)`. */
+  def release(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Release(button, col, row, mods))
+
+  /** Drag event — motion with a held `button` at `(col, row)`. */
+  def drag(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Drag(button, col, row, mods))
+
+  /**
+   * Bare motion (no held button) at `(col, row)`. The runtime only enables
+   * any-event tracking on demand, so most apps never see these in
+   * production — simulate them anyway when wiring hover behaviour.
+   */
+  def move(col: Int, row: Int, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Move(col, row, mods))
+
+  /** Single scroll-wheel detent in `direction`. Use [[scroll]] for bursts. */
+  def scrollOnce(
+    direction: ScrollDirection,
+    col: Int,
+    row: Int,
+    mods: Modifiers = NoMods
+  ): InputKey =
+    InputKey.Mouse(MouseEvent.Scroll(direction, col, row, mods))
+
+  // ---- Sequences ----------------------------------------------------------
+
+  /**
+   * Press + release pair for `button` at `(col, row)`. Useful for apps that
+   * activate on `Release` rather than `Press`. The two events share
+   * coordinates and modifier state — a real terminal can shift between
+   * them but a synthetic test usually doesn't care.
+   */
+  def clickPair(
+    col: Int,
+    row: Int,
+    button: MouseButton = MouseButton.Left,
+    mods: Modifiers = NoMods
+  ): Vector[InputKey] =
+    Vector(
+      press(col, row, button, mods),
+      release(col, row, button, mods)
+    )
+
+  /**
+   * `ticks` consecutive scroll detents in `direction`. Common shorthand
+   * for "the user wheeled three notches down at (col, row)".
+   *
+   * @throws IllegalArgumentException if `ticks` is negative.
+   */
+  def scroll(
+    direction: ScrollDirection,
+    col: Int,
+    row: Int,
+    ticks: Int = 1,
+    mods: Modifiers = NoMods
+  ): Vector[InputKey] =
+    require(ticks >= 0, s"MouseSim.scroll ticks must be non-negative, got $ticks")
+    Vector.fill(ticks)(scrollOnce(direction, col, row, mods))
+
+  /** Convenience: `ticks` scroll-up detents at `(col, row)`. */
+  def scrollUp(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Up, col, row, ticks, mods)
+
+  /** Convenience: `ticks` scroll-down detents at `(col, row)`. */
+  def scrollDown(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Down, col, row, ticks, mods)
+
+  /** Convenience: `ticks` scroll-left detents at `(col, row)`. */
+  def scrollLeft(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Left, col, row, ticks, mods)
+
+  /** Convenience: `ticks` scroll-right detents at `(col, row)`. */
+  def scrollRight(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Right, col, row, ticks, mods)
+
+  /**
+   * A drag gesture from `(fromCol, fromRow)` to `(toCol, toRow)`: a press,
+   * a series of [[MouseEvent.Drag]] events along a straight Bresenham-ish
+   * path, and a final release. The path is sampled at `steps`+1 points so
+   * tests with hit-testing can validate the intermediate positions —
+   * `steps = 0` collapses to press + release at the start, then end.
+   *
+   * @param steps Number of intermediate drag samples between the endpoints
+   *              (excluding press / release). Must be non-negative.
+   */
+  def dragGesture(
+    fromCol: Int,
+    fromRow: Int,
+    toCol: Int,
+    toRow: Int,
+    button: MouseButton = MouseButton.Left,
+    steps: Int = 4,
+    mods: Modifiers = NoMods
+  ): Vector[InputKey] =
+    require(steps >= 0, s"MouseSim.dragGesture steps must be non-negative, got $steps")
+    val builder = Vector.newBuilder[InputKey]
+    builder += press(fromCol, fromRow, button, mods)
+    if steps > 0 then
+      val total = steps + 1
+      var i     = 1
+      while i <= steps do
+        val t   = i.toDouble / total.toDouble
+        val col = math.round(fromCol + (toCol - fromCol) * t).toInt
+        val row = math.round(fromRow + (toRow - fromRow) * t).toInt
+        builder += drag(col, row, button, mods)
+        i += 1
+    builder += drag(toCol, toRow, button, mods)
+    builder += release(toCol, toRow, button, mods)
+    builder.result()

--- a/modules/termflow-testkit/src/test/scala/termflow/testkit/KeySimSpec.scala
+++ b/modules/termflow-testkit/src/test/scala/termflow/testkit/KeySimSpec.scala
@@ -1,0 +1,119 @@
+package termflow.testkit
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+
+class KeySimSpec extends AnyFunSuite:
+
+  test("char wraps a printable character") {
+    assert(KeySim.char('a') == InputKey.CharKey('a'))
+  }
+
+  test("ctrl produces a Ctrl key event") {
+    assert(KeySim.ctrl('C') == InputKey.Ctrl('C'))
+  }
+
+  test("named key fields are exact aliases of the InputKey cases") {
+    assert(KeySim.Enter == InputKey.Enter)
+    assert(KeySim.Escape == InputKey.Escape)
+    assert(KeySim.Backspace == InputKey.Backspace)
+    assert(KeySim.Delete == InputKey.Delete)
+    assert(KeySim.Insert == InputKey.Insert)
+    assert(KeySim.Home == InputKey.Home)
+    assert(KeySim.End == InputKey.End)
+    assert(KeySim.PageUp == InputKey.PageUp)
+    assert(KeySim.PageDown == InputKey.PageDown)
+    assert(KeySim.ArrowUp == InputKey.ArrowUp)
+    assert(KeySim.ArrowDown == InputKey.ArrowDown)
+    assert(KeySim.ArrowLeft == InputKey.ArrowLeft)
+    assert(KeySim.ArrowRight == InputKey.ArrowRight)
+    assert(KeySim.BackTab == InputKey.BackTab)
+    assert(KeySim.Tab == InputKey.CharKey('\t'))
+  }
+
+  test("f produces F1..F12 cases") {
+    val expected = Vector(
+      InputKey.F1,
+      InputKey.F2,
+      InputKey.F3,
+      InputKey.F4,
+      InputKey.F5,
+      InputKey.F6,
+      InputKey.F7,
+      InputKey.F8,
+      InputKey.F9,
+      InputKey.F10,
+      InputKey.F11,
+      InputKey.F12
+    )
+    (1 to 12).foreach(i => assert(KeySim.f(i) == expected(i - 1), s"F$i mismatch"))
+  }
+
+  test("f rejects out-of-range values") {
+    intercept[IllegalArgumentException](KeySim.f(0))
+    intercept[IllegalArgumentException](KeySim.f(13))
+  }
+
+  test("paste preserves the literal payload, including embedded newlines") {
+    val payload = "first\nsecond\nthird"
+    assert(KeySim.paste(payload) == InputKey.Paste(payload))
+  }
+
+  test("modified returns the bare key when no flags are set") {
+    assert(KeySim.modified(InputKey.ArrowUp) == InputKey.ArrowUp)
+  }
+
+  test("modified wraps a single flag") {
+    val k = KeySim.modified(InputKey.ArrowRight, ctrl = true)
+    assert(k == InputKey.Modified(InputKey.ArrowRight, Modifiers(ctrl = true)))
+  }
+
+  test("modified merges flags into an existing Modified envelope") {
+    val first  = KeySim.shift(InputKey.ArrowDown)
+    val second = KeySim.modified(first, ctrl = true)
+    second match
+      case InputKey.Modified(inner, mods) =>
+        assert(inner == InputKey.ArrowDown)
+        assert(mods.shift && mods.ctrl)
+      case other => fail(s"expected Modified, got $other")
+  }
+
+  test("ctrlShift wraps both modifiers") {
+    val k = KeySim.ctrlShift(InputKey.ArrowLeft)
+    k match
+      case InputKey.Modified(inner, mods) =>
+        assert(inner == InputKey.ArrowLeft)
+        assert(mods.ctrl && mods.shift)
+        assert(!mods.alt && !mods.meta)
+      case other => fail(s"expected Modified, got $other")
+  }
+
+  test("typeString turns a plain string into one CharKey per character") {
+    val keys = KeySim.typeString("hi")
+    assert(keys == Vector(InputKey.CharKey('h'), InputKey.CharKey('i')))
+  }
+
+  test("typeString returns a CharKey for tab") {
+    val keys = KeySim.typeString("a\tb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.CharKey('\t'), InputKey.CharKey('b')))
+  }
+
+  test("typeString turns LF into Enter") {
+    val keys = KeySim.typeString("a\nb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Enter, InputKey.CharKey('b')))
+  }
+
+  test("typeString collapses CRLF into a single Enter event") {
+    val keys = KeySim.typeString("a\r\nb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Enter, InputKey.CharKey('b')))
+  }
+
+  test("typeString turns a bare CR into Enter") {
+    val keys = KeySim.typeString("a\rb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Enter, InputKey.CharKey('b')))
+  }
+
+  test("typeString of an empty string yields no events") {
+    assert(KeySim.typeString("").isEmpty)
+  }

--- a/modules/termflow-testkit/src/test/scala/termflow/testkit/MouseSimSpec.scala
+++ b/modules/termflow-testkit/src/test/scala/termflow/testkit/MouseSimSpec.scala
@@ -1,0 +1,137 @@
+package termflow.testkit
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+import termflow.tui.MouseButton
+import termflow.tui.MouseEvent
+import termflow.tui.ScrollDirection
+
+class MouseSimSpec extends AnyFunSuite:
+
+  test("click returns a left-button Press wrapped in InputKey.Mouse") {
+    val k = MouseSim.click(7, 3)
+    k match
+      case InputKey.Mouse(MouseEvent.Press(MouseButton.Left, c, r, mods)) =>
+        assert(c == 7 && r == 3)
+        assert(mods.isEmpty)
+      case other => fail(s"expected left-press at (7,3), got $other")
+  }
+
+  test("press preserves the requested button + modifiers") {
+    val k = MouseSim.press(2, 4, MouseButton.Right, Modifiers(ctrl = true))
+    k match
+      case InputKey.Mouse(MouseEvent.Press(MouseButton.Right, 2, 4, mods)) =>
+        assert(mods.ctrl)
+        assert(!mods.shift)
+      case other => fail(s"unexpected $other")
+  }
+
+  test("release builds a release event") {
+    val k = MouseSim.release(10, 5)
+    k match
+      case InputKey.Mouse(MouseEvent.Release(MouseButton.Left, 10, 5, _)) => ()
+      case other                                                          => fail(s"unexpected $other")
+  }
+
+  test("drag builds a drag event") {
+    val k = MouseSim.drag(11, 6, MouseButton.Middle)
+    k match
+      case InputKey.Mouse(MouseEvent.Drag(MouseButton.Middle, 11, 6, _)) => ()
+      case other                                                         => fail(s"unexpected $other")
+  }
+
+  test("move builds a move event") {
+    val k = MouseSim.move(12, 7)
+    k match
+      case InputKey.Mouse(MouseEvent.Move(12, 7, _)) => ()
+      case other                                     => fail(s"unexpected $other")
+  }
+
+  test("scrollOnce wraps a single Scroll event in the requested direction") {
+    val k = MouseSim.scrollOnce(ScrollDirection.Up, 4, 4)
+    k match
+      case InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Up, 4, 4, _)) => ()
+      case other                                                          => fail(s"unexpected $other")
+  }
+
+  test("clickPair returns press then release with matching coordinates") {
+    val pair = MouseSim.clickPair(2, 3, MouseButton.Left)
+    assert(pair.size == 2)
+    pair(0) match
+      case InputKey.Mouse(MouseEvent.Press(MouseButton.Left, 2, 3, _)) => ()
+      case other                                                       => fail(s"expected press first, got $other")
+    pair(1) match
+      case InputKey.Mouse(MouseEvent.Release(MouseButton.Left, 2, 3, _)) => ()
+      case other                                                         => fail(s"expected release second, got $other")
+  }
+
+  test("scroll repeats a single direction for the requested ticks") {
+    val ks = MouseSim.scroll(ScrollDirection.Down, 5, 5, ticks = 3)
+    assert(ks.size == 3)
+    ks.foreach {
+      case InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Down, 5, 5, _)) => ()
+      case other                                                            => fail(s"unexpected $other")
+    }
+  }
+
+  test("scroll with ticks = 0 yields an empty sequence") {
+    assert(MouseSim.scroll(ScrollDirection.Up, 1, 1, ticks = 0).isEmpty)
+  }
+
+  test("scroll rejects negative ticks") {
+    intercept[IllegalArgumentException](MouseSim.scroll(ScrollDirection.Up, 1, 1, ticks = -1))
+  }
+
+  test("scrollUp / scrollDown / scrollLeft / scrollRight pick the right direction") {
+    def dirOf(k: InputKey): ScrollDirection = k match
+      case InputKey.Mouse(MouseEvent.Scroll(d, _, _, _)) => d
+      case other                                         => fail(s"not a scroll event: $other")
+
+    assert(MouseSim.scrollUp(1, 1).map(dirOf).head == ScrollDirection.Up)
+    assert(MouseSim.scrollDown(1, 1).map(dirOf).head == ScrollDirection.Down)
+    assert(MouseSim.scrollLeft(1, 1).map(dirOf).head == ScrollDirection.Left)
+    assert(MouseSim.scrollRight(1, 1).map(dirOf).head == ScrollDirection.Right)
+  }
+
+  test("dragGesture starts with a press, ends with a release at the destination") {
+    val seq = MouseSim.dragGesture(2, 2, 8, 4, steps = 2)
+    seq.head match
+      case InputKey.Mouse(MouseEvent.Press(_, 2, 2, _)) => ()
+      case other                                        => fail(s"first event should be press at origin, got $other")
+    seq.last match
+      case InputKey.Mouse(MouseEvent.Release(_, 8, 4, _)) => ()
+      case other => fail(s"last event should be release at destination, got $other")
+  }
+
+  test("dragGesture with steps = 0 collapses to press + drag-to-end + release") {
+    val seq = MouseSim.dragGesture(0, 0, 5, 5, steps = 0)
+    assert(seq.size == 3)
+    seq(0) match
+      case InputKey.Mouse(MouseEvent.Press(_, 0, 0, _)) => ()
+      case other                                        => fail(s"expected press, got $other")
+    seq(1) match
+      case InputKey.Mouse(MouseEvent.Drag(_, 5, 5, _)) => ()
+      case other                                       => fail(s"expected drag-to-end, got $other")
+    seq(2) match
+      case InputKey.Mouse(MouseEvent.Release(_, 5, 5, _)) => ()
+      case other                                          => fail(s"expected release, got $other")
+  }
+
+  test("dragGesture samples intermediate drag positions on the line") {
+    val seq   = MouseSim.dragGesture(0, 0, 10, 0, steps = 4)
+    val drags = seq.collect { case InputKey.Mouse(d @ MouseEvent.Drag(_, _, _, _)) => d }
+    // 4 intermediate samples + final drag at the destination = 5 drag events.
+    assert(drags.size == 5)
+    // X-coordinate must be non-decreasing along the sampled drags.
+    val xs = drags.map(_.col)
+    assert(xs == xs.sorted)
+    // Final drag is exactly at the destination.
+    assert(drags.last.col == 10 && drags.last.row == 0)
+  }
+
+  test("dragGesture rejects negative steps") {
+    intercept[IllegalArgumentException](
+      MouseSim.dragGesture(0, 0, 1, 1, steps = -1)
+    )
+  }


### PR DESCRIPTION
## Summary
- Adds `termflow.testkit.KeySim` for synthesising keyboard input: `typeString`, named-key fields, `char`/`ctrl`/`f(n)`/`paste`, and modifier shorthand (`shift`/`ctrl`/`alt`/`meta`/`ctrlShift`/`altShift`).
- Adds `termflow.testkit.MouseSim` for synthesising pointer input: `click`/`press`/`release`/`drag`/`move`/`scrollOnce`, plus higher-level `clickPair`, directional `scroll{Up,Down,Left,Right}`, and `dragGesture` that samples a straight path between endpoints.
- Both return plain `InputKey` values (mouse events flow through `InputKey.Mouse(...)` per Stage 2 §5.1) so apps wrap them in their `Msg.Key(...)` envelope before `driver.send`.
- Closes Stage 3 §6.4 in the roadmap; decision log entry added.

## Notes on shape
- Helpers are stateless factories, not bound to `TuiTestDriver` — keeps the testkit composition orthogonal to any specific message envelope.
- `KeySim.typeString` collapses CRLF into a single `Enter` to match terminal behaviour.
- `MouseSim.dragGesture` exposes intermediate drag positions so apps can validate hit-tests mid-gesture; companion `steps = 0` collapses to press + drag-to-end + release.

## Test plan
- [x] `sbt "termflowTestkit/testOnly termflow.testkit.KeySimSpec termflow.testkit.MouseSimSpec"` — 31/31 pass.
- [x] `sbt ciCheck` — full repo CI green (138 testkit + 79 termflow + 571 sample tests pass; scalafmt clean).