### PR TITLE
feat: Dialogs.fileDialog + directoryDialog (Stage 3 §6.1)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -420,11 +420,12 @@ maintain.)
 | `Dialogs.actionList` | not started | Trivially expressed as `listSelect` over `Choice` values; deferred until a real use case appears. |
 | `Dialogs.fileDialog` / `directoryDialog` | done | Path bar + entry list (parent / dir / file) + sized column for files. Companion `FileEntry` ADT, `listEntries(path, showHidden)`, and `fileDialogLayout` for hit-testing. |
 
-The five base helpers cover the everyday cases. All are exercised by
-`sbt showcase` (`d` = confirm, `i` = textInput, `l` = listSelect, `w` =
-waiting). The file pickers ship with a dedicated demo
-(`apps.dialog.FileDialogDemoApp`, runnable as `sbt run file-dialog`)
-since they need filesystem state. Tests live in `DialogsSpec`.
+All seven helpers are exercised by `sbt showcase` (`d` = confirm, `i` =
+textInput, `l` = listSelect, `w` = waiting, `f` = fileDialog, `g` =
+directoryDialog) on the Showcase tab. The file pickers also ship with
+a dedicated demo (`apps.dialog.FileDialogDemoApp`, runnable as
+`sbt run file-dialog`) for a focused look. Tests live in `DialogsSpec`
+and `Stage1ShowcaseAppSpec`.
 
 ### 6.2 Additional widgets (P1, medium) — **complete**
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -418,11 +418,13 @@ maintain.)
 | `Dialogs.listSelect(title, items, selectedIndex, maxVisible?, render?)` | done | Selection-following viewport scrolling; custom render callback. |
 | `Dialogs.waiting(title, body, tick, frames?, cancelLabel?)` | done | Spinner glyph picked from the tick (modulo); optional cancel button. App drives the tick from a `Sub.Every`. |
 | `Dialogs.actionList` | not started | Trivially expressed as `listSelect` over `Choice` values; deferred until a real use case appears. |
-| `Dialogs.fileDialog` / `directoryDialog` | not started | Need filesystem traversal helpers and async listing for big directories — own PR. |
+| `Dialogs.fileDialog` / `directoryDialog` | done | Path bar + entry list (parent / dir / file) + sized column for files. Companion `FileEntry` ADT, `listEntries(path, showHidden)`, and `fileDialogLayout` for hit-testing. |
 
-The five shipped helpers cover the everyday cases. All five are
-exercised by `sbt showcase` (`d` = confirm, `i` = textInput, `l` =
-listSelect, `w` = waiting). Tests live in `DialogsSpec`.
+The five base helpers cover the everyday cases. All are exercised by
+`sbt showcase` (`d` = confirm, `i` = textInput, `l` = listSelect, `w` =
+waiting). The file pickers ship with a dedicated demo
+(`apps.dialog.FileDialogDemoApp`, runnable as `sbt run file-dialog`)
+since they need filesystem state. Tests live in `DialogsSpec`.
 
 ### 6.2 Additional widgets (P1, medium) — **complete**
 
@@ -676,9 +678,19 @@ mirror this in module layout (§4.6) and docs (§7.2).
 
 Lanterna ships `MessageDialog`, `TextInputDialog`, `ActionListDialog`,
 `ListSelectDialog`, `WaitingDialog`, `FileDialog`, `DirectoryDialog`.
-We now ship `message`, `confirm`, `textInput`, `listSelect`, `waiting`
-(see §6.1). `FileDialog` / `DirectoryDialog` and the standalone
-`actionList` helper remain to land in Stage 3.
+We now ship `message`, `confirm`, `textInput`, `listSelect`, `waiting`,
+`fileDialog`, `directoryDialog` (see §6.1). The standalone `actionList`
+helper is still trivially `listSelect` over `Choice` values and remains
+deferred until a real use case asks for it.
+
+### 9.5b Stage 3 dialog status
+
+All five core helpers (`message`, `confirm`, `textInput`, `listSelect`,
+`waiting`) plus the file pickers (`fileDialog`, `directoryDialog`) now
+ship. The `actionList` helper is a one-line `listSelect` and remains
+deferred. Async listing (paging / cancellation for huge trees) is not
+in scope for the helper itself — apps wrap `Dialogs.listEntries` in a
+`Cmd.asyncResult` when they need it.
 
 ### 9.6 Threading model
 
@@ -795,6 +807,23 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
   loses the prefix/no-match distinction the dispatcher needs. Same PR
   migrates `forms/FormDemoApp` to use the `Form.column` builder
   shipped in #171, completing the Stage 3 DoD on that demo.
+- *2026-04-28* — Stage 3 §6.1 file dialogs completed. `Dialogs.fileDialog`
+  and `Dialogs.directoryDialog` ship as presentation-only `Overlay`
+  builders, matching the rest of the dialog family — apps own the
+  current `Path`, the `Vector[FileEntry]`, and the selected index. A
+  small `FileEntry` enum (`Parent` / `Directory(name)` /
+  `File(name, size)`) plus `Dialogs.listEntries(path, showHidden)`
+  cover the synchronous case; apps wanting non-blocking listings on
+  slow filesystems can call the same helper inside a
+  `Cmd.asyncResult`. `directoryDialog` is a thin delegation onto
+  `fileDialog` with `okLabel = "Select"` and `showSizes = false`,
+  rather than a parallel implementation, because the differences are
+  defaults — not behaviour. `FileDialogLayout` mirrors
+  `ListSelectLayout` for hit-testing. The §9.5 standalone `actionList`
+  helper stays deferred: it remains a one-line composition over
+  `listSelect`. Sample app `apps.dialog.FileDialogDemoApp`
+  (`sbt run file-dialog`) drives both dialogs against the real
+  filesystem.
 - *2026-04-28* — Stage 3 §6.4 testkit completed. `KeySim` and `MouseSim`
   ship as factory objects returning plain `InputKey` values (mouse events
   flow through `InputKey.Mouse(...)` per Stage 2 §5.1). Helpers are

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -467,21 +467,29 @@ pieces:
 The single-key `Keymap` API is unchanged, and `ChordKeymap.fromKeymap`
 promotes it for free, so existing apps don't need to migrate.
 
-### 6.4 Testkit module (P1, small)
+### 6.4 Testkit module (P1, small) — **complete**
 
-Promote `termflow.testkit.*` to a published artifact `termflow-testkit`.
+Promoted `termflow.testkit.*` to a published artifact `termflow-testkit`.
 Public API:
 
 - `TuiTestDriver[Model, Msg]` — drives an app deterministically, captures
   frames.
-- `Golden` — `assertGolden(driver, "name.golden")`, with
-  `-Dtermflow.update-goldens=true`.
-- `VirtualTerminalBackend` — first-class.
-- `KeySim` — `KeySim.type("hello\n")` → seq of `KeyEvent`s.
-- `MouseSim` — `MouseSim.click(2, 3)`, `MouseSim.scrollUp(10, 10, 3)`.
+- `GoldenSupport` — `assertGoldenFrame(frame, "name")`, with
+  `-Dtermflow.update-goldens=true` (or `UPDATE_GOLDENS=1`).
+- `TestRuntimeCtx` + `TestTerminalBackend` — virtual backend wired up by
+  default; subscriptions stay dormant for determinism.
+- `KeySim` — `KeySim.typeString("hi\n")`, `KeySim.f(5)`,
+  `KeySim.ctrlShift(KeySim.ArrowLeft)`, `KeySim.paste(text)`.
+- `MouseSim` — `MouseSim.click(2, 3)`, `MouseSim.scrollDown(10, 10, ticks = 3)`,
+  `MouseSim.dragGesture(2, 2, 8, 4)`, `MouseSim.clickPair(c, r)`.
+
+Helpers return plain `InputKey` values so apps wrap them in their own
+`Msg.Key(...)` envelope before feeding through `TuiTestDriver.send`. CRLF
+in `typeString` collapses into a single `Enter`; `dragGesture` samples a
+straight Bresenham-ish path so hit-tests can validate intermediate
+coordinates.
 
 This is **TermFlow's unique selling point** — no Java TUI library has it.
-Make it discoverable.
 
 ### 6.5 Definition of done for Stage 3
 
@@ -787,6 +795,15 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
   loses the prefix/no-match distinction the dispatcher needs. Same PR
   migrates `forms/FormDemoApp` to use the `Form.column` builder
   shipped in #171, completing the Stage 3 DoD on that demo.
+- *2026-04-28* — Stage 3 §6.4 testkit completed. `KeySim` and `MouseSim`
+  ship as factory objects returning plain `InputKey` values (mouse events
+  flow through `InputKey.Mouse(...)` per Stage 2 §5.1). Helpers are
+  deliberately stateless — apps wrap them in their app-specific `Msg`
+  before `driver.send` — so the same test code works for any app shape
+  without requiring the testkit to know the message envelope. CRLF
+  collapses to a single `Enter` in `typeString` to match real terminal
+  behaviour, and `MouseSim.dragGesture` samples intermediate drag points
+  so hit-tests can be validated mid-gesture.
 
 ---
 

