### PR TITLE
feat: dashboard sample app (Stage 4 §7.3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,3 +166,4 @@ addCommandAlias("themeDemo",    "termflowSample/runMain termflow.apps.themes.The
 addCommandAlias("dialogDemo",   "termflowSample/runMain termflow.apps.dialog.DialogDemoApp")
 addCommandAlias("showcase",     "termflowSample/runMain termflow.apps.showcase.Stage1ShowcaseApp")
 addCommandAlias("unicodeDemo",  "termflowSample/runMain termflow.apps.unicode.UnicodeDemoApp")
+addCommandAlias("dashboardDemo","termflowSample/runMain termflow.apps.dashboard.DashboardApp")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -535,14 +535,22 @@ static site. Sections (mirroring Lanterna's `docs/contents.md`):
 
 ### 7.3 Sample app catalogue expansion
 
-Today: 13 samples. Target: 25, with one app per major feature:
+Target: 25, with one app per major feature.
 
-- `mouse/` — basic mouse interaction.
-- `unicode/` — CJK + emoji rendering.
-- `dialog/` — every dialog helper.
-- `tree/` — file-tree explorer.
+- `mouse/` — basic mouse interaction. *(deferred — covered indirectly by the
+  showcase tab, which already exercises mouse hit-testing on the Themes /
+  Borders panels and the listSelect dialog.)*
+- `unicode/` — CJK + emoji rendering. **shipped** as `apps.unicode.UnicodeDemoApp`.
+- `dialog/` — every dialog helper. **shipped** as `apps.dialog.DialogDemoApp`
+  (confirm / textInput / listSelect / waiting) and `apps.dialog.FileDialogDemoApp`
+  (file & directory pickers).
+- `tree/` — file-tree explorer. *(planned — natural fit on top of the new
+  fileDialog helpers.)*
 - `chat/` — already exists; expand to use streaming + scrollback.
-- `dashboard/` — multi-pane realtime metrics.
+- `dashboard/` — multi-pane realtime metrics. **shipped** as
+  `apps.dashboard.DashboardApp` (`sbt dashboardDemo`); ListView + ProgressBar
+  per service, Spinner + StatusBar in header/footer, `Sub.Every`-driven
+  simulation with pause / restart.
 - `wizard/` — multi-step form with back/forward.
 - `editor/` — minimal text editor (proves the layout/coords refactor).
 - `ssh-shell/` *(if Stage 5 ships)* — telnet/SSH demo.

--- a/modules/termflow-sample/src/main/scala/termflow/apps/dashboard/DashboardApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/dashboard/DashboardApp.scala
@@ -1,0 +1,240 @@
+package termflow.apps.dashboard
+
+import termflow.tui.*
+import termflow.tui.Theme.themed
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+import termflow.tui.widgets
+
+import scala.util.Random
+
+/**
+ * Multi-pane realtime dashboard sample (Stage 4 §7.3).
+ *
+ * Shows a fleet of fake services with a CPU bar each, ticking on a
+ * `Sub.Every` timer. The selected service can be "restarted" with `r`,
+ * dropping its load to zero; the simulation can be paused / resumed
+ * with `p`. The header animates a `Spinner` while the simulation runs;
+ * the footer is a `StatusBar` showing aggregate counters.
+ *
+ * Demonstrates `ListView`, `ProgressBar`, `Spinner`, `StatusBar`, plus
+ * `Sub.Every` timers and `Sub.InputKey` keyboard input wired through a
+ * declarative `Keymap`.
+ *
+ * ## Keys
+ *
+ *   - `↑` / `↓`              cycle the selected service
+ *   - `r`                    restart the selected service (CPU → 0)
+ *   - `p` / `Space`          pause / resume the simulation
+ *   - `q` / `Esc` / `Ctrl+C` quit
+ *
+ * Run with `sbt dashboardDemo`.
+ */
+object DashboardApp:
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+
+  /** Default service catalogue. Stable order so the demo is reproducible. */
+  val defaultServices: Vector[String] =
+    Vector(
+      "auth-service",
+      "billing-service",
+      "search-indexer",
+      "image-resizer",
+      "analytics-pipeline",
+      "notification-bus",
+      "session-store",
+      "audit-log"
+    )
+
+  /**
+   * One service row — a name, current CPU load (0..1), and a tick count
+   * representing how many simulation steps the service has weathered
+   * since its last restart. Pure data, no widgets here.
+   */
+  final case class ServiceState(name: String, cpu: Double, ticks: Long):
+    def withCpu(next: Double): ServiceState = copy(cpu = math.max(0.0, math.min(1.0, next)))
+
+  enum Msg:
+    case Tick
+    case Restart
+    case TogglePause
+    case Quit
+    case Key(k: KeyDecoder.InputKey)
+    case KeyError(t: Throwable)
+
+  import Msg.*
+
+  /**
+   * Declarative key bindings. List navigation (↑/↓ / Home / End) is
+   * routed through `ListView.handleKey` rather than the keymap so the
+   * widget can update its own scroll offset; everything else dispatches
+   * through this table.
+   */
+  val Keys: Keymap[Msg] =
+    Keymap.quit(Quit) ++
+      Keymap(
+        KeyDecoder.InputKey.CharKey('r') -> Restart,
+        KeyDecoder.InputKey.CharKey('R') -> Restart,
+        KeyDecoder.InputKey.CharKey('p') -> TogglePause,
+        KeyDecoder.InputKey.CharKey('P') -> TogglePause,
+        KeyDecoder.InputKey.CharKey(' ') -> TogglePause
+      )
+
+  final case class Model(
+    services: widgets.ListView.State[ServiceState],
+    tick: Long,
+    paused: Boolean,
+    rng: Random
+  ):
+    /** Convenience: current service highlighted in the list, if any. */
+    def selectedService: Option[ServiceState] = services.selectedItem
+
+    /** Number of services running above the warning threshold. */
+    def hotCount: Int = services.items.count(_.cpu >= 0.85)
+
+  /**
+   * Animation period. Slow enough to be readable, fast enough to feel
+   * live. Same cadence the testkit uses to drive deterministic
+   * simulation steps in `DashboardAppSpec`.
+   */
+  val tickPeriodMs: Long = 200L
+
+  /** Visible rows in the service `ListView`. */
+  val visibleServices: Int = 8
+
+  object App extends TuiApp[Model, Msg]:
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      Sub.Every(tickPeriodMs, () => Tick, ctx)
+      Sub.InputKey(Key.apply, KeyError.apply, ctx)
+      val initial = defaultServices.zipWithIndex.map { case (name, i) =>
+        // Deterministic-ish initial loads so the demo's first frame is
+        // varied without introducing test flakes — the spec seeds its
+        // own `Random` and never reads `init`'s.
+        ServiceState(name, cpu = 0.10 + (i * 0.07) % 0.6, ticks = 0L)
+      }
+      Model(
+        services = widgets.ListView.State.of(initial, visibleRows = visibleServices),
+        tick = 0L,
+        paused = false,
+        // Stable seed so production runs are visually consistent —
+        // tests inject their own seeded model instead of going through
+        // `init`.
+        rng = new Random(20260428L)
+      ).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val _ = ctx
+      msg match
+        case Tick =>
+          if m.paused then m.copy(tick = m.tick + 1).tui
+          else
+            val nextItems = m.services.items.map { s =>
+              val delta = (m.rng.nextDouble() - 0.5) * 0.20
+              s.withCpu(s.cpu + delta).copy(ticks = s.ticks + 1)
+            }
+            m.copy(services = m.services.withItems(nextItems), tick = m.tick + 1).tui
+
+        case Restart =>
+          m.services.selectedItem match
+            case None => m.tui
+            case Some(picked) =>
+              val idx        = m.services.selected
+              val resetItems = m.services.items.updated(idx, picked.copy(cpu = 0.0, ticks = 0L))
+              m.copy(services = m.services.withItems(resetItems)).tui
+
+        case TogglePause =>
+          m.copy(paused = !m.paused).tui
+
+        case Quit        => Tui(m, Cmd.Exit)
+        case KeyError(_) => m.tui
+        case Key(k) =>
+          val (nextList, _) = widgets.ListView.handleKey[ServiceState, Msg](m.services, k)(_ => None)
+          val nm            = m.copy(services = nextList)
+          Keys.lookup(k) match
+            case Some(out) => Tui(nm, Cmd.GCmd(out))
+            case None      => nm.tui
+
+    override def view(m: Model): RootNode =
+      given Theme = Theme.dark
+
+      val title = TextNode(
+        2.x,
+        1.y,
+        List(
+          Text("TermFlow Dashboard", Style(fg = Theme.dark.primary, bold = true)),
+          "  ".text,
+          (if m.paused then "[paused]" else "[live]")
+            .themed(if m.paused then _.warning else _.success)
+        )
+      )
+      val spinner = widgets.Spinner(
+        widgets.Spinner.Braille,
+        frame = m.tick.toInt,
+        at = Coord(36.x, 1.y)
+      )
+
+      val help = TextNode(
+        2.x,
+        2.y,
+        List(
+          " ↑/↓ ".themed(_.primary),
+          "select  ".text,
+          " r ".themed(_.primary),
+          "restart  ".text,
+          " p / Space ".themed(_.primary),
+          "pause  ".text,
+          " q ".themed(_.primary),
+          "quit".text
+        )
+      )
+
+      // Services list (left pane).
+      val list = widgets.ListView.view[ServiceState](
+        m.services,
+        at = Coord(2.x, 4.y),
+        lineWidth = 28,
+        focused = true,
+        render = s => f"${s.name}%-22s ${(s.cpu * 100).toInt}%3d%%"
+      )
+
+      // Metrics panel (right pane) — one ProgressBar per service.
+      val metricsLabel = TextNode(34.x, 4.y, List(" CPU load ".themed(_.primary)))
+      val barWidth     = 24
+      val metricsRows = m.services.items.zipWithIndex.toList.map { case (svc, i) =>
+        val rowY     = 5 + i
+        val nameNode = TextNode(34.x, rowY.y, List(s"${svc.name}".text))
+        val barColor =
+          if svc.cpu >= 0.85 then Theme.dark.error
+          else if svc.cpu >= 0.6 then Theme.dark.warning
+          else Theme.dark.success
+        val bar = widgets.ProgressBar(
+          value = svc.cpu,
+          width = barWidth,
+          at = Coord((34 + 22).x, rowY.y)
+        )(using Theme.dark.copy(primary = barColor))
+        List(nameNode, bar)
+      }.flatten
+
+      val statusY = 5 + visibleServices + 1
+      val statusBar = widgets.StatusBar(
+        left = " dashboard ",
+        center = f"${m.services.size} services • ${m.hotCount} hot • tick=${m.tick}",
+        right = if m.paused then " paused " else " live ",
+        width = 90,
+        at = Coord(2.x, statusY.y)
+      )
+
+      val nodes = List(title, spinner, help, list, metricsLabel) ++ metricsRows :+ statusBar
+      RootNode(
+        width = 92,
+        height = statusY + 2,
+        children = nodes,
+        input = None
+      )
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      Left(TermFlowError.Validation("Dashboard has no prompt"))

--- a/modules/termflow-sample/src/main/scala/termflow/run/TermFlowMain.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/run/TermFlowMain.scala
@@ -27,6 +27,7 @@ object TermFlowMain:
           termflow.apps.diagnostics.LoggingMetricsDemoApp.Config
         )
       case Some("input-line") | Some("input") => TuiRuntime.run(termflow.apps.input.InputLineReproApp.App)
+      case Some("dashboard") | Some("dash")   => TuiRuntime.run(termflow.apps.dashboard.DashboardApp.App)
       case Some(_)                            => SampleHubMain.main(Array.empty)
 
   def syncCounterMain(args: Array[String]): Unit =

--- a/modules/termflow-sample/src/test/scala/termflow/apps/dashboard/DashboardAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/dashboard/DashboardAppSpec.scala
@@ -1,0 +1,125 @@
+package termflow.apps.dashboard
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.testkit.TuiTestDriver
+import termflow.tui.KeyDecoder.InputKey
+
+class DashboardAppSpec extends AnyFunSuite:
+
+  private def driver: TuiTestDriver[DashboardApp.Model, DashboardApp.Msg] =
+    val d = TuiTestDriver(DashboardApp.App, width = 100, height = 28)
+    d.init()
+    d
+
+  test("initial frame renders without exceptions and lists the default services") {
+    val d = driver
+    assert(d.model.services.size == DashboardApp.defaultServices.size)
+    assert(d.model.tick == 0L)
+    assert(!d.model.paused)
+    val rendered = renderedFrame(d)
+    DashboardApp.defaultServices.foreach(name =>
+      assert(rendered.contains(name), s"expected service '$name' to appear in the frame")
+    )
+    assert(rendered.contains("TermFlow Dashboard"))
+  }
+
+  test("Tick advances the counter and mutates CPU values") {
+    val d         = driver
+    val cpuBefore = d.model.services.items.map(_.cpu)
+    d.send(DashboardApp.Msg.Tick)
+    assert(d.model.tick == 1L)
+    val cpuAfter = d.model.services.items.map(_.cpu)
+    // At least one value should change — the rng per-service delta is
+    // [-0.10, +0.10) so the chance of every service rolling exactly 0
+    // is infinitesimal. Guard against a stuck simulation.
+    assert(cpuAfter != cpuBefore, "tick should perturb at least one CPU value")
+    // All values stay clamped into [0, 1].
+    assert(cpuAfter.forall(c => c >= 0.0 && c <= 1.0))
+  }
+
+  test("Tick increments per-service tick count") {
+    val d = driver
+    d.send(DashboardApp.Msg.Tick)
+    d.send(DashboardApp.Msg.Tick)
+    assert(d.model.services.items.forall(_.ticks == 2L))
+  }
+
+  test("ArrowDown moves the ListView selection") {
+    val d = driver
+    assert(d.model.services.selected == 0)
+    d.send(DashboardApp.Msg.Key(InputKey.ArrowDown))
+    assert(d.model.services.selected == 1)
+    d.send(DashboardApp.Msg.Key(InputKey.ArrowDown))
+    assert(d.model.services.selected == 2)
+    d.send(DashboardApp.Msg.Key(InputKey.ArrowUp))
+    assert(d.model.services.selected == 1)
+  }
+
+  test("'r' restarts the selected service — CPU drops to 0 and ticks reset") {
+    val d = driver
+    // Run the simulation a few ticks so a non-zero CPU exists to drop.
+    (1 to 5).foreach(_ => d.send(DashboardApp.Msg.Tick))
+    d.send(DashboardApp.Msg.Key(InputKey.ArrowDown)) // pick service[1]
+    d.send(DashboardApp.Msg.Key(InputKey.CharKey('r')))
+    val picked = d.model.services.items(1)
+    assert(picked.cpu == 0.0, "selected service's CPU must be reset")
+    assert(picked.ticks == 0L, "selected service's tick count must be reset")
+    // Other services keep ticking.
+    val others = d.model.services.items.zipWithIndex.collect { case (s, i) if i != 1 => s }
+    assert(others.forall(_.ticks == 5L))
+  }
+
+  test("'p' toggles paused — Tick stops perturbing CPU values while paused") {
+    val d = driver
+    d.send(DashboardApp.Msg.Key(InputKey.CharKey('p')))
+    assert(d.model.paused)
+    val frozen = d.model.services.items
+    d.send(DashboardApp.Msg.Tick)
+    d.send(DashboardApp.Msg.Tick)
+    assert(d.model.tick == 2L, "tick counter advances even while paused")
+    assert(d.model.services.items == frozen, "CPU values must not move while paused")
+    // Resume and verify ticking resumes.
+    d.send(DashboardApp.Msg.Key(InputKey.CharKey('p')))
+    assert(!d.model.paused)
+    d.send(DashboardApp.Msg.Tick)
+    assert(d.model.services.items != frozen, "tick after resume should perturb values")
+  }
+
+  test("Space also toggles pause") {
+    val d = driver
+    d.send(DashboardApp.Msg.Key(InputKey.CharKey(' ')))
+    assert(d.model.paused)
+  }
+
+  test("'q' emits Cmd.Exit") {
+    val d = driver
+    d.send(DashboardApp.Msg.Key(InputKey.CharKey('q')))
+    assert(d.exited, "'q' should request runtime exit")
+  }
+
+  test("Esc emits Cmd.Exit") {
+    val d = driver
+    d.send(DashboardApp.Msg.Key(InputKey.Escape))
+    assert(d.exited)
+  }
+
+  test("hotCount counts services above the warning threshold") {
+    val d = driver
+    // Mutate the model directly to put two services into hot territory.
+    val items = d.model.services.items
+    val hot   = items.updated(0, items(0).copy(cpu = 0.95)).updated(2, items(2).copy(cpu = 0.90))
+    val nm    = d.model.copy(services = d.model.services.withItems(hot))
+    assert(nm.hotCount == 2)
+  }
+
+  test("StatusBar reports the live service / hot / tick summary") {
+    val d = driver
+    (1 to 3).foreach(_ => d.send(DashboardApp.Msg.Tick))
+    val rendered = renderedFrame(d)
+    assert(rendered.contains(s"${d.model.services.size} services"))
+    assert(rendered.contains("tick=3"))
+  }
+
+  private def renderedFrame(d: TuiTestDriver[DashboardApp.Model, DashboardApp.Msg]): String =
+    val frame = d.frame
+    (0 until frame.height).map(r => frame.cells(r).map(_.ch).mkString).mkString("\n")


### PR DESCRIPTION
## Summary

Adds the `dashboard/` sample called out in the §7.3 catalogue list — the missing "multi-pane realtime metrics" demo. Brings the published-sample count to 14 (target: 25).

- `apps.dashboard.DashboardApp` — `ListView` (left, 8 services) + per-service `ProgressBar` grid (right). Header carries a `Spinner` and live/paused indicator; footer is a `StatusBar` with aggregate counters (`N services • K hot • tick=…`).
- Driven by a `Sub.Every` ticker (200 ms). Each tick perturbs every service's CPU value within `[-0.10, +0.10]` (clamped to `[0, 1]`), so the simulation feels live without blowing up.
- ProgressBar colour follows load: green < 60 %, warning at ≥ 60 %, error at ≥ 85 % via per-row `Theme.copy(primary = …)`. Threshold gating is exposed on the model as `hotCount` for the StatusBar summary.
- Keys: `↑`/`↓` cycle selection (routed through `ListView.handleKey`), `r` restarts the selected service (CPU → 0, ticks reset), `p` / `Space` toggles pause, `q` / `Esc` / `Ctrl+C` quit. Quit + key bindings come from a declarative `Keymap`.
- Wired into `TermFlowMain` (`dashboard` / `dash` args) and `sbt dashboardDemo`.
- ROADMAP §7.3 catalogue table updated to mark shipped samples (`unicode/`, `dialog/`, `dashboard/`) and call out the deferred / planned ones.

## Test plan
- [x] 11-test `DashboardAppSpec` covers: initial state + service list rendering, Tick advancing the counter and perturbing CPU values within clamp invariants, ArrowDown/Up moving the ListView selection, `r` resetting only the selected service while others keep ticking, `p` and `Space` toggling pause, pause-stops-perturbations / resume-restores-perturbations, `q` and `Esc` emitting `Cmd.Exit`, `hotCount` threshold counting, StatusBar summary text.
- [x] `sbt ciCheck` green: 571 lib + 149 testkit + 79 sample tests across the build.
- [ ] Smoke-test interactively: `sbt dashboardDemo`.