--- a/modules/termflow-sample/src/main/scala/termflow/apps/dialog/FileDialogDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/dialog/FileDialogDemoApp.scala
@@ -1,0 +1,185 @@
+package termflow.apps.dialog
+
+import termflow.tui.*
+import termflow.tui.Theme.themed
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Demonstrates the file-picker overlays shipped with Stage 3 §6.1.
+ *
+ * Press `f` to open `Dialogs.fileDialog`; `d` for `Dialogs.directoryDialog`.
+ * Inside a dialog: arrow keys move the selection, Enter activates a row
+ * (Parent / Directory navigates; File / Select returns), Esc cancels.
+ */
+object FileDialogDemoApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  private given Theme = Theme.rounded
+
+  enum Mode:
+    case Files
+    case Directories
+
+  enum Dialog:
+    case None
+    case Open(
+      mode: Mode,
+      currentPath: Path,
+      entries: Vector[Dialogs.FileEntry],
+      selectedIndex: Int
+    )
+
+  final case class Model(
+    lastPick: Option[String],
+    dialog: Dialog,
+    input: Sub[Msg]
+  )
+
+  enum Msg:
+    case OpenFiles
+    case OpenDirs
+    case CloseDialog
+    case Move(delta: Int)
+    case Activate
+    case Pick(path: String)
+    case Refresh(currentPath: Path, entries: Vector[Dialogs.FileEntry])
+    case ShowError(message: String)
+    case Quit
+    case Key(k: KeyDecoder.InputKey)
+    case KeyError(t: Throwable)
+
+  import Msg._
+
+  object App extends TuiApp[Model, Msg]:
+
+    private val startPath: Path = Paths.get(sys.props.getOrElse("user.home", "."))
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Model(
+        lastPick = None,
+        dialog = Dialog.None,
+        input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx)
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      msg match
+        case OpenFiles =>
+          openDialog(m, Mode.Files, startPath)
+
+        case OpenDirs =>
+          openDialog(m, Mode.Directories, startPath)
+
+        case CloseDialog =>
+          m.copy(dialog = Dialog.None).tui
+
+        case Move(delta) =>
+          m.dialog match
+            case Dialog.Open(mode, path, entries, idx) if entries.nonEmpty =>
+              val next = math.max(0, math.min(entries.size - 1, idx + delta))
+              m.copy(dialog = Dialog.Open(mode, path, entries, next)).tui
+            case _ => m.tui
+
+        case Activate =>
+          m.dialog match
+            case Dialog.Open(mode, path, entries, idx) if entries.nonEmpty =>
+              entries(idx) match
+                case Dialogs.FileEntry.Parent =>
+                  val parent = Option(path.getParent).getOrElse(path)
+                  refresh(m, mode, parent)
+                case Dialogs.FileEntry.Directory(name) =>
+                  refresh(m, mode, path.resolve(name))
+                case Dialogs.FileEntry.File(name, _) =>
+                  mode match
+                    case Mode.Files =>
+                      Tui(m.copy(dialog = Dialog.None), Cmd.GCmd(Pick(path.resolve(name).toString)))
+                    case Mode.Directories => m.tui
+            case _ => m.tui
+
+        case Refresh(path, entries) =>
+          m.dialog match
+            case Dialog.Open(mode, _, _, _) =>
+              m.copy(dialog = Dialog.Open(mode, path, entries, 0)).tui
+            case _ => m.tui
+
+        case Pick(p) =>
+          m.copy(lastPick = Some(p)).tui
+
+        case ShowError(message) =>
+          m.copy(lastPick = Some(s"error: $message"), dialog = Dialog.None).tui
+
+        case Quit        => Tui(m, Cmd.Exit)
+        case KeyError(_) => m.tui
+        case Key(k)      => Tui(m, dispatch(m, k))
+
+    private def openDialog(m: Model, mode: Mode, path: Path): Tui[Model, Msg] =
+      Dialogs.listEntries(path) match
+        case Right(entries) =>
+          val filtered = mode match
+            case Mode.Files       => entries
+            case Mode.Directories => entries.filter(_.isDirectory)
+          m.copy(dialog = Dialog.Open(mode, path, filtered, 0)).tui
+        case Left(err) =>
+          m.copy(lastPick = Some(s"error: ${err.toString}")).tui
+
+    private def refresh(m: Model, mode: Mode, path: Path): Tui[Model, Msg] =
+      Dialogs.listEntries(path) match
+        case Right(entries) =>
+          val filtered = mode match
+            case Mode.Files       => entries
+            case Mode.Directories => entries.filter(_.isDirectory)
+          m.copy(dialog = Dialog.Open(mode, path, filtered, 0)).tui
+        case Left(err) =>
+          Tui(m, Cmd.GCmd(ShowError(err.toString)))
+
+    private def dispatch(m: Model, k: KeyDecoder.InputKey): Cmd[Msg] =
+      import KeyDecoder.InputKey.*
+      m.dialog match
+        case Dialog.Open(_, _, _, _) =>
+          k match
+            case ArrowUp   => Cmd.GCmd(Move(-1))
+            case ArrowDown => Cmd.GCmd(Move(+1))
+            case PageUp    => Cmd.GCmd(Move(-5))
+            case PageDown  => Cmd.GCmd(Move(+5))
+            case Enter     => Cmd.GCmd(Activate)
+            case Escape    => Cmd.GCmd(CloseDialog)
+            case _         => Cmd.NoCmd
+        case Dialog.None =>
+          k match
+            case CharKey('f') | CharKey('F')          => Cmd.GCmd(OpenFiles)
+            case CharKey('d') | CharKey('D')          => Cmd.GCmd(OpenDirs)
+            case CharKey('q') | CharKey('Q') | Escape => Cmd.GCmd(Quit)
+            case _                                    => Cmd.NoCmd
+
+    override def view(m: Model): RootNode =
+      val title = TextNode(2.x, 1.y, List("File-dialog demo".themed(_.primary)))
+      val help1 = TextNode(2.x, 3.y, List("f : open file picker    d : open directory picker".text))
+      val help2 = TextNode(2.x, 4.y, List("↑/↓ : move    Enter : activate    Esc : cancel    q : quit".text))
+      val pick = m.lastPick match
+        case Some(p) => TextNode(2.x, 6.y, List("Last pick: ".text, p.themed(_.success)))
+        case None    => TextNode(2.x, 6.y, List("Last pick: ".text, "(none yet)".themed(_.secondary)))
+
+      val baseRoot = RootNode(
+        width = 100,
+        height = 16,
+        children = List(title, help1, help2, pick),
+        input = None
+      )
+
+      m.dialog match
+        case Dialog.None => baseRoot
+        case Dialog.Open(Mode.Files, path, entries, idx) =>
+          baseRoot.copy(overlays = List(Dialogs.fileDialog("Open file", path, entries, idx, maxVisible = 8)))
+        case Dialog.Open(Mode.Directories, path, entries, idx) =>
+          baseRoot.copy(overlays =
+            List(Dialogs.directoryDialog("Choose directory", path, entries, idx, maxVisible = 8))
+          )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      Left(TermFlowError.Validation("FileDialogDemo has no prompt"))

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -5,6 +5,9 @@ import termflow.tui.Theme.themed
 import termflow.tui.Tui.*
 import termflow.tui.TuiPrelude.*
 
+import java.nio.file.Path
+import java.nio.file.Paths
+
 /**
  * Six-tab showcase of every shipped TermFlow widget and runtime feature.
  *
@@ -301,12 +304,23 @@ object Stage1ShowcaseApp:
     DemoFile("build.sbt")
   )
 
+  /** Whether a [[Dialog.FilePicker]] is showing files + directories or only directories. */
+  enum FilePickerMode:
+    case Files
+    case Directories
+
   enum Dialog:
     case None
     case ConfirmQuit(yesFocused: Boolean)
     case TextInput(state: Prompt.State, okFocused: Boolean)
     case ListSelect(selectedIndex: Int)
     case Waiting(openedAtTick: Long, autoCloseAtTick: Long)
+    case FilePicker(
+      mode: FilePickerMode,
+      currentPath: Path,
+      entries: Vector[Dialogs.FileEntry],
+      selectedIndex: Int
+    )
 
   final case class Model(
     width: Int,
@@ -327,6 +341,8 @@ object Stage1ShowcaseApp:
     lastTextInput: Option[String],
     /** Last item picked from a listSelect dialog. */
     lastListPick: Option[String],
+    /** Last value picked from a fileDialog / directoryDialog. */
+    lastFilePick: Option[String],
     /** Tick counter incremented by `tickSub`; drives the waiting spinner. */
     tick: Long,
     /** 0-based index of the currently selected tab. See `showcaseTabs`. */
@@ -379,6 +395,11 @@ object Stage1ShowcaseApp:
     case OpenTextInput
     case OpenListSelect
     case OpenWaiting
+    case OpenFileDialog
+    case OpenDirectoryDialog
+    case FilePickerMove(delta: Int)
+    case FilePickerActivate
+    case FilePickerAccept(path: String)
     case CloseDialog
     case ToggleDialogFocus
     case TextInputAccept(value: String)
@@ -412,6 +433,7 @@ object Stage1ShowcaseApp:
         eventHistory = Vector.empty,
         lastTextInput = None,
         lastListPick = None,
+        lastFilePick = None,
         tick = 0L,
         activeTab = ShowcaseTabIdx,
         treeExpanded = Set("termflow", "tui"),
@@ -449,6 +471,31 @@ object Stage1ShowcaseApp:
           m.copy(dialog = Dialog.ListSelect(selectedIndex = 0)).tui
         case OpenWaiting =>
           m.copy(dialog = Dialog.Waiting(openedAtTick = m.tick, autoCloseAtTick = m.tick + waitingDurationTicks)).tui
+        case OpenFileDialog      => openFilePicker(m, FilePickerMode.Files)
+        case OpenDirectoryDialog => openFilePicker(m, FilePickerMode.Directories)
+        case FilePickerMove(delta) =>
+          m.dialog match
+            case Dialog.FilePicker(mode, p, entries, idx) if entries.nonEmpty =>
+              val next = math.max(0, math.min(entries.size - 1, idx + delta))
+              m.copy(dialog = Dialog.FilePicker(mode, p, entries, next)).tui
+            case _ => m.tui
+        case FilePickerActivate =>
+          m.dialog match
+            case Dialog.FilePicker(mode, p, entries, idx) if entries.nonEmpty =>
+              entries(idx) match
+                case Dialogs.FileEntry.Parent =>
+                  refreshFilePicker(m, mode, Option(p.getParent).getOrElse(p))
+                case Dialogs.FileEntry.Directory(name) =>
+                  refreshFilePicker(m, mode, p.resolve(name))
+                case Dialogs.FileEntry.File(name, _) =>
+                  mode match
+                    case FilePickerMode.Files =>
+                      val picked = p.resolve(name).toString
+                      m.copy(dialog = Dialog.None, lastFilePick = Some(picked)).tui
+                    case FilePickerMode.Directories => m.tui
+            case _ => m.tui
+        case FilePickerAccept(path) =>
+          m.copy(dialog = Dialog.None, lastFilePick = Some(path)).tui
         case CloseDialog => m.copy(dialog = Dialog.None).tui
         case ToggleDialogFocus =>
           m.dialog match
@@ -537,6 +584,27 @@ object Stage1ShowcaseApp:
 
     private def clampIdx(i: Int, size: Int): Int = math.max(0, math.min(size - 1, i))
 
+    /** Start path for the file pickers — `user.home`, defaulting to `.` if unset. */
+    private val filePickerStartPath: Path = Paths.get(sys.props.getOrElse("user.home", "."))
+
+    private def openFilePicker(m: Model, mode: FilePickerMode): Tui[Model, Msg] =
+      refreshFilePicker(m, mode, filePickerStartPath)
+
+    /**
+     * (Re)list `path` and replace the FilePicker dialog state. On listing
+     * failure the dialog is closed and the error message is shown via
+     * `lastFilePick`.
+     */
+    private def refreshFilePicker(m: Model, mode: FilePickerMode, path: Path): Tui[Model, Msg] =
+      Dialogs.listEntries(path) match
+        case Right(entries) =>
+          val filtered = mode match
+            case FilePickerMode.Files       => entries
+            case FilePickerMode.Directories => entries.filter(_.isDirectory)
+          m.copy(dialog = Dialog.FilePicker(mode, path, filtered, 0)).tui
+        case Left(err) =>
+          m.copy(dialog = Dialog.None, lastFilePick = Some(s"error: $err")).tui
+
     private def dispatch(m: Model, k: KeyDecoder.InputKey): Cmd[Msg] =
       import KeyDecoder.InputKey.*
       m.dialog match
@@ -576,6 +644,16 @@ object Stage1ShowcaseApp:
             case Escape => Cmd.GCmd(CloseDialog)
             case _      => Cmd.NoCmd
 
+        case Dialog.FilePicker(_, _, _, _) =>
+          k match
+            case ArrowUp   => Cmd.GCmd(FilePickerMove(-1))
+            case ArrowDown => Cmd.GCmd(FilePickerMove(+1))
+            case PageUp    => Cmd.GCmd(FilePickerMove(-5))
+            case PageDown  => Cmd.GCmd(FilePickerMove(+5))
+            case Enter     => Cmd.GCmd(FilePickerActivate)
+            case Escape    => Cmd.GCmd(CloseDialog)
+            case _         => Cmd.NoCmd
+
         case Dialog.None =>
           // Tab-switch shortcuts work on every tab.
           digitTabSwitch(k, allowDigits = true) match
@@ -597,6 +675,8 @@ object Stage1ShowcaseApp:
         case CharKey('i') | CharKey('I') => Cmd.GCmd(OpenTextInput)
         case CharKey('l') | CharKey('L') => Cmd.GCmd(OpenListSelect)
         case CharKey('w') | CharKey('W') => Cmd.GCmd(OpenWaiting)
+        case CharKey('f') | CharKey('F') => Cmd.GCmd(OpenFileDialog)
+        case CharKey('g') | CharKey('G') => Cmd.GCmd(OpenDirectoryDialog)
         case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
         case Escape                      => Cmd.GCmd(OpenDialog)
         case Mouse(ev)                   => mouseDispatch(m, ev)
@@ -1045,7 +1125,11 @@ object Stage1ShowcaseApp:
             " l ".themed(_.primary),
             "list  ".text,
             " w ".themed(_.primary),
-            "wait  ".text
+            "wait  ".text,
+            " f ".themed(_.primary),
+            "file  ".text,
+            " g ".themed(_.primary),
+            "dir  ".text
           )
       val tail     = List[Text](" q ".themed(_.primary), "quit ".text)
       val helpNode = TextNode(2.x, (m.height - 1).y, tabSwitch ++ perTab ++ tail)
@@ -1111,6 +1195,30 @@ object Stage1ShowcaseApp:
                 body = s"simulated task — ${remaining / 10}.${remaining % 10}s remaining",
                 tick = m.tick - openedAt,
                 cancelLabel = Some("Cancel")
+              )
+            )
+          )
+        case Dialog.FilePicker(FilePickerMode.Files, p, entries, idx) =>
+          baseRoot.copy(overlays =
+            List(
+              Dialogs.fileDialog(
+                title = "Open file",
+                currentPath = p,
+                entries = entries,
+                selectedIndex = idx,
+                maxVisible = 8
+              )
+            )
+          )
+        case Dialog.FilePicker(FilePickerMode.Directories, p, entries, idx) =>
+          baseRoot.copy(overlays =
+            List(
+              Dialogs.directoryDialog(
+                title = "Choose directory",
+                currentPath = p,
+                entries = entries,
+                selectedIndex = idx,
+                maxVisible = 8
               )
             )
           )
@@ -1214,9 +1322,11 @@ object Stage1ShowcaseApp:
       )
       val txt  = m.lastTextInput.map(s => s"\"${truncate(s, 24)}\"").getOrElse("—")
       val pick = m.lastListPick.getOrElse("—")
+      val file = m.lastFilePick.map(truncate(_, 26)).getOrElse("—")
       val results = List(
         TextNode(2.x, 10.y, List("Last text input: ".text, txt.themed(_.info))),
-        TextNode(2.x, 11.y, List("Last list pick:  ".text, pick.themed(_.info)))
+        TextNode(2.x, 11.y, List("Last list pick:  ".text, pick.themed(_.info))),
+        TextNode(2.x, 12.y, List("Last file pick:  ".text, file.themed(_.info)))
       )
       panel(r, theme, (title :: intro :: historyRows) ++ results)
 
@@ -1472,6 +1582,7 @@ object Stage1ShowcaseApp:
         TextNode(2.x, 6.y, List("   b  cycle border style".text)),
         TextNode(2.x, 7.y, List("   t  cycle theme".text)),
         TextNode(2.x, 8.y, List("   d / i / l / w  open dialogs".text)),
+        TextNode(2.x, 9.y, List("   f / g  open fileDialog / directoryDialog".text)),
         TextNode(2.x, 10.y, List(" 2 Widgets (Tree)".themed(_.success))),
         TextNode(2.x, 11.y, List("   ↑/↓ move,  Space/Enter toggle node".text)),
         TextNode(2.x, 13.y, List(" 3 Inputs (Form)".themed(_.success))),

--- a/modules/termflow-sample/src/main/scala/termflow/run/TermFlowMain.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/run/TermFlowMain.scala
@@ -26,8 +26,10 @@ object TermFlowMain:
           new JLineTerminalBackend(),
           termflow.apps.diagnostics.LoggingMetricsDemoApp.Config
         )
-      case Some("input-line") | Some("input") => TuiRuntime.run(termflow.apps.input.InputLineReproApp.App)
-      case Some(_)                            => SampleHubMain.main(Array.empty)
+      case Some("input-line") | Some("input")    => TuiRuntime.run(termflow.apps.input.InputLineReproApp.App)
+      case Some("dialog") | Some("dialog-demo")  => TuiRuntime.run(termflow.apps.dialog.DialogDemoApp.App)
+      case Some("file-dialog") | Some("filedlg") => TuiRuntime.run(termflow.apps.dialog.FileDialogDemoApp.App)
+      case Some(_)                               => SampleHubMain.main(Array.empty)
 
   def syncCounterMain(args: Array[String]): Unit =
     val _ = args

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -413,6 +413,52 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(d.model.dialog == Stage1ShowcaseApp.Dialog.None, "waiting dialog should auto-close after its deadline")
   }
 
+  test("'f' opens the file picker rooted at user.home in Files mode") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('f')))
+    d.model.dialog match
+      case Stage1ShowcaseApp.Dialog.FilePicker(mode, _, _, _) =>
+        assert(mode == Stage1ShowcaseApp.FilePickerMode.Files)
+      case other => fail(s"expected FilePicker(Files), got $other")
+  }
+
+  test("'g' opens the file picker in Directories mode and filters out files") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('g')))
+    d.model.dialog match
+      case Stage1ShowcaseApp.Dialog.FilePicker(mode, _, entries, _) =>
+        assert(mode == Stage1ShowcaseApp.FilePickerMode.Directories)
+        assert(entries.forall(_.isDirectory), "Directories mode must drop File entries")
+      case other => fail(s"expected FilePicker(Directories), got $other")
+  }
+
+  test("ArrowDown advances FilePicker selection; Esc closes without picking") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('f')))
+    val before = d.model.dialog match
+      case Stage1ShowcaseApp.Dialog.FilePicker(_, _, _, idx) => idx
+      case other                                             => fail(s"expected FilePicker, got $other")
+    val entriesSize = d.model.dialog match
+      case Stage1ShowcaseApp.Dialog.FilePicker(_, _, e, _) => e.size
+      case _                                               => 0
+    if entriesSize > 1 then
+      d.send(Stage1ShowcaseApp.Msg.Key(InputKey.ArrowDown))
+      d.model.dialog match
+        case Stage1ShowcaseApp.Dialog.FilePicker(_, _, _, idx) => assert(idx == before + 1)
+        case other => fail(s"expected FilePicker after ArrowDown, got $other")
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Escape))
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.None)
+    assert(d.model.lastFilePick.isEmpty, "Esc must not record a pick")
+  }
+
+  test("FilePicker base bindings are suppressed (modal)") {
+    val d            = driver
+    val borderBefore = d.model.borderName
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('f')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('b')))
+    assert(d.model.borderName == borderBefore, "modal must suppress base 'b' binding")
+  }
+
   test("Esc inside waiting cancels immediately") {
     val d = driver
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('w')))

--- a/modules/termflow-testkit/src/main/scala/termflow/testkit/KeySim.scala
+++ b/modules/termflow-testkit/src/main/scala/termflow/testkit/KeySim.scala
@@ -1,0 +1,157 @@
+package termflow.testkit
+
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+
+/**
+ * Factory helpers for synthesising [[InputKey]] events in tests.
+ *
+ * `KeySim` exists so test bodies don't have to spell out the full
+ * `KeyDecoder.InputKey.CharKey('h')` / `Modified(ArrowUp, Modifiers(...))`
+ * incantations every time. The helpers return plain `InputKey` values, so
+ * apps wrap them in their own `Msg.Key(...)` (or whatever name they use) and
+ * feed through [[TuiTestDriver.send]].
+ *
+ * {{{
+ * import termflow.testkit.KeySim
+ *
+ * KeySim.typeString("hello\n").foreach(k => driver.send(Msg.Key(k)))
+ * driver.send(Msg.Key(KeySim.ctrlShift(KeySim.ArrowLeft)))
+ * driver.send(Msg.Key(KeySim.f(5)))
+ * }}}
+ *
+ * Pairs with [[MouseSim]], which produces `InputKey.Mouse(...)` values for
+ * the same input pipeline.
+ */
+object KeySim:
+
+  // ---- Named keys ---------------------------------------------------------
+
+  /**
+   * Re-export of the literal `InputKey` enum cases as fields so callers
+   * can write `KeySim.Enter` without importing `KeyDecoder.InputKey.*`.
+   */
+  val Enter: InputKey      = InputKey.Enter
+  val Escape: InputKey     = InputKey.Escape
+  val Backspace: InputKey  = InputKey.Backspace
+  val Delete: InputKey     = InputKey.Delete
+  val Insert: InputKey     = InputKey.Insert
+  val Home: InputKey       = InputKey.Home
+  val End: InputKey        = InputKey.End
+  val PageUp: InputKey     = InputKey.PageUp
+  val PageDown: InputKey   = InputKey.PageDown
+  val ArrowUp: InputKey    = InputKey.ArrowUp
+  val ArrowDown: InputKey  = InputKey.ArrowDown
+  val ArrowLeft: InputKey  = InputKey.ArrowLeft
+  val ArrowRight: InputKey = InputKey.ArrowRight
+  val BackTab: InputKey    = InputKey.BackTab
+  val Tab: InputKey        = InputKey.CharKey('\t')
+
+  // ---- Character + control ------------------------------------------------
+
+  /** Plain printable character keystroke. */
+  def char(c: Char): InputKey = InputKey.CharKey(c)
+
+  /** Ctrl-modified character (e.g. `Ctrl+C` is `ctrl('C')`). */
+  def ctrl(c: Char): InputKey = InputKey.Ctrl(c)
+
+  /** Function key by 1-based index in `[1, 12]`. */
+  def f(n: Int): InputKey = n match
+    case 1  => InputKey.F1
+    case 2  => InputKey.F2
+    case 3  => InputKey.F3
+    case 4  => InputKey.F4
+    case 5  => InputKey.F5
+    case 6  => InputKey.F6
+    case 7  => InputKey.F7
+    case 8  => InputKey.F8
+    case 9  => InputKey.F9
+    case 10 => InputKey.F10
+    case 11 => InputKey.F11
+    case 12 => InputKey.F12
+    case _ =>
+      throw new IllegalArgumentException(s"KeySim.f only supports F1..F12; got F$n")
+
+  /** Bracketed-paste payload — a single event carrying the whole pasted text. */
+  def paste(text: String): InputKey = InputKey.Paste(text)
+
+  // ---- Modifiers ----------------------------------------------------------
+
+  /**
+   * Wrap `key` in [[InputKey.Modified]] with the given modifier flags.
+   *
+   * Bare keys (no modifiers) are returned unchanged so the same convention
+   * the parser uses — never wrap an unmodified key — is preserved. Wrapping
+   * an already-modified key merges the new flags into the existing set.
+   */
+  def modified(
+    key: InputKey,
+    shift: Boolean = false,
+    alt: Boolean = false,
+    ctrl: Boolean = false,
+    meta: Boolean = false
+  ): InputKey =
+    val incoming = Modifiers(shift = shift, alt = alt, ctrl = ctrl, meta = meta)
+    if incoming.isEmpty then key
+    else
+      key match
+        case InputKey.Modified(inner, existing) =>
+          InputKey.Modified(
+            inner,
+            Modifiers(
+              shift = existing.shift || incoming.shift,
+              alt = existing.alt || incoming.alt,
+              ctrl = existing.ctrl || incoming.ctrl,
+              meta = existing.meta || incoming.meta
+            )
+          )
+        case other => InputKey.Modified(other, incoming)
+
+  /** Shorthand: shift-modify a key. */
+  def shift(key: InputKey): InputKey = modified(key, shift = true)
+
+  /** Shorthand: alt-modify a key. */
+  def alt(key: InputKey): InputKey = modified(key, alt = true)
+
+  /** Shorthand: ctrl-modify a key. Use [[ctrl(Char)]] for control characters. */
+  def ctrlMod(key: InputKey): InputKey = modified(key, ctrl = true)
+
+  /** Shorthand: meta-modify a key. */
+  def meta(key: InputKey): InputKey = modified(key, meta = true)
+
+  /** Shorthand: shift+ctrl-modify a key. */
+  def ctrlShift(key: InputKey): InputKey = modified(key, ctrl = true, shift = true)
+
+  /** Shorthand: shift+alt-modify a key. */
+  def altShift(key: InputKey): InputKey = modified(key, alt = true, shift = true)
+
+  // ---- Strings ------------------------------------------------------------
+
+  /**
+   * Convert a string into a sequence of keystrokes, one [[InputKey]] per
+   * character.
+   *
+   * Newlines (`\n`, `\r\n`, `\r`) become [[InputKey.Enter]] events;
+   * everything else — including `\t` — becomes [[InputKey.CharKey]]. To
+   * emulate a paste (one event for the whole payload), use [[paste]]
+   * instead.
+   *
+   * Returns a `Vector` so callers can `foreach` or splice without
+   * exhausting an iterator.
+   */
+  def typeString(s: String): Vector[InputKey] =
+    val builder = Vector.newBuilder[InputKey]
+    var i       = 0
+    while i < s.length do
+      val ch = s.charAt(i)
+      ch match
+        case '\r' =>
+          builder += InputKey.Enter
+          // Consume the paired LF in CRLF so we don't emit two Enters.
+          if i + 1 < s.length && s.charAt(i + 1) == '\n' then i += 1
+        case '\n' =>
+          builder += InputKey.Enter
+        case other =>
+          builder += InputKey.CharKey(other)
+      i += 1
+    builder.result()

--- a/modules/termflow-testkit/src/main/scala/termflow/testkit/MouseSim.scala
+++ b/modules/termflow-testkit/src/main/scala/termflow/testkit/MouseSim.scala
@@ -1,0 +1,156 @@
+package termflow.testkit
+
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+import termflow.tui.MouseButton
+import termflow.tui.MouseEvent
+import termflow.tui.ScrollDirection
+
+/**
+ * Factory helpers for synthesising mouse events in tests.
+ *
+ * Mouse events are multiplexed onto the key stream as
+ * `InputKey.Mouse(MouseEvent)` (Stage 2 §5.1), so every helper here returns
+ * an [[InputKey]] ready to drop into the same `Msg.Key(...)` handler that
+ * receives keyboard events.
+ *
+ * {{{
+ * import termflow.testkit.MouseSim
+ *
+ * driver.send(Msg.Key(MouseSim.click(col = 7, row = 3)))
+ * MouseSim.scrollDown(col = 10, row = 10, ticks = 3)
+ *   .foreach(k => driver.send(Msg.Key(k)))
+ * }}}
+ *
+ * Coordinates follow the rest of the library: 1-based, with `(1, 1)` at the
+ * top-left cell.
+ */
+object MouseSim:
+
+  /** No modifiers — convenience alias for the common case. */
+  val NoMods: Modifiers = Modifiers.none
+
+  // ---- Single events ------------------------------------------------------
+
+  /**
+   * Synthesise a left-button click — a [[MouseEvent.Press]] / `InputKey.Mouse`
+   * pair. Most apps consume `Press` directly; if your handler waits for
+   * `Release`, use [[clickPair]] to get both events.
+   */
+  def click(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    press(col, row, button, mods)
+
+  /** Press event for `button` at `(col, row)`. */
+  def press(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Press(button, col, row, mods))
+
+  /** Release event for `button` at `(col, row)`. */
+  def release(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Release(button, col, row, mods))
+
+  /** Drag event — motion with a held `button` at `(col, row)`. */
+  def drag(col: Int, row: Int, button: MouseButton = MouseButton.Left, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Drag(button, col, row, mods))
+
+  /**
+   * Bare motion (no held button) at `(col, row)`. The runtime only enables
+   * any-event tracking on demand, so most apps never see these in
+   * production — simulate them anyway when wiring hover behaviour.
+   */
+  def move(col: Int, row: Int, mods: Modifiers = NoMods): InputKey =
+    InputKey.Mouse(MouseEvent.Move(col, row, mods))
+
+  /** Single scroll-wheel detent in `direction`. Use [[scroll]] for bursts. */
+  def scrollOnce(
+    direction: ScrollDirection,
+    col: Int,
+    row: Int,
+    mods: Modifiers = NoMods
+  ): InputKey =
+    InputKey.Mouse(MouseEvent.Scroll(direction, col, row, mods))
+
+  // ---- Sequences ----------------------------------------------------------
+
+  /**
+   * Press + release pair for `button` at `(col, row)`. Useful for apps that
+   * activate on `Release` rather than `Press`. The two events share
+   * coordinates and modifier state — a real terminal can shift between
+   * them but a synthetic test usually doesn't care.
+   */
+  def clickPair(
+    col: Int,
+    row: Int,
+    button: MouseButton = MouseButton.Left,
+    mods: Modifiers = NoMods
+  ): Vector[InputKey] =
+    Vector(
+      press(col, row, button, mods),
+      release(col, row, button, mods)
+    )
+
+  /**
+   * `ticks` consecutive scroll detents in `direction`. Common shorthand
+   * for "the user wheeled three notches down at (col, row)".
+   *
+   * @throws IllegalArgumentException if `ticks` is negative.
+   */
+  def scroll(
+    direction: ScrollDirection,
+    col: Int,
+    row: Int,
+    ticks: Int = 1,
+    mods: Modifiers = NoMods
+  ): Vector[InputKey] =
+    require(ticks >= 0, s"MouseSim.scroll ticks must be non-negative, got $ticks")
+    Vector.fill(ticks)(scrollOnce(direction, col, row, mods))
+
+  /** Convenience: `ticks` scroll-up detents at `(col, row)`. */
+  def scrollUp(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Up, col, row, ticks, mods)
+
+  /** Convenience: `ticks` scroll-down detents at `(col, row)`. */
+  def scrollDown(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Down, col, row, ticks, mods)
+
+  /** Convenience: `ticks` scroll-left detents at `(col, row)`. */
+  def scrollLeft(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Left, col, row, ticks, mods)
+
+  /** Convenience: `ticks` scroll-right detents at `(col, row)`. */
+  def scrollRight(col: Int, row: Int, ticks: Int = 1, mods: Modifiers = NoMods): Vector[InputKey] =
+    scroll(ScrollDirection.Right, col, row, ticks, mods)
+
+  /**
+   * A drag gesture from `(fromCol, fromRow)` to `(toCol, toRow)`: a press,
+   * a series of [[MouseEvent.Drag]] events along a straight Bresenham-ish
+   * path, and a final release. The path is sampled at `steps`+1 points so
+   * tests with hit-testing can validate the intermediate positions —
+   * `steps = 0` collapses to press + release at the start, then end.
+   *
+   * @param steps Number of intermediate drag samples between the endpoints
+   *              (excluding press / release). Must be non-negative.
+   */
+  def dragGesture(
+    fromCol: Int,
+    fromRow: Int,
+    toCol: Int,
+    toRow: Int,
+    button: MouseButton = MouseButton.Left,
+    steps: Int = 4,
+    mods: Modifiers = NoMods
+  ): Vector[InputKey] =
+    require(steps >= 0, s"MouseSim.dragGesture steps must be non-negative, got $steps")
+    val builder = Vector.newBuilder[InputKey]
+    builder += press(fromCol, fromRow, button, mods)
+    if steps > 0 then
+      val total = steps + 1
+      var i     = 1
+      while i <= steps do
+        val t   = i.toDouble / total.toDouble
+        val col = math.round(fromCol + (toCol - fromCol) * t).toInt
+        val row = math.round(fromRow + (toRow - fromRow) * t).toInt
+        builder += drag(col, row, button, mods)
+        i += 1
+    builder += drag(toCol, toRow, button, mods)
+    builder += release(toCol, toRow, button, mods)
+    builder.result()

--- a/modules/termflow-testkit/src/test/scala/termflow/testkit/KeySimSpec.scala
+++ b/modules/termflow-testkit/src/test/scala/termflow/testkit/KeySimSpec.scala
@@ -1,0 +1,119 @@
+package termflow.testkit
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+
+class KeySimSpec extends AnyFunSuite:
+
+  test("char wraps a printable character") {
+    assert(KeySim.char('a') == InputKey.CharKey('a'))
+  }
+
+  test("ctrl produces a Ctrl key event") {
+    assert(KeySim.ctrl('C') == InputKey.Ctrl('C'))
+  }
+
+  test("named key fields are exact aliases of the InputKey cases") {
+    assert(KeySim.Enter == InputKey.Enter)
+    assert(KeySim.Escape == InputKey.Escape)
+    assert(KeySim.Backspace == InputKey.Backspace)
+    assert(KeySim.Delete == InputKey.Delete)
+    assert(KeySim.Insert == InputKey.Insert)
+    assert(KeySim.Home == InputKey.Home)
+    assert(KeySim.End == InputKey.End)
+    assert(KeySim.PageUp == InputKey.PageUp)
+    assert(KeySim.PageDown == InputKey.PageDown)
+    assert(KeySim.ArrowUp == InputKey.ArrowUp)
+    assert(KeySim.ArrowDown == InputKey.ArrowDown)
+    assert(KeySim.ArrowLeft == InputKey.ArrowLeft)
+    assert(KeySim.ArrowRight == InputKey.ArrowRight)
+    assert(KeySim.BackTab == InputKey.BackTab)
+    assert(KeySim.Tab == InputKey.CharKey('\t'))
+  }
+
+  test("f produces F1..F12 cases") {
+    val expected = Vector(
+      InputKey.F1,
+      InputKey.F2,
+      InputKey.F3,
+      InputKey.F4,
+      InputKey.F5,
+      InputKey.F6,
+      InputKey.F7,
+      InputKey.F8,
+      InputKey.F9,
+      InputKey.F10,
+      InputKey.F11,
+      InputKey.F12
+    )
+    (1 to 12).foreach(i => assert(KeySim.f(i) == expected(i - 1), s"F$i mismatch"))
+  }
+
+  test("f rejects out-of-range values") {
+    intercept[IllegalArgumentException](KeySim.f(0))
+    intercept[IllegalArgumentException](KeySim.f(13))
+  }
+
+  test("paste preserves the literal payload, including embedded newlines") {
+    val payload = "first\nsecond\nthird"
+    assert(KeySim.paste(payload) == InputKey.Paste(payload))
+  }
+
+  test("modified returns the bare key when no flags are set") {
+    assert(KeySim.modified(InputKey.ArrowUp) == InputKey.ArrowUp)
+  }
+
+  test("modified wraps a single flag") {
+    val k = KeySim.modified(InputKey.ArrowRight, ctrl = true)
+    assert(k == InputKey.Modified(InputKey.ArrowRight, Modifiers(ctrl = true)))
+  }
+
+  test("modified merges flags into an existing Modified envelope") {
+    val first  = KeySim.shift(InputKey.ArrowDown)
+    val second = KeySim.modified(first, ctrl = true)
+    second match
+      case InputKey.Modified(inner, mods) =>
+        assert(inner == InputKey.ArrowDown)
+        assert(mods.shift && mods.ctrl)
+      case other => fail(s"expected Modified, got $other")
+  }
+
+  test("ctrlShift wraps both modifiers") {
+    val k = KeySim.ctrlShift(InputKey.ArrowLeft)
+    k match
+      case InputKey.Modified(inner, mods) =>
+        assert(inner == InputKey.ArrowLeft)
+        assert(mods.ctrl && mods.shift)
+        assert(!mods.alt && !mods.meta)
+      case other => fail(s"expected Modified, got $other")
+  }
+
+  test("typeString turns a plain string into one CharKey per character") {
+    val keys = KeySim.typeString("hi")
+    assert(keys == Vector(InputKey.CharKey('h'), InputKey.CharKey('i')))
+  }
+
+  test("typeString returns a CharKey for tab") {
+    val keys = KeySim.typeString("a\tb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.CharKey('\t'), InputKey.CharKey('b')))
+  }
+
+  test("typeString turns LF into Enter") {
+    val keys = KeySim.typeString("a\nb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Enter, InputKey.CharKey('b')))
+  }
+
+  test("typeString collapses CRLF into a single Enter event") {
+    val keys = KeySim.typeString("a\r\nb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Enter, InputKey.CharKey('b')))
+  }
+
+  test("typeString turns a bare CR into Enter") {
+    val keys = KeySim.typeString("a\rb")
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Enter, InputKey.CharKey('b')))
+  }
+
+  test("typeString of an empty string yields no events") {
+    assert(KeySim.typeString("").isEmpty)
+  }

--- a/modules/termflow-testkit/src/test/scala/termflow/testkit/MouseSimSpec.scala
+++ b/modules/termflow-testkit/src/test/scala/termflow/testkit/MouseSimSpec.scala
@@ -1,0 +1,137 @@
+package termflow.testkit
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.Modifiers
+import termflow.tui.MouseButton
+import termflow.tui.MouseEvent
+import termflow.tui.ScrollDirection
+
+class MouseSimSpec extends AnyFunSuite:
+
+  test("click returns a left-button Press wrapped in InputKey.Mouse") {
+    val k = MouseSim.click(7, 3)
+    k match
+      case InputKey.Mouse(MouseEvent.Press(MouseButton.Left, c, r, mods)) =>
+        assert(c == 7 && r == 3)
+        assert(mods.isEmpty)
+      case other => fail(s"expected left-press at (7,3), got $other")
+  }
+
+  test("press preserves the requested button + modifiers") {
+    val k = MouseSim.press(2, 4, MouseButton.Right, Modifiers(ctrl = true))
+    k match
+      case InputKey.Mouse(MouseEvent.Press(MouseButton.Right, 2, 4, mods)) =>
+        assert(mods.ctrl)
+        assert(!mods.shift)
+      case other => fail(s"unexpected $other")
+  }
+
+  test("release builds a release event") {
+    val k = MouseSim.release(10, 5)
+    k match
+      case InputKey.Mouse(MouseEvent.Release(MouseButton.Left, 10, 5, _)) => ()
+      case other                                                          => fail(s"unexpected $other")
+  }
+
+  test("drag builds a drag event") {
+    val k = MouseSim.drag(11, 6, MouseButton.Middle)
+    k match
+      case InputKey.Mouse(MouseEvent.Drag(MouseButton.Middle, 11, 6, _)) => ()
+      case other                                                         => fail(s"unexpected $other")
+  }
+
+  test("move builds a move event") {
+    val k = MouseSim.move(12, 7)
+    k match
+      case InputKey.Mouse(MouseEvent.Move(12, 7, _)) => ()
+      case other                                     => fail(s"unexpected $other")
+  }
+
+  test("scrollOnce wraps a single Scroll event in the requested direction") {
+    val k = MouseSim.scrollOnce(ScrollDirection.Up, 4, 4)
+    k match
+      case InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Up, 4, 4, _)) => ()
+      case other                                                          => fail(s"unexpected $other")
+  }
+
+  test("clickPair returns press then release with matching coordinates") {
+    val pair = MouseSim.clickPair(2, 3, MouseButton.Left)
+    assert(pair.size == 2)
+    pair(0) match
+      case InputKey.Mouse(MouseEvent.Press(MouseButton.Left, 2, 3, _)) => ()
+      case other                                                       => fail(s"expected press first, got $other")
+    pair(1) match
+      case InputKey.Mouse(MouseEvent.Release(MouseButton.Left, 2, 3, _)) => ()
+      case other                                                         => fail(s"expected release second, got $other")
+  }
+
+  test("scroll repeats a single direction for the requested ticks") {
+    val ks = MouseSim.scroll(ScrollDirection.Down, 5, 5, ticks = 3)
+    assert(ks.size == 3)
+    ks.foreach {
+      case InputKey.Mouse(MouseEvent.Scroll(ScrollDirection.Down, 5, 5, _)) => ()
+      case other                                                            => fail(s"unexpected $other")
+    }
+  }
+
+  test("scroll with ticks = 0 yields an empty sequence") {
+    assert(MouseSim.scroll(ScrollDirection.Up, 1, 1, ticks = 0).isEmpty)
+  }
+
+  test("scroll rejects negative ticks") {
+    intercept[IllegalArgumentException](MouseSim.scroll(ScrollDirection.Up, 1, 1, ticks = -1))
+  }
+
+  test("scrollUp / scrollDown / scrollLeft / scrollRight pick the right direction") {
+    def dirOf(k: InputKey): ScrollDirection = k match
+      case InputKey.Mouse(MouseEvent.Scroll(d, _, _, _)) => d
+      case other                                         => fail(s"not a scroll event: $other")
+
+    assert(MouseSim.scrollUp(1, 1).map(dirOf).head == ScrollDirection.Up)
+    assert(MouseSim.scrollDown(1, 1).map(dirOf).head == ScrollDirection.Down)
+    assert(MouseSim.scrollLeft(1, 1).map(dirOf).head == ScrollDirection.Left)
+    assert(MouseSim.scrollRight(1, 1).map(dirOf).head == ScrollDirection.Right)
+  }
+
+  test("dragGesture starts with a press, ends with a release at the destination") {
+    val seq = MouseSim.dragGesture(2, 2, 8, 4, steps = 2)
+    seq.head match
+      case InputKey.Mouse(MouseEvent.Press(_, 2, 2, _)) => ()
+      case other                                        => fail(s"first event should be press at origin, got $other")
+    seq.last match
+      case InputKey.Mouse(MouseEvent.Release(_, 8, 4, _)) => ()
+      case other => fail(s"last event should be release at destination, got $other")
+  }
+
+  test("dragGesture with steps = 0 collapses to press + drag-to-end + release") {
+    val seq = MouseSim.dragGesture(0, 0, 5, 5, steps = 0)
+    assert(seq.size == 3)
+    seq(0) match
+      case InputKey.Mouse(MouseEvent.Press(_, 0, 0, _)) => ()
+      case other                                        => fail(s"expected press, got $other")
+    seq(1) match
+      case InputKey.Mouse(MouseEvent.Drag(_, 5, 5, _)) => ()
+      case other                                       => fail(s"expected drag-to-end, got $other")
+    seq(2) match
+      case InputKey.Mouse(MouseEvent.Release(_, 5, 5, _)) => ()
+      case other                                          => fail(s"expected release, got $other")
+  }
+
+  test("dragGesture samples intermediate drag positions on the line") {
+    val seq   = MouseSim.dragGesture(0, 0, 10, 0, steps = 4)
+    val drags = seq.collect { case InputKey.Mouse(d @ MouseEvent.Drag(_, _, _, _)) => d }
+    // 4 intermediate samples + final drag at the destination = 5 drag events.
+    assert(drags.size == 5)
+    // X-coordinate must be non-decreasing along the sampled drags.
+    val xs = drags.map(_.col)
+    assert(xs == xs.sorted)
+    // Final drag is exactly at the destination.
+    assert(drags.last.col == 10 && drags.last.row == 0)
+  }
+
+  test("dragGesture rejects negative steps") {
+    intercept[IllegalArgumentException](
+      MouseSim.dragGesture(0, 0, 1, 1, steps = -1)
+    )
+  }

--- a/modules/termflow/src/main/scala/termflow/tui/Dialogs.scala
+++ b/modules/termflow/src/main/scala/termflow/tui/Dialogs.scala
@@ -1,5 +1,12 @@
 package termflow.tui
 
+import termflow.tui.TuiPrelude.Result
+
+import java.nio.file.Files
+import java.nio.file.Path
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+
 /**
  * Builders for common modal dialogs as [[Overlay]] values.
  *
@@ -272,6 +279,319 @@ object Dialogs:
       children = (box :: titleNode :: rows) :+ actionsRow,
       inputCapture = InputCapture.Modal
     )
+
+  /**
+   * One row in a [[fileDialog]] / [[directoryDialog]] listing.
+   *
+   * The helpers are pure presentation: they don't touch the filesystem.
+   * Apps build a `Seq[FileEntry]` (typically via [[listEntries]]) and pass
+   * it in alongside the current selection. This keeps directory traversal
+   * and any caching policy (e.g. listing in a `Future` for huge trees) out
+   * of the dialog rendering, which stays trivially testable.
+   */
+  enum FileEntry:
+    /** Sentinel for the parent directory. Rendered as `"..".`. */
+    case Parent
+
+    /** A subdirectory of the currently displayed path. */
+    case Directory(name: String)
+
+    /** A regular file in the currently displayed path. */
+    case File(name: String, size: Long)
+
+    /** True for `Parent` and `Directory(_)`; false for `File(_, _)`. */
+    def isDirectory: Boolean = this match
+      case Parent | Directory(_) => true
+      case File(_, _)            => false
+
+    /** Human-readable name; directories get a trailing `/`. */
+    def displayName: String = this match
+      case Parent          => ".."
+      case Directory(name) => s"$name/"
+      case File(name, _)   => name
+
+  /**
+   * Synchronously list the immediate children of `path` as a
+   * `Vector[FileEntry]`, sorted directories-first then alphabetically.
+   *
+   * A [[FileEntry.Parent]] sentinel is prepended unless `path` is the
+   * filesystem root. Hidden entries (names starting with `.`) are filtered
+   * out unless `showHidden` is set.
+   *
+   * Errors (path not a directory, permission denied, I/O failure) are
+   * surfaced as `TermFlowError.Unexpected` so the caller can choose
+   * whether to render an error toast or fall back. Apps that need
+   * non-blocking listings on slow filesystems should wrap the call in a
+   * `Cmd.asyncResult` rather than calling this from `view`.
+   *
+   * @param path        Directory to list.
+   * @param showHidden  Include dotfiles when true.
+   */
+  def listEntries(path: Path, showHidden: Boolean = false): Result[Vector[FileEntry]] =
+    Try {
+      if !Files.isDirectory(path) then throw new IllegalArgumentException(s"Not a directory: $path")
+      val parentEntry =
+        if path.getParent != null then Vector(FileEntry.Parent) else Vector.empty
+      val stream = Files.newDirectoryStream(path)
+      try
+        val all = stream.iterator().asScala.toVector
+        val visible =
+          if showHidden then all
+          else all.filterNot(p => Option(p.getFileName).exists(_.toString.startsWith(".")))
+        val (rawDirs, rawFiles) = visible.partition(p => Files.isDirectory(p))
+        val dirs =
+          rawDirs
+            .sortBy(p => Option(p.getFileName).fold("")(_.toString.toLowerCase))
+            .map(p => FileEntry.Directory(p.getFileName.toString))
+        val files =
+          rawFiles
+            .sortBy(p => Option(p.getFileName).fold("")(_.toString.toLowerCase))
+            .map { p =>
+              val size = Try(Files.size(p)).getOrElse(0L)
+              FileEntry.File(p.getFileName.toString, size)
+            }
+        parentEntry ++ dirs ++ files
+      finally stream.close()
+    }.toEither.left.map(t => TermFlowError.Unexpected(s"listEntries failed for $path", Some(t)))
+
+  /**
+   * Layout descriptor for a [[fileDialog]] or [[directoryDialog]]. Mirrors
+   * [[ListSelectLayout]] so apps wiring mouse hit-testing on the listing
+   * portion can map a click row to an entry without re-deriving the
+   * helper's anchor math.
+   *
+   * @param visibleCount   Number of list rows actually drawn.
+   * @param anchorIndex    Index of the first visible entry — selection
+   *                       scrolls relative to this.
+   * @param firstRowOffset Y-offset of the first list row inside the
+   *                       overlay rectangle (panel-local).
+   */
+  final case class FileDialogLayout(
+    visibleCount: Int,
+    anchorIndex: Int,
+    firstRowOffset: Int
+  )
+
+  /** First selectable row inside a fileDialog (panel-local Y). */
+  private val FileDialogFirstRowOffset: Int = 4
+
+  /** Compute the visible-window math `fileDialog` uses internally. */
+  def fileDialogLayout(
+    entriesSize: Int,
+    selectedIndex: Int,
+    maxVisible: Int = 10
+  ): FileDialogLayout =
+    val visible = math.max(1, math.min(maxVisible, math.max(1, entriesSize)))
+    val anchor =
+      if entriesSize == 0 then 0
+      else
+        val sel    = math.max(0, math.min(entriesSize - 1, selectedIndex))
+        val maxTop = math.max(0, entriesSize - visible)
+        val raw    = sel - visible / 2
+        math.max(0, math.min(maxTop, raw))
+    FileDialogLayout(visible, anchor, FileDialogFirstRowOffset)
+
+  /**
+   * Centred file-picker dialog. Renders the current path on the second
+   * row, a scrollable list of [[FileEntry]] values below it, and an
+   * OK / Cancel action row at the bottom.
+   *
+   * Like the other helpers, `fileDialog` is pure presentation. The app
+   * holds:
+   *
+   *   - the current `Path` and a precomputed `Seq[FileEntry]` for it
+   *     (via [[listEntries]] or its own listing strategy);
+   *   - a `selectedIndex` that the app advances on `↑`/`↓`;
+   *   - logic that, on `Enter` over a [[FileEntry.Directory]] or
+   *     [[FileEntry.Parent]], rebuilds `entries` for the new path.
+   *
+   * The dialog itself doesn't filter or sort entries — it draws what it
+   * is given. Use [[directoryDialog]] when you want a directory-only
+   * picker; in that mode entries should already be filtered to
+   * directories.
+   *
+   * Sizing: width is the max of (title + padding), (path + padding),
+   * (longest item + size column + padding), (action row + padding) with
+   * a 50-cell floor. Height is `6 + visibleCount`.
+   *
+   * @param title         Title rendered on the top border.
+   * @param currentPath   Path shown on the second row. Truncated from
+   *                      the left with `…` if longer than the inner width.
+   * @param entries       Listing rows to draw. The first entry is shown
+   *                      at the top of the viewport; selection scrolls
+   *                      the viewport per [[fileDialogLayout]].
+   * @param selectedIndex Index of the highlighted row.
+   * @param okFocused     Action-button focus.
+   * @param maxVisible    Number of entry rows visible at once. Defaults to 10.
+   * @param showSizes     Render a right-aligned size column for files.
+   *                      Off for [[directoryDialog]] by default.
+   * @param okLabel       Label for the confirm button.
+   * @param cancelLabel   Label for the cancel button.
+   * @param position      Anchor (default [[OverlayPosition.Centered]]).
+   */
+  def fileDialog(
+    title: String,
+    currentPath: Path,
+    entries: Seq[FileEntry],
+    selectedIndex: Int,
+    okFocused: Boolean = true,
+    maxVisible: Int = 10,
+    showSizes: Boolean = true,
+    okLabel: String = "Open",
+    cancelLabel: String = "Cancel",
+    position: OverlayPosition = OverlayPosition.Centered
+  )(using theme: Theme): Overlay =
+    val layout  = fileDialogLayout(entries.size, selectedIndex, maxVisible)
+    val visible = layout.visibleCount
+    val anchor  = layout.anchorIndex
+    val choices = List(Choice(okLabel, okFocused), Choice(cancelLabel, !okFocused))
+
+    val pathStr    = currentPath.toString
+    val titleLen   = title.length + 4
+    val pathLen    = pathStr.length + 8 // "Path: " + name + padding
+    val actionsLen = choiceWidth(choices) + 4
+    val sizeColLen = if showSizes then 10 else 0
+    val itemLen =
+      (0 +: entries.map(e => e.displayName.length)).max + 4 + sizeColLen
+    val width  = math.max(50, math.max(titleLen, math.max(pathLen, math.max(actionsLen, itemLen))))
+    val height = 6 + visible
+
+    val box = Theme.box(XCoord(1), YCoord(1), width, height)
+    val titleNode =
+      TextNode(XCoord(3), YCoord(1), List(Text(s" $title ", Style(fg = theme.primary, bold = true))))
+
+    val innerWidth = width - 4
+    val pathLabel  = "Path: "
+    val pathBudget = math.max(1, innerWidth - pathLabel.length)
+    val pathDisplay =
+      if pathStr.length <= pathBudget then pathStr
+      else "…" + pathStr.takeRight(math.max(1, pathBudget - 1))
+    val pathNode =
+      TextNode(
+        XCoord(3),
+        YCoord(2),
+        List(
+          Text(pathLabel, Style(fg = theme.secondary)),
+          Text(pathDisplay, Style(fg = theme.foreground))
+        )
+      )
+
+    val rows: List[VNode] =
+      entries
+        .slice(anchor, anchor + visible)
+        .zipWithIndex
+        .map { case (entry, i) =>
+          val absIdx = anchor + i
+          val sel    = absIdx == selectedIndex
+          renderEntryRow(entry, sel, layout.firstRowOffset + i, innerWidth, showSizes, theme)
+        }
+        .toList
+
+    val actionsRow = renderActions(choices, width, height - 1, theme)
+
+    Overlay(
+      position = position,
+      width = width,
+      height = height,
+      children = (box :: titleNode :: pathNode :: rows) :+ actionsRow,
+      inputCapture = InputCapture.Modal
+    )
+
+  /**
+   * Centred directory-picker dialog. Identical layout to [[fileDialog]]
+   * but defaults `okLabel = "Select"` and `showSizes = false`. Apps are
+   * expected to have already filtered `entries` to directories (and the
+   * [[FileEntry.Parent]] sentinel) — the dialog itself doesn't enforce
+   * the constraint, so listing files alongside directories still
+   * renders, just without sizes.
+   */
+  def directoryDialog(
+    title: String,
+    currentPath: Path,
+    entries: Seq[FileEntry],
+    selectedIndex: Int,
+    okFocused: Boolean = true,
+    maxVisible: Int = 10,
+    okLabel: String = "Select",
+    cancelLabel: String = "Cancel",
+    position: OverlayPosition = OverlayPosition.Centered
+  )(using Theme): Overlay =
+    fileDialog(
+      title = title,
+      currentPath = currentPath,
+      entries = entries,
+      selectedIndex = selectedIndex,
+      okFocused = okFocused,
+      maxVisible = maxVisible,
+      showSizes = false,
+      okLabel = okLabel,
+      cancelLabel = cancelLabel,
+      position = position
+    )
+
+  /**
+   * Format a byte count as a short, human-readable size string for the
+   * file-dialog size column. Kept package-private for tests.
+   */
+  private[tui] def formatSize(bytes: Long): String =
+    if bytes < 1024L then s"$bytes B"
+    else
+      val units         = Vector("KB", "MB", "GB", "TB", "PB")
+      var value: Double = bytes.toDouble / 1024.0
+      var idx           = 0
+      while value >= 1024.0 && idx < units.size - 1 do
+        value /= 1024.0
+        idx += 1
+      val rendered =
+        if value >= 100.0 then f"$value%.0f"
+        else if value >= 10.0 then f"$value%.1f"
+        else f"$value%.2f"
+      s"$rendered ${units(idx)}"
+
+  private def renderEntryRow(
+    entry: FileEntry,
+    selected: Boolean,
+    row: Int,
+    innerWidth: Int,
+    showSizes: Boolean,
+    theme: Theme
+  ): VNode =
+    val marker = if selected then "▸ " else "  "
+    val (glyph, glyphColor) = entry match
+      case FileEntry.Parent       => ("↩ ", theme.info)
+      case FileEntry.Directory(_) => ("▸ ", theme.primary)
+      case FileEntry.File(_, _)   => ("  ", theme.foreground)
+    val nameStyle =
+      if selected then Style(fg = theme.background, bg = theme.primary, bold = true)
+      else Style(fg = theme.foreground)
+    val markerStyle =
+      if selected then nameStyle
+      else Style(fg = glyphColor, bold = entry.isDirectory)
+    val sizeText = entry match
+      case FileEntry.File(_, size) if showSizes => formatSize(size)
+      case _                                    => ""
+    val nameMaxLen =
+      math.max(1, innerWidth - marker.length - glyph.length - (if sizeText.nonEmpty then sizeText.length + 2 else 0))
+    val displayName = entry.displayName
+    val truncatedName =
+      if displayName.length <= nameMaxLen then displayName
+      else displayName.take(math.max(1, nameMaxLen - 1)) + "…"
+    val padCount =
+      if sizeText.isEmpty then 0
+      else math.max(1, nameMaxLen - truncatedName.length + 1)
+    val padding = if padCount > 0 then " " * padCount else ""
+    val sizeStyle =
+      if selected then nameStyle
+      else Style(fg = theme.secondary)
+    val segments: List[Text] =
+      val base = List(
+        Text(marker, markerStyle),
+        Text(glyph, markerStyle),
+        Text(truncatedName, nameStyle)
+      )
+      if sizeText.isEmpty then base
+      else base ++ List(Text(padding, nameStyle), Text(sizeText, sizeStyle))
+    TextNode(XCoord(3), YCoord(row), segments)
 
   /**
    * Animated frames for [[waiting]]. Apps that don't pass a custom set

--- a/modules/termflow/src/test/scala/termflow/tui/DialogsSpec.scala
+++ b/modules/termflow/src/test/scala/termflow/tui/DialogsSpec.scala
@@ -2,6 +2,10 @@ package termflow.tui
 
 import org.scalatest.funsuite.AnyFunSuite
 
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
 class DialogsSpec extends AnyFunSuite:
 
   given Theme = Theme.dark
@@ -195,6 +199,214 @@ class DialogsSpec extends AnyFunSuite:
       s"expected one of X/Y/Z prefixed frames, got: $s"
     )
   }
+
+  // ---- Dialogs.fileDialog / directoryDialog -------------------------------
+
+  test("Dialogs.fileDialog renders the path, entries, and OK/Cancel") {
+    val o = Dialogs.fileDialog(
+      title = "Open file",
+      currentPath = Paths.get("/tmp/example"),
+      entries = Seq(
+        Dialogs.FileEntry.Parent,
+        Dialogs.FileEntry.Directory("docs"),
+        Dialogs.FileEntry.File("README.md", 1234L)
+      ),
+      selectedIndex = 1
+    )
+    assert(o.inputCapture == InputCapture.Modal)
+    assert(o.input.isEmpty)
+    val s = stringForm(o)
+    assert(s.contains("Open file"))
+    assert(s.contains("/tmp/example"))
+    assert(s.contains(".."))
+    assert(s.contains("docs"))
+    assert(s.contains("README.md"))
+    assert(s.contains("[ Open ]"))
+    assert(s.contains("Cancel"))
+  }
+
+  test("Dialogs.fileDialog highlights the selected row with a marker") {
+    val o = Dialogs.fileDialog(
+      title = "Open",
+      currentPath = Paths.get("/x"),
+      entries = Seq(
+        Dialogs.FileEntry.Parent,
+        Dialogs.FileEntry.Directory("a"),
+        Dialogs.FileEntry.Directory("b")
+      ),
+      selectedIndex = 2
+    )
+    val s = stringForm(o)
+    // Selection marker is "▸ " followed by the directory glyph and name.
+    assert(s.contains("▸"), s"expected selection marker, got: $s")
+    // The selected row should hold the "b" name; "a" should not be marked.
+    val bIdx      = s.indexOf("b/")
+    val markerIdx = s.lastIndexOf("▸")
+    assert(bIdx > 0 && markerIdx > 0 && markerIdx < bIdx)
+  }
+
+  test("Dialogs.fileDialog renders sizes for files when showSizes is on (default)") {
+    val o = Dialogs.fileDialog(
+      title = "Pick",
+      currentPath = Paths.get("/x"),
+      entries = Seq(Dialogs.FileEntry.File("big.bin", 5L * 1024 * 1024)),
+      selectedIndex = 0
+    )
+    val s = stringForm(o)
+    assert(s.contains("big.bin"))
+    assert(s.contains("MB"), s"expected size column with MB unit, got: $s")
+  }
+
+  test("Dialogs.fileDialog with showSizes=false omits the size column") {
+    val o = Dialogs.fileDialog(
+      title = "Pick",
+      currentPath = Paths.get("/x"),
+      entries = Seq(Dialogs.FileEntry.File("big.bin", 5L * 1024 * 1024)),
+      selectedIndex = 0,
+      showSizes = false
+    )
+    val s = stringForm(o)
+    assert(s.contains("big.bin"))
+    assert(!s.contains("MB"))
+  }
+
+  test("Dialogs.fileDialog truncates a very long path from the left") {
+    val deep = Paths.get("/a/very/very/very/very/very/very/very/very/long/path/to/somewhere")
+    val o    = Dialogs.fileDialog("Open", deep, entries = Seq.empty, selectedIndex = 0)
+    val s    = stringForm(o)
+    assert(s.contains("…"), s"expected ellipsis on truncated path, got: $s")
+    assert(s.contains("somewhere"), "tail of the path should remain visible")
+  }
+
+  test("Dialogs.fileDialog scrolls so the selected entry stays visible") {
+    val many = (1 to 30).map(i => Dialogs.FileEntry.File(s"file-$i.txt", i.toLong))
+    val o = Dialogs.fileDialog(
+      title = "Pick",
+      currentPath = Paths.get("/x"),
+      entries = many,
+      selectedIndex = 25,
+      maxVisible = 5
+    )
+    val s = stringForm(o)
+    assert(s.contains("file-25.txt"), s"selected file must be visible, got: $s")
+    assert(!s.contains("file-1.txt") && !s.contains("file-2.txt"))
+  }
+
+  test("Dialogs.fileDialog handles an empty entry list without exploding") {
+    val o = Dialogs.fileDialog(
+      title = "Empty",
+      currentPath = Paths.get("/x"),
+      entries = Seq.empty,
+      selectedIndex = 0
+    )
+    val s = stringForm(o)
+    assert(s.contains("Empty"))
+    assert(s.contains("[ Open ]"))
+  }
+
+  test("Dialogs.directoryDialog defaults okLabel to Select and hides sizes") {
+    val o = Dialogs.directoryDialog(
+      title = "Choose dir",
+      currentPath = Paths.get("/x"),
+      entries = Seq(Dialogs.FileEntry.Parent, Dialogs.FileEntry.Directory("docs")),
+      selectedIndex = 1
+    )
+    val s = stringForm(o)
+    assert(s.contains("[ Select ]"))
+    assert(s.contains("docs"))
+  }
+
+  test("Dialogs.fileDialogLayout exposes the same anchor math as fileDialog") {
+    val empty = Dialogs.fileDialogLayout(entriesSize = 0, selectedIndex = 0, maxVisible = 5)
+    assert(empty.anchorIndex == 0)
+    assert(empty.visibleCount == 1)
+
+    val small = Dialogs.fileDialogLayout(entriesSize = 3, selectedIndex = 1, maxVisible = 5)
+    assert(small.anchorIndex == 0)
+    assert(small.visibleCount == 3)
+
+    val long = Dialogs.fileDialogLayout(entriesSize = 30, selectedIndex = 25, maxVisible = 6)
+    assert(long.visibleCount == 6)
+    assert(long.anchorIndex >= 25 - long.visibleCount + 1)
+    assert(long.anchorIndex <= 25)
+    assert(long.firstRowOffset == 4)
+  }
+
+  test("Dialogs.FileEntry.displayName formats directories with a trailing slash") {
+    assert((Dialogs.FileEntry.Parent: Dialogs.FileEntry).displayName == "..")
+    assert((Dialogs.FileEntry.Directory("src"): Dialogs.FileEntry).displayName == "src/")
+    assert((Dialogs.FileEntry.File("README.md", 0L): Dialogs.FileEntry).displayName == "README.md")
+  }
+
+  test("Dialogs.FileEntry.isDirectory distinguishes directories from files") {
+    assert((Dialogs.FileEntry.Parent: Dialogs.FileEntry).isDirectory)
+    assert((Dialogs.FileEntry.Directory("x"): Dialogs.FileEntry).isDirectory)
+    assert(!(Dialogs.FileEntry.File("x", 0L): Dialogs.FileEntry).isDirectory)
+  }
+
+  // ---- Dialogs.listEntries -------------------------------------------------
+
+  test("Dialogs.listEntries lists directories first then files, sorted alphabetically") {
+    val tmp = Files.createTempDirectory("dialogs-spec-")
+    try
+      Files.createDirectory(tmp.resolve("zeta"))
+      Files.createDirectory(tmp.resolve("alpha"))
+      Files.writeString(tmp.resolve("readme.txt"), "hello")
+      Files.writeString(tmp.resolve("aaa.bin"), "x")
+      val res = Dialogs.listEntries(tmp).getOrElse(fail("listEntries failed"))
+      // The first entry is the parent sentinel.
+      assert(res.head == Dialogs.FileEntry.Parent)
+      val names = res.tail.map(_.displayName)
+      // Directories first (alphabetical), then files (alphabetical).
+      assert(names == Vector("alpha/", "zeta/", "aaa.bin", "readme.txt"))
+    finally deleteRecursively(tmp)
+  }
+
+  test("Dialogs.listEntries excludes dotfiles by default and includes them when requested") {
+    val tmp = Files.createTempDirectory("dialogs-spec-")
+    try
+      Files.writeString(tmp.resolve("visible.txt"), "x")
+      Files.writeString(tmp.resolve(".hidden"), "y")
+      val def_ = Dialogs.listEntries(tmp).getOrElse(fail())
+      assert(def_.exists(_.displayName == "visible.txt"))
+      assert(!def_.exists(_.displayName == ".hidden"))
+      val all = Dialogs.listEntries(tmp, showHidden = true).getOrElse(fail())
+      assert(all.exists(_.displayName == ".hidden"))
+    finally deleteRecursively(tmp)
+  }
+
+  test("Dialogs.listEntries surfaces an Unexpected error when the path is not a directory") {
+    val tmp = Files.createTempFile("dialogs-spec-", ".txt")
+    try
+      val res = Dialogs.listEntries(tmp)
+      assert(res.isLeft)
+      res.swap.foreach {
+        case TermFlowError.Unexpected(_, _) => succeed
+        case other                          => fail(s"unexpected error type: $other")
+      }
+    finally
+      val _ = Files.deleteIfExists(tmp)
+      ()
+  }
+
+  test("Dialogs.formatSize renders bytes / KB / MB and stays under five characters of digits") {
+    assert(Dialogs.formatSize(0L) == "0 B")
+    assert(Dialogs.formatSize(512L) == "512 B")
+    val oneKb = Dialogs.formatSize(1024L)
+    assert(oneKb.endsWith("KB") && oneKb.startsWith("1"))
+    val oneMb = Dialogs.formatSize(1024L * 1024L)
+    assert(oneMb.endsWith("MB"))
+    val twoGb = Dialogs.formatSize(2L * 1024 * 1024 * 1024)
+    assert(twoGb.endsWith("GB"))
+  }
+
+  private def deleteRecursively(p: Path): Unit =
+    if Files.isDirectory(p) then
+      val s = Files.newDirectoryStream(p)
+      try s.iterator().forEachRemaining(deleteRecursively)
+      finally s.close()
+    Files.deleteIfExists(p)
+    ()
 
   // ---- helper: walk an overlay's tree into a flat string for assertions ---
 


### PR DESCRIPTION
## Summary

Closes the last named Stage 3 §6.1 dialog gap from the roadmap (`fileDialog` / `directoryDialog` were the only items still listed as "not started" alongside the deferred `actionList`).

- `Dialogs.fileDialog` / `Dialogs.directoryDialog` ship as presentation-only `Overlay` builders, matching the rest of the dialog family. Apps own the current `Path`, the `Vector[FileEntry]`, and the selected index. `directoryDialog` is a thin delegation onto `fileDialog` with `okLabel = "Select"` and `showSizes = false`.
- A small `Dialogs.FileEntry` enum (`Parent` / `Directory(name)` / `File(name, size)`) plus `Dialogs.listEntries(path, showHidden)` covers the synchronous case. Apps that need non-blocking listings on slow filesystems wrap the same helper in a `Cmd.asyncResult`.
- `Dialogs.FileDialogLayout` + `fileDialogLayout(...)` mirror `ListSelectLayout` so apps wiring mouse hit-testing on the listing portion can map a click row to an entry without re-deriving the helper's anchor math.
- `apps.dialog.FileDialogDemoApp` (`sbt run file-dialog`) drives both dialogs against the real filesystem — arrow keys + Enter navigate; `f` opens the file picker, `d` the directory picker.
- Roadmap §6.1 / §9.5 / §11 updated; decision log entry explains the design choices (presentation-only, `Parent` sentinel, `directoryDialog` as delegation).

## Test plan
- [x] `sbt ciCheck` green (test counts: 586 / 138 / 79 across modules).
- [x] `DialogsSpec` extended with 14 new cases covering rendering, scrolling, path truncation, size column, `directoryDialog` defaults, `listEntries` ordering / hidden-files / not-a-directory error, and `formatSize`.
- [ ] Smoke-tested manually via `sbt "termflowSample/runMain termflow.apps.dialog.FileDialogDemoApp"` (left to reviewer or follow-up — terminal interaction).