### PR TITLE
feat: complete remaining Stage 3 components (§6.1 / §6.2 / §5.1 / §5.3)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -304,8 +304,8 @@ self-contained and the goldens churn least at each step:
 | 1 | §5.5 Extended style attributes | done — `Style` gains `italic`/`dim`/`reverse`/`strikethrough`/`blink`; capability gate `Capabilities.extendedStyles` decides emission |
 | 2 | §5.6 Extended modifier parsing | done — new `KeyDecoder.Modifiers`, `InputKey.Modified`, `Insert`/`PageUp`/`PageDown`; CSI parser unified to read params then dispatch |
 | 3 | §5.4 Bracketed paste | done — `Capabilities.bracketedPaste`, `ANSI.enableBracketedPaste`/`disableBracketedPaste`, `InputKey.Paste(text)` collapses the whole `200~ … 201~` window into one event |
-| 4 | §5.3 Unicode width handling | initial cut — `WCWidth` helper, `RenderCell.width`, layout / diff respect wide cells. Known gap: `Prompt`/`InputNode` cursor math is still 1-char-per-column; multi-line input + grapheme clusters deferred |
-| 5 | §5.1 Mouse support | done — `MouseEvent` / `MouseButton` / `ScrollDirection` ADTs, `ANSI.enableMouse`/`disableMouse` SGR-1006 + button-event tracking, `InputKey.Mouse(event)` multiplexed onto the key stream so existing `Sub.InputKey` handlers see it. Hit-testing on the layout-pass rect cache is deferred to Stage 3 |
+| 4 | §5.3 Unicode width handling | done — `WCWidth` helper, `RenderCell.width`, layout / diff respect wide cells. Stage 3 follow-up landed cursor column math (renderer's `visibleInput` uses `WCWidth.stringWidth` for the hardware cursor), grapheme-aware navigation in `Prompt` (`Backspace`, `Delete`, `ArrowLeft`, `ArrowRight` step by Unicode UAX #29 boundaries via `BreakIterator`), and a new `widgets.MultiLineInput` for multi-line editing. |
+| 5 | §5.1 Mouse support | done — `MouseEvent` / `MouseButton` / `ScrollDirection` ADTs, `ANSI.enableMouse`/`disableMouse` SGR-1006 + button-event tracking, `InputKey.Mouse(event)` multiplexed onto the key stream so existing `Sub.InputKey` handlers see it. Stage 3 follow-up shipped the layout-pass hit-test cache (`HitTest[Id]` + `Rect` + `Layout.Zone(id, content)` + `Layout.resolveTracked[Id]`) so apps can map a click coordinate to a logical zone without re-deriving rectangles. |
 
 The showcase demo (`sbt showcase`) was extended in the same session to
 exercise every sub-item — Styles panel for §5.5, Live-input panel for
@@ -402,7 +402,7 @@ function keys). Update `KeyDecoder.scala` and `InputKey` enum.
 
 Polishing the catalogue so users don't reinvent common patterns.
 
-### 6.1 Dialog helpers (P1, medium) — **mostly done**
+### 6.1 Dialog helpers (P1, medium) — **complete**
 
 Layered on §4.2. Helpers are pure presentation builders that return an
 `Overlay` ready to drop into `RootNode.overlays`; the dialog state lives
@@ -419,15 +419,16 @@ maintain.)
 | `Dialogs.textInput(title, prompt, value, cursor?, prefix?, …)` | done | Owns its own `InputNode`; supports a fixed pinned prefix. |
 | `Dialogs.listSelect(title, items, selectedIndex, maxVisible?, render?)` | done | Selection-following viewport scrolling; custom render callback. |
 | `Dialogs.waiting(title, body, tick, frames?, cancelLabel?)` | done | Spinner glyph picked from the tick (modulo); optional cancel button. App drives the tick from a `Sub.Every`. |
-| `Dialogs.actionList` | not started | Trivially expressed as `listSelect` over `Choice` values; deferred until a real use case appears. |
+| `Dialogs.actionList(title, actions, …)` | done | Centred vertical menu of `Choice` actions; auto-sizes to the longest label and ships without an OK / Cancel row. Wired to the showcase as `a`. |
 | `Dialogs.fileDialog` / `directoryDialog` | done | Path bar + entry list (parent / dir / file) + sized column for files. Companion `FileEntry` ADT, `listEntries(path, showHidden)`, and `fileDialogLayout` for hit-testing. |
 
-All seven helpers are exercised by `sbt showcase` (`d` = confirm, `i` =
-textInput, `l` = listSelect, `w` = waiting, `f` = fileDialog, `g` =
-directoryDialog) on the Showcase tab. The file pickers also ship with
-a dedicated demo (`apps.dialog.FileDialogDemoApp`, runnable as
-`sbt run file-dialog`) for a focused look. Tests live in `DialogsSpec`
-and `Stage1ShowcaseAppSpec`.
+All eight helpers are exercised by `sbt showcase` (`d` = confirm, `i` =
+textInput, `l` = listSelect, `w` = waiting, `a` = actionList, `f` =
+fileDialog, `g` = directoryDialog) on the Showcase tab. The file
+pickers also ship with a dedicated demo
+(`apps.dialog.FileDialogDemoApp`, runnable as `sbt run file-dialog`)
+for a focused look. Tests live in `DialogsSpec` and
+`Stage1ShowcaseAppSpec`.
 
 ### 6.2 Additional widgets (P1, medium) — **complete**
 
@@ -442,7 +443,10 @@ and `Stage1ShowcaseAppSpec`.
 | `Autocomplete` (open) | done (PR #171) — `State[A]` holds input + options + selectedIdx; pluggable `matches` predicate; companion `handleKey` returns `(state, picked: Option[A])`. |
 | `Menu` / `MenuBar` | done (PR #171) — horizontal title bar + on-demand dropdown; pure `handleKey` dispatcher returns picked `(menuIdx, itemIdx)`; companion `hitTest` maps clicks to title cells or dropdown rows. |
 | `Form` builder | done (PR #171) — declarative `Vector[Form.Row]` of (id, label, widget render fn); pairs with `FocusManager` for navigation; per-row `errors: Map[FocusId, String]` annotations. |
-| `SplitPane` | done (PR #171) — horizontal / vertical two-pane layout at a configurable ratio; renderer callbacks receive resolved `(at, w, h)`. Drag-to-resize deferred to the mouse hit-test cache follow-up; companion `dividerRect` exposes the drag region for apps that want to wire it manually now. |
+| `SplitPane` | done — horizontal / vertical two-pane layout at a configurable ratio; renderer callbacks receive resolved `(at, w, h)`. Drag-to-resize landed via `SplitPane.handleMouse` + `DragState`: apps hold a `DragState`, feed every `MouseEvent` through `handleMouse`, and the returned `splitRatio` drives the next frame. The Layout tab in `sbt showcase` exercises it. |
+| `ScrollBar` | done — vertical / horizontal scroll indicator with track + proportional thumb. Pure-presentation `State(offset, visible, total)` plus companion `thumbRange`, `hitTest`, `offsetForDrag`, `clampOffset` helpers. The Data tab on the showcase pins one next to the ListView. |
+| `Separator` | done — horizontal / vertical single-glyph rule with optional centred title. Uses the active theme's `chars`. The Help tab on the showcase uses two as section rules. |
+| `MultiLineInput` | done (Stage 3 §5.3) — multi-line editor with grapheme-aware `Backspace` / `Delete` / arrow-key navigation, `Enter` inserts a newline, `Home` / `End` snap within the row. Cursor row renders with a reverse-video cell (TextField-style) so embedding is straightforward; vertical scroll keeps the cursor visible. The new `9 Editor` tab on the showcase drives it. |
 
 ### 6.3 Keymap framework (P1, small) — **done**
 
@@ -900,6 +904,34 @@ on design rationale, light on user-facing tutorial. Closed in Stage 4
   backends remain on the speculative roadmap. §3 stages overview, the
   §9.2 Lanterna comparison table, and the Stage 5 section all updated
   to match.
+- *2026-04-28* — Stage 3 final components landed: §6.1
+  `Dialogs.actionList`; §6.2 `widgets.{ScrollBar, Separator,
+  MultiLineInput}` plus `widgets.SplitPane` drag-to-resize via
+  `handleMouse` + `DragState`; §5.1 hit-test cache (`HitTest[Id]` +
+  `Rect` + `Layout.Zone` + `Layout.resolveTracked[Id]`); §5.3
+  grapheme-aware cursor navigation in `Prompt` (via
+  `java.text.BreakIterator.getCharacterInstance`, exposed as a
+  `Grapheme` helper alongside `WCWidth`) plus column-aware hardware-
+  cursor placement in `AnsiRenderer.visibleInput`. The showcase grew
+  to nine tabs: `9 Editor` drives the new MultiLineInput, the Help
+  tab uses `Separator` rules, the Data tab pins a `ScrollBar` next to
+  the ListView, and the Layout tab wires mouse drag through
+  `SplitPane.handleMouse`. **Decision: SplitPane + MultiLineInput
+  render their cursor-bearing rows with a TextField-style
+  reverse-video cell rather than installing an `InputNode`.** The
+  renderer ignores InputNodes that aren't `RootNode.input`, so
+  embedding-friendly widgets need a self-contained caret. The
+  reverse-video approach matches the existing `widgets.TextField`
+  convention and keeps these widgets composable inside any container
+  (panels, tabs, overlays) without the parent having to thread an
+  `InputNode` through `RootNode.input`. **Decision: hit-test ids are
+  declared at the `resolveTracked[Id]` call site, not on `Layout.Zone`
+  itself.** The `Zone` case carries `id: Any` so a single layout tree
+  can mix id types; the call site fixes the registry's `Id` parameter.
+  JVM erasure means the cast is unchecked at runtime, so apps using a
+  uniform id type per tracked tree (sealed enums, strings) get clean
+  ergonomics; mixed-type trees still resolve and the registry contains
+  whatever the call sites supplied.
 
 ---
 

--- a/modules/termflow-app/src/main/scala/termflow/tui/Dialogs.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Dialogs.scala
@@ -281,6 +281,59 @@ object Dialogs:
     )
 
   /**
+   * Centred action-list dialog. A vertical menu of `Choice` actions; the
+   * one with `focused = true` is highlighted in the theme's primary
+   * palette. Apps drive arrow-key navigation by toggling which `Choice`
+   * is focused in their own model and re-rendering.
+   *
+   * This is a thin convenience over [[listSelect]] tailored for "pick an
+   * action" menus: the items are `Choice` values (so they already carry
+   * a label and a focused flag), there is no OK / Cancel row, and the
+   * dialog auto-sizes to its longest label. Use [[listSelect]] when
+   * you're choosing a value (with explicit OK / Cancel) rather than
+   * triggering an action.
+   *
+   * Sizing: width is the max of (title + padding) and (longest label +
+   * padding) with a 30-cell floor. Height is `4 + actions.size`.
+   *
+   * @param title    Title rendered on the top border.
+   * @param actions  Action items. Exactly one should have
+   *                 `focused = true`; if none are focused, the first row
+   *                 still renders as the selection-target style.
+   * @param position Anchor (default [[OverlayPosition.Centered]]).
+   */
+  def actionList(
+    title: String,
+    actions: List[Choice],
+    position: OverlayPosition = OverlayPosition.Centered
+  )(using theme: Theme): Overlay =
+    val titleLen = title.length + 4
+    val itemLen  = (0 :: actions.map(_.label.length)).max + 6
+    val width    = math.max(30, math.max(titleLen, itemLen))
+    val height   = 4 + math.max(1, actions.size)
+
+    val box       = Theme.box(XCoord(1), YCoord(1), width, height)
+    val titleNode = TextNode(XCoord(3), YCoord(1), List(Text(s" $title ", Style(fg = theme.primary, bold = true))))
+
+    val rows: List[VNode] =
+      actions.zipWithIndex.map { case (action, i) =>
+        val sel    = action.focused
+        val marker = if sel then "▸ " else "  "
+        val style =
+          if sel then Style(fg = theme.background, bg = theme.primary, bold = true)
+          else Style(fg = theme.foreground)
+        TextNode(XCoord(3), YCoord(3 + i), List(Text(s"$marker${action.label}", style)))
+      }
+
+    Overlay(
+      position = position,
+      width = width,
+      height = height,
+      children = box :: titleNode :: rows,
+      inputCapture = InputCapture.Modal
+    )
+
+  /**
    * One row in a [[fileDialog]] / [[directoryDialog]] listing.
    *
    * The helpers are pure presentation: they don't touch the filesystem.

--- a/modules/termflow-app/src/main/scala/termflow/tui/Keymap.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Keymap.scala
@@ -99,7 +99,7 @@ object Keymap:
   /**
    * Conventional focus bindings: `Tab` advances, `Shift+Tab` retreats.
    *
-   * `Tab` arrives as `Ctrl+I` from the ASCII decoder; `Shift+Tab` arrives
+   * `Tab` is a distinct [[InputKey.Tab]] (decoded from ASCII 9); `Shift+Tab` arrives
    * as `InputKey.BackTab` (decoded from the `[Z` escape sequence).
    *
    * @param next     Message dispatched on `Tab`.
@@ -107,8 +107,8 @@ object Keymap:
    */
   def focus[Msg](next: Msg, previous: Msg): Keymap[Msg] =
     Keymap(
-      InputKey.Ctrl('I') -> next,
-      InputKey.BackTab   -> previous
+      InputKey.Tab     -> next,
+      InputKey.BackTab -> previous
     )
 
   /**
@@ -205,6 +205,7 @@ object Keymap:
     case InputKey.ArrowDown              => "Down"
     case InputKey.ArrowLeft              => "Left"
     case InputKey.ArrowRight             => "Right"
+    case InputKey.Tab                    => "Tab"
     case InputKey.BackTab                => "S-Tab"
     case InputKey.F1                     => "F1"
     case InputKey.F2                     => "F2"

--- a/modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala
@@ -12,6 +12,22 @@ object Prompt:
 
   final case class RenderedLine(text: String, cursorIndex: Int, prefixLength: Int = 0)
 
+  /**
+   * Visual column the cursor occupies inside `state.buffer`, computed
+   * via [[WCWidth.stringWidth]] across the characters before the
+   * cursor. Wide characters (CJK, fullwidth, most emoji) contribute 2
+   * columns; combining marks contribute 0; everything else is 1.
+   *
+   * The renderer already uses this math when positioning the hardware
+   * cursor on an `InputNode`; [[cursorColumn]] is exposed for apps that
+   * need the same number for their own layout (e.g. drawing a custom
+   * caret indicator next to the buffer).
+   */
+  def cursorColumn(state: State): Int =
+    val cursor = math.max(0, math.min(state.buffer.length, state.cursor))
+    val text   = state.buffer.take(cursor).mkString
+    WCWidth.stringWidth(text)
+
   /** Render the prompt buffer with a fixed prefix, returning full text and cursor index. */
   def renderWithPrefix(state: State, prefix: String): RenderedLine =
     val content = render(state)
@@ -39,13 +55,21 @@ object Prompt:
 
       case KeyDecoder.InputKey.Backspace =>
         if state.cursor > 0 then
-          val newBuf = state.buffer.patch(state.cursor - 1, Nil, 1)
-          (normalized(state.copy(buffer = newBuf, cursor = state.cursor - 1)), None)
+          // Step back by a grapheme so combining marks, surrogate pairs, and
+          // ZWJ sequences delete as one unit.
+          val text    = state.buffer.mkString
+          val prevIdx = Grapheme.previousBoundary(text, state.cursor)
+          val deleteN = state.cursor - prevIdx
+          val newBuf  = state.buffer.patch(prevIdx, Nil, deleteN)
+          (normalized(state.copy(buffer = newBuf, cursor = prevIdx)), None)
         else (state, None)
 
       case KeyDecoder.InputKey.Delete =>
         if state.cursor < state.buffer.length then
-          val newBuf = state.buffer.patch(state.cursor, Nil, 1)
+          val text    = state.buffer.mkString
+          val nextIdx = Grapheme.nextBoundary(text, state.cursor)
+          val deleteN = nextIdx - state.cursor
+          val newBuf  = state.buffer.patch(state.cursor, Nil, deleteN)
           (normalized(state.copy(buffer = newBuf)), None)
         else (state, None)
 
@@ -54,10 +78,15 @@ object Prompt:
         (normalized(state.copy(buffer = newBuf, cursor = state.cursor + 1)), None)
 
       case KeyDecoder.InputKey.ArrowLeft =>
-        (normalized(state.copy(cursor = state.cursor - 1)), None)
+        // Grapheme-aware step so the cursor doesn't strand combining marks.
+        val text    = state.buffer.mkString
+        val prevIdx = Grapheme.previousBoundary(text, state.cursor)
+        (normalized(state.copy(cursor = prevIdx)), None)
 
       case KeyDecoder.InputKey.ArrowRight =>
-        (normalized(state.copy(cursor = state.cursor + 1)), None)
+        val text    = state.buffer.mkString
+        val nextIdx = Grapheme.nextBoundary(text, state.cursor)
+        (normalized(state.copy(cursor = nextIdx)), None)
 
       case KeyDecoder.InputKey.Home =>
         (normalized(state.copy(cursor = 0)), None)

--- a/modules/termflow-app/src/test/scala/termflow/tui/DialogsSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/DialogsSpec.scala
@@ -165,6 +165,43 @@ class DialogsSpec extends AnyFunSuite:
     assert(s.contains("OK"))
   }
 
+  // ---- Dialogs.actionList --------------------------------------------------
+
+  test("Dialogs.actionList renders one row per action and highlights the focused one") {
+    val o = Dialogs.actionList(
+      title = "Edit",
+      actions = List(
+        Dialogs.Choice("Cut", focused = false),
+        Dialogs.Choice("Copy", focused = true),
+        Dialogs.Choice("Paste", focused = false)
+      )
+    )
+    assert(o.input.isEmpty, "actionList has no live input")
+    assert(o.inputCapture == InputCapture.Modal)
+    val s = stringForm(o)
+    assert(s.contains("Edit"))
+    assert(s.contains("Cut") && s.contains("Copy") && s.contains("Paste"))
+    // OK / Cancel are NOT part of an actionList — apps fire on selection.
+    assert(!s.contains("[ OK ]"))
+    assert(!s.contains("[ Cancel ]"))
+  }
+
+  test("Dialogs.actionList sizes width to its widest label") {
+    val short = Dialogs.actionList("M", List(Dialogs.Choice("Hi", true), Dialogs.Choice("Bye", false)))
+    val wide = Dialogs.actionList(
+      "M",
+      List(Dialogs.Choice("Open Recent…", true), Dialogs.Choice("Save As Encrypted Archive", false))
+    )
+    assert(wide.width > short.width)
+  }
+
+  test("Dialogs.actionList with empty actions still renders the title") {
+    val o = Dialogs.actionList("Empty", List.empty)
+    val s = stringForm(o)
+    assert(s.contains("Empty"))
+    assert(o.height >= 5)
+  }
+
   // ---- Dialogs.waiting -----------------------------------------------------
 
   test("Dialogs.waiting picks the spinner frame from the tick (modulo)") {

--- a/modules/termflow-app/src/test/scala/termflow/tui/KeymapSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/KeymapSpec.scala
@@ -55,9 +55,9 @@ class KeymapSpec extends AnyFunSuite:
     assert(k.lookup(InputKey.CharKey('q')).contains(DemoMsg.Quit))
     assert(k.lookup(InputKey.CharKey('Q')).contains(DemoMsg.Quit))
 
-  test("Keymap.focus binds Tab (Ctrl+I) to next and BackTab (Shift+Tab) to previous"):
+  test("Keymap.focus binds Tab to next and BackTab (Shift+Tab) to previous"):
     val k = Keymap.focus(next = DemoMsg.NextFocus, previous = DemoMsg.A)
-    assert(k.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus))
+    assert(k.lookup(InputKey.Tab).contains(DemoMsg.NextFocus))
     assert(k.lookup(InputKey.BackTab).contains(DemoMsg.A))
     assert(k.size == 2)
 
@@ -80,7 +80,7 @@ class KeymapSpec extends AnyFunSuite:
         Keymap.focusHorizontal(previous = DemoMsg.A, next = DemoMsg.NextFocus)
     assert(k.size == 6) // Tab + BackTab + Up + Down + Left + Right
     // Spot-check that all six distinct keys land where expected.
-    assert(k.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus))
+    assert(k.lookup(InputKey.Tab).contains(DemoMsg.NextFocus))
     assert(k.lookup(InputKey.BackTab).contains(DemoMsg.A))
     assert(k.lookup(InputKey.ArrowUp).contains(DemoMsg.A))
     assert(k.lookup(InputKey.ArrowDown).contains(DemoMsg.NextFocus))
@@ -106,7 +106,7 @@ class KeymapSpec extends AnyFunSuite:
       InputKey.CharKey('q') -> DemoMsg.A // override quit's q->Quit
     )
     val full = baseline ++ mine
-    assert(full.lookup(InputKey.Ctrl('C')).contains(DemoMsg.Quit))      // baseline
-    assert(full.lookup(InputKey.Ctrl('I')).contains(DemoMsg.NextFocus)) // baseline
-    assert(full.lookup(InputKey.CharKey('q')).contains(DemoMsg.A))      // override
-    assert(full.lookup(InputKey.CharKey('Q')).contains(DemoMsg.Quit))   // baseline preserved
+    assert(full.lookup(InputKey.Ctrl('C')).contains(DemoMsg.Quit))    // baseline
+    assert(full.lookup(InputKey.Tab).contains(DemoMsg.NextFocus))     // baseline
+    assert(full.lookup(InputKey.CharKey('q')).contains(DemoMsg.A))    // override
+    assert(full.lookup(InputKey.CharKey('Q')).contains(DemoMsg.Quit)) // baseline preserved

--- a/modules/termflow-app/src/test/scala/termflow/tui/PromptSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/PromptSpec.scala
@@ -92,3 +92,52 @@ class PromptSpec extends AnyFunSuite:
     assert(line.text == ">> ab")
     assert(line.cursorIndex == 4)
     assert(line.prefixLength == 3)
+
+  // ---- grapheme-aware navigation ------------------------------------------
+
+  test("Backspace deletes a surrogate pair as one unit"):
+    // 😀 = U+1F600, encoded as a high+low surrogate (length = 2).
+    val emoji     = "a😀"
+    val state     = Prompt.State(buffer = emoji.toVector, cursor = emoji.length)
+    val (next, _) = Prompt.handleKey[String](state, InputKey.Backspace)(noopToMsg)
+    assert(Prompt.render(next) == "a")
+    assert(next.cursor == 1)
+
+  test("Backspace deletes a combining mark with its base"):
+    // "é" = e + COMBINING ACUTE ACCENT (one grapheme, two chars).
+    val s         = "é"
+    val state     = Prompt.State(buffer = s.toVector, cursor = s.length)
+    val (next, _) = Prompt.handleKey[String](state, InputKey.Backspace)(noopToMsg)
+    assert(Prompt.render(next).isEmpty)
+    assert(next.cursor == 0)
+
+  test("ArrowLeft steps over a surrogate pair"):
+    val emoji     = "a😀b"
+    val state     = Prompt.State(buffer = emoji.toVector, cursor = 3) // after the emoji
+    val (next, _) = Prompt.handleKey[String](state, InputKey.ArrowLeft)(noopToMsg)
+    assert(next.cursor == 1, s"expected cursor=1 after stepping over 😀, got ${next.cursor}")
+
+  test("ArrowRight steps over a surrogate pair"):
+    val emoji     = "a😀b"
+    val state     = Prompt.State(buffer = emoji.toVector, cursor = 1) // after a
+    val (next, _) = Prompt.handleKey[String](state, InputKey.ArrowRight)(noopToMsg)
+    assert(next.cursor == 3)
+
+  test("Delete removes a surrogate pair"):
+    val emoji     = "a😀b"
+    val state     = Prompt.State(buffer = emoji.toVector, cursor = 1)
+    val (next, _) = Prompt.handleKey[String](state, InputKey.Delete)(noopToMsg)
+    assert(Prompt.render(next) == "ab")
+    assert(next.cursor == 1)
+
+  test("cursorColumn counts wide characters as 2 columns"):
+    // 你好 = two CJK chars, each width 2.
+    val s     = "你好"
+    val state = Prompt.State(buffer = s.toVector, cursor = 1) // after 你
+    assert(Prompt.cursorColumn(state) == 2)
+    val state2 = state.copy(cursor = 2) // after 好
+    assert(Prompt.cursorColumn(state2) == 4)
+
+  test("cursorColumn counts combining marks as 0 columns"):
+    val state = Prompt.State(buffer = "é".toVector, cursor = 2)
+    assert(Prompt.cursorColumn(state) == 1, "e=1, combining mark=0")

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -11,22 +11,33 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
- * Six-tab showcase of every shipped TermFlow widget and runtime feature.
+ * Nine-tab showcase of every shipped TermFlow widget and runtime feature.
  *
- * Tabs (switch with `1`..`6` or click the cell in the bar at row 2):
+ * Tabs (switch with `1`..`9` or click the cell in the bar at row 2):
  *
  *   - **1 Showcase** — Stage 1 + Stage 2 demo: capabilities, palette,
  *     themes (RadioGroup), borders (RadioGroup), styles (CheckBox),
- *     unicode width, LogView-driven live input, Tabs widget.
+ *     unicode width, LogView-driven live input, Tabs widget. The
+ *     Showcase tab also wires `a` for the new
+ *     [[Dialogs.actionList]] dialog (Stage 3 §6.1).
  *   - **2 Widgets** — the Tree widget over a sample file tree (arrow keys
  *     navigate, Space / Enter toggles).
  *   - **3 Inputs** — Form widget composing TextField, Select, Autocomplete,
  *     CheckBox, and Button. Tab/Shift+Tab cycles focus, Enter submits.
  *   - **4 Data** — ListView + Table side-by-side with an animated Spinner
- *     and ProgressBar in the header and a StatusBar pinned at the bottom.
+ *     and ProgressBar in the header, a vertical
+ *     [[widgets.ScrollBar]] (Stage 3 §6.2) tracking the ListView, and
+ *     a StatusBar pinned at the bottom.
  *   - **5 Layout** — SplitPane horizontal split with a MenuBar in the left
- *     pane; `[`/`]` resize the divider, ←/→/↓ drive the menu.
- *   - **6 Help** — keybinding reference + about.
+ *     pane; `[`/`]` or **drag the divider with the mouse**
+ *     ([[widgets.SplitPane.handleMouse]], Stage 3 §6.2) resize it,
+ *     ←/→/↓ drive the menu.
+ *   - **6 Wizard** / **7 Dashboard** — embedded sample apps.
+ *   - **8 Help** — keybinding reference, with the new
+ *     [[widgets.Separator]] (Stage 3 §6.2) used as section rules.
+ *   - **9 Editor** — [[widgets.MultiLineInput]] (Stage 3 §5.3) — type
+ *     to edit, Enter inserts a newline, ↑/↓/←/→ navigate, surrogate
+ *     pairs and combining marks edit by grapheme.
  *
  * Stage 1+2 features (Showcase tab):
  *
@@ -145,7 +156,8 @@ object Stage1ShowcaseApp:
       "5 Layout",
       "6 Wizard",
       "7 Dashboard",
-      "8 Help"
+      "8 Help",
+      "9 Editor"
     )
 
   /**
@@ -169,6 +181,7 @@ object Stage1ShowcaseApp:
   private val WizardTabIdx: Int    = 5
   private val DashboardTabIdx: Int = 6
   private val HelpTabIdx: Int      = 7
+  private val EditorTabIdx: Int    = 8
 
   // ---- Inputs tab (Form + TextField + Select + Autocomplete + CheckBox + Button) ----
   private val InpNameId: FocusId    = FocusId("inp-name")
@@ -322,12 +335,28 @@ object Stage1ShowcaseApp:
     case Files
     case Directories
 
+  /**
+   * Action items rendered by the [[Dialogs.actionList]] dialog opened
+   * via `a` on the Showcase tab. Each entry maps to a Msg dispatched
+   * when the user picks it.
+   */
+  enum ActionListItem:
+    case CycleTheme, CycleBorder, OpenListDialog
+
+  /** Vector form of [[ActionListItem]] so we can index by selection. */
+  private val actionListItems: Vector[ActionListItem] = Vector(
+    ActionListItem.CycleTheme,
+    ActionListItem.CycleBorder,
+    ActionListItem.OpenListDialog
+  )
+
   enum Dialog:
     case None
     case ConfirmQuit(yesFocused: Boolean)
     case TextInput(state: Prompt.State, okFocused: Boolean)
     case ListSelect(selectedIndex: Int)
     case Waiting(openedAtTick: Long, autoCloseAtTick: Long)
+    case ActionList(selectedIndex: Int)
     case FilePicker(
       mode: FilePickerMode,
       currentPath: Path,
@@ -378,8 +407,11 @@ object Stage1ShowcaseApp:
     dataProgress: Double,
     // ---- Layout tab state ----
     layoutSplitRatio: Double,
+    layoutSplitDrag: widgets.SplitPane.DragState,
     layoutMenu: widgets.MenuBar.State,
     layoutLastPick: Option[String],
+    // ---- Editor tab state ----
+    editorState: widgets.MultiLineInput.State,
     // ---- Embedded sub-apps ----
     wizardModel: WizardApp.Model,
     dashboardModel: DashboardApp.Model,
@@ -411,6 +443,9 @@ object Stage1ShowcaseApp:
     case OpenTextInput
     case OpenListSelect
     case OpenWaiting
+    case OpenActionList
+    case ActionListMove(delta: Int)
+    case ActionListAccept(index: Int)
     case OpenFileDialog
     case OpenDirectoryDialog
     case FilePickerMove(delta: Int)
@@ -422,6 +457,8 @@ object Stage1ShowcaseApp:
     case ListSelectAccept(index: Int)
     case InputsSubmit
     case LayoutMenuPick(menuTitle: String, item: String)
+    case LayoutMouse(ev: MouseEvent)
+    case EditorKey(k: KeyDecoder.InputKey)
     case Quit
     case Key(k: KeyDecoder.InputKey)
     case KeyError(t: Throwable)
@@ -465,8 +502,16 @@ object Stage1ShowcaseApp:
         dataList = widgets.ListView.State.of(dataTasks, visibleRows = 8),
         dataProgress = 0.0,
         layoutSplitRatio = 0.55,
+        layoutSplitDrag = widgets.SplitPane.DragState.at(0.55),
         layoutMenu = widgets.MenuBar.State(layoutMenus),
         layoutLastPick = None,
+        editorState = widgets.MultiLineInput.State.of(
+          "MultiLineInput demo — Stage 3 §5.3.\n" +
+            "Enter inserts a newline.\n" +
+            "↑/↓ between rows; ←/→ within a row.\n" +
+            "Backspace at start of a row joins with the line above.\n" +
+            "Wide chars and emoji edit by grapheme: 你好 😀."
+        ),
         wizardModel = WizardApp.initialModel,
         dashboardModel = DashboardApp.initialModel,
         input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx),
@@ -489,6 +534,24 @@ object Stage1ShowcaseApp:
           m.copy(dialog = Dialog.ListSelect(selectedIndex = 0)).tui
         case OpenWaiting =>
           m.copy(dialog = Dialog.Waiting(openedAtTick = m.tick, autoCloseAtTick = m.tick + waitingDurationTicks)).tui
+        case OpenActionList =>
+          m.copy(dialog = Dialog.ActionList(selectedIndex = 0)).tui
+        case ActionListMove(delta) =>
+          m.dialog match
+            case Dialog.ActionList(idx) =>
+              val next = math.max(0, math.min(actionListItems.size - 1, idx + delta))
+              m.copy(dialog = Dialog.ActionList(next)).tui
+            case _ => m.tui
+        case ActionListAccept(idx) =>
+          val pick   = actionListItems(clampIdx(idx, actionListItems.size))
+          val closed = m.copy(dialog = Dialog.None)
+          pick match
+            case ActionListItem.CycleTheme =>
+              closed.copy(themeIdx = (m.themeIdx + 1) % themePresets.size).tui
+            case ActionListItem.CycleBorder =>
+              closed.copy(borderIdx = (m.borderIdx + 1) % borderStyles.size).tui
+            case ActionListItem.OpenListDialog =>
+              closed.copy(dialog = Dialog.ListSelect(selectedIndex = 0)).tui
         case OpenFileDialog      => openFilePicker(m, FilePickerMode.Files)
         case OpenDirectoryDialog => openFilePicker(m, FilePickerMode.Directories)
         case FilePickerMove(delta) =>
@@ -532,6 +595,22 @@ object Stage1ShowcaseApp:
           m.copy(inputsSubmitted = Some(s"$name • $country • $fruit • $agree")).tui
         case LayoutMenuPick(menuTitle, item) =>
           m.copy(layoutLastPick = Some(s"$menuTitle › $item")).tui
+        case EditorKey(k) =>
+          val (next, _) = widgets.MultiLineInput.handleKey[Msg](m.editorState, k)
+          m.copy(editorState = next).tui
+        case LayoutMouse(ev) =>
+          val (sw, sh, sx, sy) = layoutSplitGeom(m)
+          val state            = m.layoutSplitDrag.copy(splitRatio = m.layoutSplitRatio)
+          val drag = widgets.SplitPane.handleMouse(
+            state = state,
+            event = ev,
+            direction = widgets.SplitPane.Direction.Horizontal,
+            width = sw,
+            height = sh,
+            at = Coord(XCoord(sx), YCoord(sy)),
+            gap = 1
+          )
+          m.copy(layoutSplitDrag = drag, layoutSplitRatio = drag.splitRatio).tui
         case SelectListIdx(i) =>
           m.dialog match
             case Dialog.ListSelect(_) =>
@@ -584,6 +663,7 @@ object Stage1ShowcaseApp:
                 case LayoutTabIdx    => handleLayoutKey(withEvent, k, ctx)
                 case WizardTabIdx    => handleWizardKey(withEvent, k)
                 case DashboardTabIdx => handleDashboardKey(withEvent, k)
+                case EditorTabIdx    => handleEditorKey(withEvent, k)
                 case _               => Tui(withEvent, dispatch(withEvent, k))
             case _ => Tui(withEvent, dispatch(withEvent, k))
 
@@ -642,6 +722,23 @@ object Stage1ShowcaseApp:
             case _ =>
               val nextDashboard = DashboardApp.step(m.dashboardModel, DashboardApp.Msg.Key(k))
               m.copy(dashboardModel = nextDashboard).tui
+
+    /**
+     * Forward keystrokes to the [[widgets.MultiLineInput]] on the
+     * Editor tab. Tab-switch digits stay routed to the showcase, and
+     * `Esc` opens the quit dialog so the user can leave the tab; every
+     * other key (including `q`, since the editor accepts text) is fed
+     * to the editor.
+     */
+    private def handleEditorKey(m: Model, k: KeyDecoder.InputKey): Tui[Model, Msg] =
+      import KeyDecoder.InputKey.*
+      digitTabSwitch(k, allowDigits = false) match
+        case Some(idx) => Tui(m, Cmd.GCmd(SelectTab(idx)))
+        case None =>
+          k match
+            case Mouse(ev) => Tui(m, tabBarMouseDispatch(ev))
+            case Escape    => Tui(m, Cmd.GCmd(OpenDialog))
+            case _         => Tui(m, Cmd.GCmd(EditorKey(k)))
 
     private def clampIdx(i: Int, size: Int): Int = math.max(0, math.min(size - 1, i))
 
@@ -705,6 +802,16 @@ object Stage1ShowcaseApp:
             case Escape => Cmd.GCmd(CloseDialog)
             case _      => Cmd.NoCmd
 
+        case Dialog.ActionList(idx) =>
+          k match
+            case ArrowUp   => Cmd.GCmd(ActionListMove(-1))
+            case ArrowDown => Cmd.GCmd(ActionListMove(+1))
+            case Home      => Cmd.GCmd(ActionListMove(-actionListItems.size))
+            case End       => Cmd.GCmd(ActionListMove(actionListItems.size))
+            case Enter     => Cmd.GCmd(ActionListAccept(idx))
+            case Escape    => Cmd.GCmd(CloseDialog)
+            case _         => Cmd.NoCmd
+
         case Dialog.FilePicker(_, _, _, _) =>
           k match
             case ArrowUp   => Cmd.GCmd(FilePickerMove(-1))
@@ -736,6 +843,7 @@ object Stage1ShowcaseApp:
         case CharKey('i') | CharKey('I') => Cmd.GCmd(OpenTextInput)
         case CharKey('l') | CharKey('L') => Cmd.GCmd(OpenListSelect)
         case CharKey('w') | CharKey('W') => Cmd.GCmd(OpenWaiting)
+        case CharKey('a') | CharKey('A') => Cmd.GCmd(OpenActionList)
         case CharKey('f') | CharKey('F') => Cmd.GCmd(OpenFileDialog)
         case CharKey('g') | CharKey('G') => Cmd.GCmd(OpenDirectoryDialog)
         case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
@@ -880,7 +988,16 @@ object Stage1ShowcaseApp:
       val pre: Option[Tui[Model, Msg]] = k match
         case CharKey('q') | CharKey('Q') => Some(Tui(m, Cmd.GCmd(OpenDialog)))
         case Escape if !menuActive       => Some(Tui(m, Cmd.GCmd(OpenDialog)))
-        case Mouse(ev)                   => Some(Tui(m, tabBarMouseDispatch(ev)))
+        case Mouse(ev)                   =>
+          // A Press on the tab bar still switches tabs; every other
+          // mouse event (including releases / drags) is forwarded to
+          // the SplitPane drag handler.
+          val tabPick = ev match
+            case MouseEvent.Press(MouseButton.Left, col, row, _) => tabHitTest(col, row)
+            case _                                               => None
+          tabPick match
+            case Some(idx) => Some(Tui(m, Cmd.GCmd(SelectTab(idx))))
+            case None      => Some(Tui(m, Cmd.GCmd(LayoutMouse(ev))))
         case CharKey('[') =>
           Some(m.copy(layoutSplitRatio = math.max(widgets.SplitPane.MinSizeRatio, m.layoutSplitRatio - 0.05)).tui)
         case CharKey(']') =>
@@ -1172,7 +1289,16 @@ object Stage1ShowcaseApp:
             "split  ".text
           )
         case HelpTabIdx =>
-          List(" press 1..5 to leave Help ".themed(_.info), "  ".text)
+          List(" press 1..9 to leave Help ".themed(_.info), "  ".text)
+        case EditorTabIdx =>
+          List(
+            " type ".themed(_.primary),
+            "to edit  ".text,
+            " ↑/↓/←/→ ".themed(_.primary),
+            "navigate  ".text,
+            " Enter ".themed(_.primary),
+            "newline  ".text
+          )
         case _ =>
           List(
             " b ".themed(_.primary),
@@ -1212,6 +1338,7 @@ object Stage1ShowcaseApp:
         case WizardTabIdx    => wizardTabBody(m)
         case DashboardTabIdx => dashboardTabBody(m)
         case HelpTabIdx      => helpTabBody(m)
+        case EditorTabIdx    => editorTabBody(m)
         case _               => showcaseTabBody(m)
 
       val baseRoot = RootNode(
@@ -1249,6 +1376,18 @@ object Stage1ShowcaseApp:
           )
         case Dialog.ListSelect(idx) =>
           baseRoot.copy(overlays = List(buildListSelectOverlay(idx)))
+        case Dialog.ActionList(idx) =>
+          val labels = Vector("Cycle theme", "Cycle border", "Open list dialog")
+          val choices =
+            labels.zipWithIndex.map { case (lbl, i) => Dialogs.Choice(lbl, focused = i == idx) }.toList
+          baseRoot.copy(overlays =
+            List(
+              Dialogs.actionList(
+                title = "Quick actions",
+                actions = choices
+              )
+            )
+          )
         case Dialog.Waiting(openedAt, deadline) =>
           val remaining = math.max(0L, deadline - m.tick)
           baseRoot.copy(overlays =
@@ -1531,6 +1670,20 @@ object Stage1ShowcaseApp:
         focused = listFocused
       )
 
+      // Vertical ScrollBar pinned next to the list — driven by the
+      // ListView's selection / visibleRows / total. Hidden when there
+      // are fewer items than fit (the helper short-circuits).
+      val scrollBarNodes = widgets.ScrollBar(
+        state = widgets.ScrollBar.State(
+          offset = m.dataList.scrollOffset,
+          visible = m.dataList.visibleRows,
+          total = m.dataList.items.size
+        ),
+        length = m.dataList.visibleRows,
+        direction = widgets.ScrollBar.Direction.Vertical,
+        at = Coord(31.x, 7.y)
+      )
+
       // Table (right) — render rows from the same items + paired statuses.
       val tableRows: Vector[(String, String)] =
         m.dataList.items.zipWithIndex.map { case (t, i) =>
@@ -1557,7 +1710,14 @@ object Stage1ShowcaseApp:
         at = Coord(2.x, statusY.y)
       )
 
-      List(panel(r, theme, List(title, spinnerNode, progressNode, intro, listNode, tableNode, statusBar)))
+      List(
+        panel(
+          r,
+          theme,
+          (title :: spinnerNode :: progressNode :: intro :: listNode :: scrollBarNodes) ++
+            List(tableNode, statusBar)
+        )
+      )
 
     /**
      * Body content for the "Layout" tab — SplitPane horizontally split
@@ -1603,8 +1763,8 @@ object Stage1ShowcaseApp:
             TextNode((at.x.value + 1).x, (at.y.value + 4).y, List(s"Width = $w cells.".themed(_.info))),
             TextNode((at.x.value + 1).x, (at.y.value + 6).y, List("[ shrinks the left pane".text)),
             TextNode((at.x.value + 1).x, (at.y.value + 7).y, List("] grows the left pane".text)),
-            TextNode((at.x.value + 1).x, (at.y.value + 9).y, List("Drag-resize is on the".text)),
-            TextNode((at.x.value + 1).x, (at.y.value + 10).y, List("Stage 3 mouse follow-up.".themed(_.info)))
+            TextNode((at.x.value + 1).x, (at.y.value + 9).y, List("…or drag the divider".text)),
+            TextNode((at.x.value + 1).x, (at.y.value + 10).y, List("with the mouse.".themed(_.info)))
           )
           rowNodes
         },
@@ -1639,32 +1799,38 @@ object Stage1ShowcaseApp:
     private def helpTabBody(m: Model)(using theme: Theme): List[VNode] =
       val r     = widgetsTabRect(m)
       val title = TextNode(2.x, 1.y, List(" Keybindings & help ".themed(_.primary)))
+
+      // Separator widget puts a labelled rule across the panel between
+      // the title and the tab list — also exercises the new
+      // `widgets.Separator` helper end-to-end.
+      val sepWidth  = math.max(20, r.width - 4)
+      val sepNodes  = widgets.Separator.horizontal(width = sepWidth, at = Coord(2.x, 2.y), title = "Tabs")
+      val sepNodes2 = widgets.Separator.horizontal(width = sepWidth, at = Coord(2.x, 28.y), title = "Anywhere")
+
       val rows = List(
-        TextNode(2.x, 3.y, List(" 1..8 ".themed(_.primary), "  switch tab".text)),
+        TextNode(2.x, 3.y, List(" 1..9 ".themed(_.primary), "  switch tab".text)),
         TextNode(2.x, 5.y, List(" 1 Showcase".themed(_.success))),
         TextNode(2.x, 6.y, List("   b  cycle border style".text)),
         TextNode(2.x, 7.y, List("   t  cycle theme".text)),
         TextNode(2.x, 8.y, List("   d / i / l / w  open dialogs".text)),
-        TextNode(2.x, 9.y, List("   f / g  open fileDialog / directoryDialog".text)),
-        TextNode(2.x, 10.y, List(" 2 Widgets (Tree)".themed(_.success))),
-        TextNode(2.x, 11.y, List("   ↑/↓ move,  Space/Enter toggle node".text)),
-        TextNode(2.x, 13.y, List(" 3 Inputs (Form)".themed(_.success))),
-        TextNode(2.x, 14.y, List("   Tab/Shift+Tab cycle focus,  Enter submit".text)),
-        TextNode(2.x, 15.y, List("   Space toggles the CheckBox / activates Button".text)),
-        TextNode(2.x, 17.y, List(" 4 Data (List + Table)".themed(_.success))),
-        TextNode(2.x, 18.y, List("   ↑/↓ move,  Tab focuses ListView vs Table".text)),
-        TextNode(2.x, 20.y, List(" 5 Layout (SplitPane + MenuBar)".themed(_.success))),
-        TextNode(2.x, 21.y, List("   ←/→ menu,  ↓ open,  Enter pick,  Esc close".text)),
-        TextNode(2.x, 22.y, List("   [ / ] resize the split".text)),
-        TextNode(2.x, 24.y, List(" 6 Wizard (3-step form)".themed(_.success))),
-        TextNode(2.x, 25.y, List("   Tab/Shift+Tab cycle focus,  Enter activates Next/Submit".text)),
-        TextNode(2.x, 26.y, List(" 7 Dashboard (live metrics)".themed(_.success))),
-        TextNode(2.x, 27.y, List("   ↑/↓ select service,  r restart,  p / Space pause".text)),
-        TextNode(2.x, 29.y, List(" Anywhere".themed(_.success))),
-        TextNode(2.x, 30.y, List("   q / Esc  open quit confirmation".text)),
-        TextNode(2.x, 31.y, List("   click on Tabs bar  switch tab".text))
+        TextNode(2.x, 9.y, List("   a  open actionList dialog".text)),
+        TextNode(2.x, 10.y, List("   f / g  open fileDialog / directoryDialog".text)),
+        TextNode(2.x, 11.y, List(" 2 Widgets (Tree)".themed(_.success))),
+        TextNode(2.x, 12.y, List("   ↑/↓ move,  Space/Enter toggle node".text)),
+        TextNode(2.x, 14.y, List(" 3 Inputs (Form)".themed(_.success))),
+        TextNode(2.x, 15.y, List("   Tab/Shift+Tab cycle focus,  Enter submit".text)),
+        TextNode(2.x, 16.y, List("   Space toggles the CheckBox / activates Button".text)),
+        TextNode(2.x, 18.y, List(" 4 Data (List + Table + ScrollBar)".themed(_.success))),
+        TextNode(2.x, 19.y, List("   ↑/↓ move,  Tab focuses ListView vs Table".text)),
+        TextNode(2.x, 21.y, List(" 5 Layout (SplitPane + MenuBar)".themed(_.success))),
+        TextNode(2.x, 22.y, List("   ←/→ menu,  ↓ open,  Enter pick,  Esc close".text)),
+        TextNode(2.x, 23.y, List("   [ / ] or drag the divider to resize the split".text)),
+        TextNode(2.x, 25.y, List(" 6 Wizard / 7 Dashboard / 9 Editor (MultiLineInput)".themed(_.success))),
+        TextNode(2.x, 26.y, List("   editor: Enter inserts newline, ↑/↓ between rows".text)),
+        TextNode(2.x, 29.y, List("   q / Esc  open quit confirmation".text)),
+        TextNode(2.x, 30.y, List("   click on Tabs bar  switch tab".text))
       )
-      List(panel(r, theme, title :: rows))
+      List(panel(r, theme, (title :: sepNodes) ++ sepNodes2 ++ rows))
 
     /**
      * Body content for the "Wizard" tab — embeds [[WizardApp]]'s view by
@@ -1688,6 +1854,52 @@ object Stage1ShowcaseApp:
       embedded.children.map(c => Layout.translate(c, dx = r.col - 1, dy = r.row - 1))
 
     /**
+     * Body content for the "Editor" tab — wraps the
+     * [[widgets.MultiLineInput]] in a bordered panel and pins a help
+     * footer underneath. The widget renders an [[InputNode]] for the
+     * cursor row internally, so the hardware cursor follows editing
+     * even when wide chars (CJK, emoji) are in the buffer.
+     */
+    private def editorTabBody(m: Model)(using theme: Theme): List[VNode] =
+      val r     = widgetsTabRect(m)
+      val title = TextNode(2.x, 1.y, List(" MultiLineInput (Stage 3 §5.3) ".themed(_.primary)))
+      val intro = TextNode(
+        2.x,
+        3.y,
+        List("Type to edit; ↑/↓/←/→ navigate; Enter inserts a newline.".themed(_.info))
+      )
+
+      // Reserve the full panel below the intro for the editor.
+      val editorTop    = 5
+      val editorWidth  = math.max(20, r.width - 6)
+      val editorHeight = math.max(4, r.height - editorTop - 4)
+      val editorNodes = widgets.MultiLineInput.render(
+        state = m.editorState,
+        width = editorWidth,
+        height = editorHeight,
+        at = Coord(3.x, editorTop.y)
+      )
+
+      val rowsCount = m.editorState.lines.size
+      val statusY   = math.max(editorTop + editorHeight, r.height - 2)
+      val status = TextNode(
+        2.x,
+        statusY.y,
+        List(
+          " row ".themed(_.secondary),
+          (m.editorState.cursorRow + 1).toString.themed(_.foreground),
+          " / ".themed(_.secondary),
+          rowsCount.toString.themed(_.foreground),
+          "  col ".themed(_.secondary),
+          (m.editorState.cursorCol + 1).toString.themed(_.foreground),
+          "  total chars ".themed(_.secondary),
+          m.editorState.text.length.toString.themed(_.foreground)
+        )
+      )
+
+      List(panel(r, theme, (title :: intro :: editorNodes) :+ status))
+
+    /**
      * Rect that fills the area below the Tabs bar to the help footer.
      *  Leaves a 1-cell margin on the right (matching the Showcase tab's
      *  rightmost panel layout) so the box's right border doesn't get
@@ -1698,6 +1910,21 @@ object Stage1ShowcaseApp:
       val bottom = math.max(top + 5, m.height - 2) // leave row m.height-1 for footer
       val width  = math.max(60, m.width) - 1
       Rect(col = 1, row = top, width = width, height = bottom - top + 1)
+
+    /**
+     * Absolute geometry of the Layout tab's SplitPane region:
+     *  `(width, height, absX, absY)`. Mirrors the constants used in
+     *  `layoutTabBody` so the mouse drag handler operates in the same
+     *  coordinate system the renderer uses.
+     */
+    private def layoutSplitGeom(m: Model): (Int, Int, Int, Int) =
+      val r           = widgetsTabRect(m)
+      val splitTop    = 5
+      val splitHeight = math.max(8, r.height - splitTop - 2)
+      val splitWidth  = math.max(40, r.width - 4)
+      val absX        = r.col + 2 - 1 // panel-local 2.x
+      val absY        = r.row + splitTop - 1
+      (splitWidth, splitHeight, absX, absY)
 
     /** Bordered panel positioned at `r` with the theme's border style. */
     private def panel(r: Rect, theme: Theme, children: List[VNode]): VNode =

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -756,13 +756,15 @@ object Stage1ShowcaseApp:
      */
     private def handleEditorKey(m: Model, k: KeyDecoder.InputKey): Tui[Model, Msg] =
       import KeyDecoder.InputKey.*
-      digitTabSwitch(k, allowDigits = false) match
-        case Some(idx) => Tui(m, Cmd.GCmd(SelectTab(idx)))
-        case None =>
-          k match
-            case Mouse(ev) => Tui(m, tabBarMouseDispatch(ev))
-            case Escape    => Tui(m, Cmd.GCmd(OpenDialog))
-            case _         => Tui(m, Cmd.GCmd(EditorKey(k)))
+      // The editor consumes every printable key (digits included) so the
+      // showcase's normal `1..9` tab-switch is unavailable. Esc is the
+      // dedicated leave-the-editor key — it switches back to the
+      // Showcase tab so the user has a keyboard-only path out. Ctrl+C
+      // still closes the app at the runtime level.
+      k match
+        case Mouse(ev) => Tui(m, tabBarMouseDispatch(ev))
+        case Escape    => Tui(m, Cmd.GCmd(SelectTab(ShowcaseTabIdx)))
+        case _         => Tui(m, Cmd.GCmd(EditorKey(k)))
 
     private def clampIdx(i: Int, size: Int): Int = math.max(0, math.min(size - 1, i))
 
@@ -1382,7 +1384,9 @@ object Stage1ShowcaseApp:
             " ↑/↓/←/→ ".themed(_.primary),
             "navigate  ".text,
             " Enter ".themed(_.primary),
-            "newline  ".text
+            "newline  ".text,
+            " Esc ".themed(_.primary),
+            "leave  ".text
           )
         case _ =>
           List(
@@ -1698,11 +1702,16 @@ object Stage1ShowcaseApp:
         widgets.Form.Row(
           InpFruitId,
           "Fruit:",
-          _ =>
-            // Autocomplete is always-open, so it doesn't take a `focused`
-            // parameter — wrap its node list into a BoxNode so the Form
-            // row can place a single VNode.
-            val parts = widgets.Autocomplete.view(m.inputsFruit, width = fieldWidth, maxVisible = 5)
+          focused =>
+            // Pass focus through so the dropdown drops the primary-bar
+            // highlight when another row owns focus — the static field
+            // shouldn't compete with the active widget visually.
+            val parts = widgets.Autocomplete.view(
+              m.inputsFruit,
+              width = fieldWidth,
+              maxVisible = 5,
+              focused = focused
+            )
             VNode.BoxNode(1.x, 1.y, fieldWidth, widgets.Autocomplete.height(m.inputsFruit, 5), parts, Style())
           ,
           height = widgets.Autocomplete.height(m.inputsFruit, 5)
@@ -1923,7 +1932,7 @@ object Stage1ShowcaseApp:
         TextNode(2.x, 22.y, List("   ←/→ menu,  ↓ open,  Enter pick,  Esc close".text)),
         TextNode(2.x, 23.y, List("   [ shrink, ] grow, = reset, or drag the divider with the mouse".text)),
         TextNode(2.x, 25.y, List(" 6 Wizard / 7 Dashboard / 9 Editor (MultiLineInput)".themed(_.success))),
-        TextNode(2.x, 26.y, List("   editor: Enter inserts newline, ↑/↓ between rows".text)),
+        TextNode(2.x, 26.y, List("   editor: Enter newline, ↑/↓ between rows, Esc leaves the tab".text)),
         TextNode(2.x, 29.y, List("   q / Esc  open quit confirmation".text)),
         TextNode(2.x, 30.y, List("   click on Tabs bar  switch tab".text))
       )
@@ -1963,7 +1972,7 @@ object Stage1ShowcaseApp:
       val intro = TextNode(
         2.x,
         3.y,
-        List("Type to edit; ↑/↓/←/→ navigate; Enter inserts a newline.".themed(_.info))
+        List("Type to edit. ↑/↓/←/→ navigate. Enter newline. Esc leaves the tab.".themed(_.info))
       )
 
       // Reserve the full panel below the intro for the editor.

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -459,6 +459,7 @@ object Stage1ShowcaseApp:
     case LayoutMenuPick(menuTitle: String, item: String)
     case LayoutMouse(ev: MouseEvent)
     case EditorKey(k: KeyDecoder.InputKey)
+    case TreeMouse(ev: MouseEvent)
     case Quit
     case Key(k: KeyDecoder.InputKey)
     case KeyError(t: Throwable)
@@ -598,6 +599,29 @@ object Stage1ShowcaseApp:
         case EditorKey(k) =>
           val (next, _) = widgets.MultiLineInput.handleKey[Msg](m.editorState, k)
           m.copy(editorState = next).tui
+        case TreeMouse(ev) =>
+          ev match
+            case MouseEvent.Press(MouseButton.Left, col, row, _) =>
+              val r      = widgetsTabRect(m)
+              val origin = Coord(XCoord(r.col + 1), YCoord(r.row + 4))
+              val rows   = widgets.Tree.visibleRows(demoTree, m.treeExpanded)
+              widgets.Tree.hitTest(rows, origin, indentWidth = 2, col = col, row = row, labelLength = 60) match
+                case Some(widgets.Tree.HitResult.Chevron(idx)) =>
+                  val r0  = rows(idx)
+                  val nxt = if r0.expanded then m.treeExpanded - r0.id else m.treeExpanded + r0.id
+                  m.copy(treeSelected = idx, treeExpanded = nxt).tui
+                case Some(widgets.Tree.HitResult.Label(idx)) =>
+                  m.copy(treeSelected = idx).tui
+                case None => m.tui
+            case MouseEvent.Scroll(dir, _, _, _) =>
+              val rows = widgets.Tree.visibleRows(demoTree, m.treeExpanded)
+              val step = dir match
+                case ScrollDirection.Up   => -1
+                case ScrollDirection.Down => +1
+                case _                    => 0
+              val next = math.max(0, math.min(rows.size - 1, m.treeSelected + step))
+              m.copy(treeSelected = next).tui
+            case _ => m.tui
         case LayoutMouse(ev) =>
           val (sw, sh, sx, sy) = layoutSplitGeom(m)
           val state            = m.layoutSplitDrag.copy(splitRatio = m.layoutSplitRatio)
@@ -864,6 +888,7 @@ object Stage1ShowcaseApp:
 
     /** Key bindings for the Widgets tab — tree navigation. */
     private def widgetsTabKey(k: KeyDecoder.InputKey, m: Model): Cmd[Msg] =
+      val _ = m
       import KeyDecoder.InputKey.*
       k match
         case ArrowUp                     => Cmd.GCmd(TreeUp)
@@ -871,8 +896,16 @@ object Stage1ShowcaseApp:
         case Enter | CharKey(' ')        => Cmd.GCmd(ToggleTreeNode)
         case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
         case Escape                      => Cmd.GCmd(OpenDialog)
-        case Mouse(ev)                   => tabBarMouseDispatch(ev)
-        case _                           => Cmd.NoCmd
+        case Mouse(ev)                   =>
+          // A press on the tab bar still switches tabs; everything else
+          // (clicks on the tree, scroll wheel) goes to the Tree handler.
+          ev match
+            case MouseEvent.Press(MouseButton.Left, col, row, _) =>
+              tabHitTest(col, row) match
+                case Some(idx) => Cmd.GCmd(SelectTab(idx))
+                case None      => Cmd.GCmd(TreeMouse(ev))
+            case _ => Cmd.GCmd(TreeMouse(ev))
+        case _ => Cmd.NoCmd
 
     /** Key bindings for the Help tab. */
     private def helpTabKey(k: KeyDecoder.InputKey): Cmd[Msg] =
@@ -1010,9 +1043,16 @@ object Stage1ShowcaseApp:
             case Some(idx) => Some(Tui(m, Cmd.GCmd(SelectTab(idx))))
             case None      => Some(Tui(m, Cmd.GCmd(LayoutMouse(ev))))
         case CharKey('[') =>
-          Some(m.copy(layoutSplitRatio = math.max(widgets.SplitPane.MinSizeRatio, m.layoutSplitRatio - 0.05)).tui)
+          val next = math.max(widgets.SplitPane.MinSizeRatio, m.layoutSplitRatio - 0.05)
+          Some(m.copy(layoutSplitRatio = next, layoutSplitDrag = widgets.SplitPane.DragState.at(next)).tui)
         case CharKey(']') =>
-          Some(m.copy(layoutSplitRatio = math.min(1.0 - widgets.SplitPane.MinSizeRatio, m.layoutSplitRatio + 0.05)).tui)
+          val next = math.min(1.0 - widgets.SplitPane.MinSizeRatio, m.layoutSplitRatio + 0.05)
+          Some(m.copy(layoutSplitRatio = next, layoutSplitDrag = widgets.SplitPane.DragState.at(next)).tui)
+        case CharKey('=') | CharKey('/') =>
+          // Reset the split back to 50/50. `=` is the more conventional
+          // key (Vim-style window resize); `/` is the explicit "reset"
+          // documented in the help footer.
+          Some(m.copy(layoutSplitRatio = 0.5, layoutSplitDrag = widgets.SplitPane.DragState.at(0.5)).tui)
         case _ =>
           digitTabSwitch(k, allowDigits = !menuActive).map(idx => Tui(m, Cmd.GCmd(SelectTab(idx))))
 
@@ -1326,8 +1366,12 @@ object Stage1ShowcaseApp:
             "menu  ".text,
             " ↓ ".themed(_.primary),
             "open  ".text,
-            " [ / ] ".themed(_.primary),
-            "split  ".text
+            " [ ".themed(_.primary),
+            "shrink ".text,
+            " ] ".themed(_.primary),
+            "grow ".text,
+            " = ".themed(_.primary),
+            "reset  ".text
           )
         case HelpTabIdx =>
           List(" press 1..9 to leave Help ".themed(_.info), "  ".text)
@@ -1598,7 +1642,17 @@ object Stage1ShowcaseApp:
     private def widgetsTabBody(m: Model)(using theme: Theme): List[VNode] =
       val r     = widgetsTabRect(m)
       val title = TextNode(2.x, 1.y, List(" Tree widget demo ".themed(_.primary)))
-      val intro = TextNode(2.x, 3.y, List("Arrow keys move; Space/Enter toggles a node.".text))
+      val intro = TextNode(
+        2.x,
+        3.y,
+        List(
+          "↑/↓ move; Space/Enter toggle.  Click a row to select it.  Click ".text,
+          "[+]".themed(_.primary),
+          " or ".text,
+          "[-]".themed(_.primary),
+          " to expand/collapse.  Scroll wheel moves selection.".text
+        )
+      )
       val treeRows = widgets.Tree(
         roots = demoTree,
         expanded = m.treeExpanded,
@@ -1772,7 +1826,9 @@ object Stage1ShowcaseApp:
       val intro = TextNode(
         2.x,
         3.y,
-        List("←/→ move between menus.  ↓/Enter open.  Esc close.  [ / ] resize split.".themed(_.info))
+        List(
+          "←/→ menus.  ↓/Enter open.  Esc close.  [ shrink, ] grow, = reset.  Drag divider with mouse.".themed(_.info)
+        )
       )
 
       val splitTop    = 5
@@ -1802,8 +1858,8 @@ object Stage1ShowcaseApp:
             TextNode((at.x.value + 1).x, (at.y.value + 1).y, List(" Right pane ".themed(_.primary))),
             TextNode((at.x.value + 1).x, (at.y.value + 3).y, List("This pane is rendered by SplitPane.".text)),
             TextNode((at.x.value + 1).x, (at.y.value + 4).y, List(s"Width = $w cells.".themed(_.info))),
-            TextNode((at.x.value + 1).x, (at.y.value + 6).y, List("[ shrinks the left pane".text)),
-            TextNode((at.x.value + 1).x, (at.y.value + 7).y, List("] grows the left pane".text)),
+            TextNode((at.x.value + 1).x, (at.y.value + 6).y, List("[ shrink, ] grow,".text)),
+            TextNode((at.x.value + 1).x, (at.y.value + 7).y, List("= or / reset to 50/50.".text)),
             TextNode((at.x.value + 1).x, (at.y.value + 9).y, List("…or drag the divider".text)),
             TextNode((at.x.value + 1).x, (at.y.value + 10).y, List("with the mouse.".themed(_.info)))
           )
@@ -1865,7 +1921,7 @@ object Stage1ShowcaseApp:
         TextNode(2.x, 19.y, List("   ↑/↓ move,  Tab focuses ListView vs Table".text)),
         TextNode(2.x, 21.y, List(" 5 Layout (SplitPane + MenuBar)".themed(_.success))),
         TextNode(2.x, 22.y, List("   ←/→ menu,  ↓ open,  Enter pick,  Esc close".text)),
-        TextNode(2.x, 23.y, List("   [ / ] or drag the divider to resize the split".text)),
+        TextNode(2.x, 23.y, List("   [ shrink, ] grow, = reset, or drag the divider with the mouse".text)),
         TextNode(2.x, 25.y, List(" 6 Wizard / 7 Dashboard / 9 Editor (MultiLineInput)".themed(_.success))),
         TextNode(2.x, 26.y, List("   editor: Enter inserts newline, ↑/↓ between rows".text)),
         TextNode(2.x, 29.y, List("   q / Esc  open quit confirmation".text)),

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -802,15 +802,26 @@ object Stage1ShowcaseApp:
             case Escape => Cmd.GCmd(CloseDialog)
             case _      => Cmd.NoCmd
 
-        case Dialog.ActionList(idx) =>
+        case Dialog.ActionList(_) =>
           k match
             case ArrowUp   => Cmd.GCmd(ActionListMove(-1))
             case ArrowDown => Cmd.GCmd(ActionListMove(+1))
             case Home      => Cmd.GCmd(ActionListMove(-actionListItems.size))
             case End       => Cmd.GCmd(ActionListMove(actionListItems.size))
-            case Enter     => Cmd.GCmd(ActionListAccept(idx))
-            case Escape    => Cmd.GCmd(CloseDialog)
-            case _         => Cmd.NoCmd
+            case Enter =>
+              m.dialog match
+                case Dialog.ActionList(i) => Cmd.GCmd(ActionListAccept(i))
+                case _                    => Cmd.NoCmd
+            case Escape                                                 => Cmd.GCmd(CloseDialog)
+            case Mouse(MouseEvent.Press(MouseButton.Left, col, row, _)) =>
+              // Route the click through the HitTest registry built for
+              // the dialog's rows. Demonstrates the Stage 3 §5.1 API
+              // end-to-end: zones registered, `hit(col, row)` looks up
+              // the topmost match, dispatch fires the matching Msg.
+              actionListHitTest(m).hit(col, row) match
+                case Some(idx) => Cmd.GCmd(ActionListAccept(idx))
+                case None      => Cmd.NoCmd
+            case _ => Cmd.NoCmd
 
         case Dialog.FilePicker(_, _, _, _) =>
           k match
@@ -1101,6 +1112,36 @@ object Stage1ShowcaseApp:
      * Mouse handling while the listSelect dialog is open: clicks on a
      *  visible row commit that item, scroll-wheel cycles the selection.
      */
+    /**
+     * Build a [[HitTest]] registry for the actionList dialog's rows so
+     * mouse clicks can be mapped back to the underlying action index
+     * (Stage 3 §5.1 API). The dialog's geometry mirrors what
+     * [[Dialogs.actionList]] computes internally; the registry is
+     * rebuilt every frame so resizes / theme changes are picked up
+     * automatically.
+     */
+    private def actionListHitTest(m: Model): HitTest[Int] =
+      val title    = "Quick actions"
+      val labels   = Vector("Cycle theme", "Cycle border", "Open list dialog")
+      val titleLen = title.length + 4
+      val itemLen  = (0 +: labels.map(_.length)).max + 6
+      val width    = math.max(30, math.max(titleLen, itemLen))
+      val height   = 4 + math.max(1, labels.size)
+
+      val rootW    = math.max(60, m.width)
+      val rootH    = math.max(20, m.height)
+      val (ox, oy) = OverlayPosition.resolve(OverlayPosition.Centered, width, height, rootW, rootH)
+
+      // Each row sits at panel-local (3.x, (3 + i).y). Translate to
+      // absolute; click target is the full inner width of the row so
+      // users don't have to land precisely on the label.
+      labels.indices.foldLeft(HitTest.empty[Int]) { (reg, i) =>
+        val rowX  = ox.value + 1
+        val rowY  = oy.value + 2 + i
+        val rectW = math.max(1, width - 2)
+        reg.add(i, termflow.tui.Rect(rowX, rowY, rectW, 1))
+      }
+
     private def listSelectMouseDispatch(m: Model, currentIdx: Int, ev: MouseEvent): Cmd[Msg] =
       val (col, row) = ev.at
       val rect       = listSelectRect(m, currentIdx)
@@ -1813,7 +1854,7 @@ object Stage1ShowcaseApp:
         TextNode(2.x, 6.y, List("   b  cycle border style".text)),
         TextNode(2.x, 7.y, List("   t  cycle theme".text)),
         TextNode(2.x, 8.y, List("   d / i / l / w  open dialogs".text)),
-        TextNode(2.x, 9.y, List("   a  open actionList dialog".text)),
+        TextNode(2.x, 9.y, List("   a  open actionList (click rows for HitTest demo)".text)),
         TextNode(2.x, 10.y, List("   f / g  open fileDialog / directoryDialog".text)),
         TextNode(2.x, 11.y, List(" 2 Widgets (Tree)".themed(_.success))),
         TextNode(2.x, 12.y, List("   ↑/↓ move,  Space/Enter toggle node".text)),

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -778,7 +778,7 @@ object Stage1ShowcaseApp:
           k match
             // Esc cancels; Tab moves focus between OK and Cancel.
             case Escape => Cmd.GCmd(CloseDialog)
-            case CharKey('\t') | KeyDecoder.InputKey.BackTab =>
+            case Tab | BackTab =>
               Cmd.GCmd(ToggleDialogFocus)
             case _ => Cmd.NoCmd
 
@@ -915,7 +915,7 @@ object Stage1ShowcaseApp:
       // text focus so typing letters into a TextField stays unaffected;
       // digits collide with showcase tab shortcuts and are reserved.
       val pre: Option[Tui[Model, Msg]] = k match
-        case CharKey('\t')                               => Some(m.copy(inputsFocus = m.inputsFocus.next).tui)
+        case Tab                                         => Some(m.copy(inputsFocus = m.inputsFocus.next).tui)
         case BackTab                                     => Some(m.copy(inputsFocus = m.inputsFocus.previous).tui)
         case Escape                                      => Some(Tui(m, Cmd.GCmd(OpenDialog)))
         case CharKey('q') | CharKey('Q') if !textFocused => Some(Tui(m, Cmd.GCmd(OpenDialog)))
@@ -971,7 +971,7 @@ object Stage1ShowcaseApp:
       val _ = ctx
       import KeyDecoder.InputKey.*
       val pre: Option[Tui[Model, Msg]] = k match
-        case CharKey('\t')               => Some(m.copy(dataFocus = m.dataFocus.next).tui)
+        case Tab                         => Some(m.copy(dataFocus = m.dataFocus.next).tui)
         case BackTab                     => Some(m.copy(dataFocus = m.dataFocus.previous).tui)
         case Escape                      => Some(Tui(m, Cmd.GCmd(OpenDialog)))
         case CharKey('q') | CharKey('Q') => Some(Tui(m, Cmd.GCmd(OpenDialog)))

--- a/modules/termflow-sample/src/main/scala/termflow/apps/themes/ThemeDemoApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/themes/ThemeDemoApp.scala
@@ -54,12 +54,12 @@ object ThemeDemoApp:
         case Key(k) =>
           import KeyDecoder.InputKey.*
           k match
-            case CharKey('\t') => Tui(m, Cmd.GCmd(Cycle))
-            case CharKey(' ')  => Tui(m, Cmd.GCmd(Cycle))
-            case CharKey('q')  => Tui(m, Cmd.GCmd(Quit))
-            case CharKey('Q')  => Tui(m, Cmd.GCmd(Quit))
-            case Escape        => Tui(m, Cmd.GCmd(Quit))
-            case _             => m.tui
+            case Tab          => Tui(m, Cmd.GCmd(Cycle))
+            case CharKey(' ') => Tui(m, Cmd.GCmd(Cycle))
+            case CharKey('q') => Tui(m, Cmd.GCmd(Quit))
+            case CharKey('Q') => Tui(m, Cmd.GCmd(Quit))
+            case Escape       => Tui(m, Cmd.GCmd(Quit))
+            case _            => m.tui
 
     override def view(m: Model): RootNode =
       val (name, theme)   = themes(m.themeIndex)

--- a/modules/termflow-sample/src/main/scala/termflow/apps/wizard/WizardApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/wizard/WizardApp.scala
@@ -228,7 +228,14 @@ object WizardApp:
             k match
               case ArrowUp   => step(m, PlanUp)
               case ArrowDown => step(m, PlanDown)
-              case _         => m
+              // Enter / Space commit the current selection (it's already
+              // chosen via arrow keys) and jump focus straight to the
+              // Next button — the user is committing to advance, not
+              // backing out, so we skip the Back button in the focus
+              // cycle.
+              case Enter | CharKey(' ') =>
+                m.copy(focus = m.focus.updated(m.step, m.currentFocus.focus(NextPlanId)))
+              case _ => m
           case Some(id) if id == BackPlanId =>
             k match
               case Enter | CharKey(' ') => step(m, PrevStep)

--- a/modules/termflow-sample/src/main/scala/termflow/apps/wizard/WizardApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/wizard/WizardApp.scala
@@ -200,9 +200,9 @@ object WizardApp:
     if isQuitKey then m // runtime handles Quit at the App layer
     else
       k match
-        case CharKey('\t') => step(m, NextFocus)
-        case BackTab       => step(m, PrevFocus)
-        case _             => stepKeyForStep(m, k)
+        case Tab     => step(m, NextFocus)
+        case BackTab => step(m, PrevFocus)
+        case _       => stepKeyForStep(m, k)
 
   private def stepKeyForStep(m: Model, k: KeyDecoder.InputKey): Model =
     import KeyDecoder.InputKey.*

--- a/modules/termflow-sample/src/test/scala/termflow/apps/catalog/CatalogDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/catalog/CatalogDemoAppSpec.scala
@@ -159,7 +159,7 @@ class CatalogDemoAppSpec extends AnyFunSuite with GoldenSupport:
 
   test("Globals bind Tab / Shift+Tab / Ctrl+T / Ctrl+C / Esc but NOT vertical arrows"):
     val g = CatalogDemoApp.Globals
-    assert(g.lookup(InputKey.Ctrl('I')).contains(Msg.NextFocus))
+    assert(g.lookup(InputKey.Tab).contains(Msg.NextFocus))
     assert(g.lookup(InputKey.BackTab).contains(Msg.PrevFocus))
     assert(g.lookup(InputKey.Ctrl('T')).contains(Msg.ToggleTheme))
     assert(g.lookup(InputKey.Ctrl('C')).contains(Msg.Quit))

--- a/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/forms/FormDemoAppSpec.scala
@@ -124,7 +124,7 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
   test("Tab inside a TextField advances focus and keeps the buffer"):
     val d = driver()
     typeKeys(d, "alice")
-    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('I'))) // Tab
+    d.send(Msg.ConsoleInputKey(InputKey.Tab)) // Tab
     assert(d.model.fm.isFocused(EmailId))
     assert(d.model.name.buffer == "alice")
 
@@ -224,8 +224,8 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
 
   test("Globals bind only truly-global keys — no printable letters"):
     val g = FormDemoApp.Globals
-    assert(g.lookup(InputKey.Ctrl('I')).contains(Msg.NextFocus)) // Tab
-    assert(g.lookup(InputKey.BackTab).contains(Msg.PrevFocus))   // Shift+Tab
+    assert(g.lookup(InputKey.Tab).contains(Msg.NextFocus))     // Tab
+    assert(g.lookup(InputKey.BackTab).contains(Msg.PrevFocus)) // Shift+Tab
     assert(g.lookup(InputKey.Ctrl('C')).contains(Msg.Quit))
     assert(g.lookup(InputKey.Escape).contains(Msg.Quit))
     assert(g.lookup(InputKey.Ctrl('T')).contains(Msg.ToggleTheme))
@@ -294,7 +294,7 @@ class FormDemoAppSpec extends AnyFunSuite with GoldenSupport:
   test("after typing into Name + Tab to Email"):
     val d = driver()
     typeKeys(d, "alice")
-    d.send(Msg.ConsoleInputKey(InputKey.Ctrl('I'))) // Tab
+    d.send(Msg.ConsoleInputKey(InputKey.Tab)) // Tab
     assertGoldenFrame(d.frame, "name-typed-email-focused")
 
   test("after submitting a complete form"):

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -791,6 +791,25 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(d.model.editorState.lines.size == rowsBefore + 1)
   }
 
+  test("Mouse click on an actionList row dispatches via HitTest registry") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('a')))
+    val themeBefore = d.model.themeName
+    // The actionList is centred at width=30 over a 100x28 driver; first
+    // row sits roughly at (rootH - dialogH)/2 + 3. We click around the
+    // middle of the dialog to land somewhere on the first action row.
+    val mods    = termflow.tui.KeyDecoder.Modifiers(false, false, false)
+    val frameH  = 28
+    val dialogH = 4 + 3
+    val rowY    = (frameH - dialogH) / 2 + 1 + 2 // +2 = title + blank
+    val rowX    = (100 - 30) / 2 + 1 + 5         // +5 = somewhere inside the row
+    val ev      = termflow.tui.MouseEvent.Press(termflow.tui.MouseButton.Left, col = rowX, row = rowY, mods)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Mouse(ev)))
+    // First row = "Cycle theme" — click should fire the action and close the dialog.
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.None)
+    assert(d.model.themeName != themeBefore, "first-row click should fire CycleTheme")
+  }
+
   test("Layout tab Mouse press on the divider arms the SplitPane drag") {
     val d = driver
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('5')))

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -699,8 +699,8 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     val d = driver
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('6')))
     // Tab past Name and Email so focus is on the Next button (no TextField).
-    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('\t')))
-    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('\t')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Tab))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Tab))
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('q')))
     assert(d.model.dialog.isInstanceOf[Stage1ShowcaseApp.Dialog.ConfirmQuit])
   }

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -810,6 +810,31 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(d.model.themeName != themeBefore, "first-row click should fire CycleTheme")
   }
 
+  test("Layout tab '=' resets the split ratio to 0.5") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('5')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('[')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('[')))
+    assert(d.model.layoutSplitRatio < 0.55)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('=')))
+    assert(d.model.layoutSplitRatio == 0.5)
+  }
+
+  test("Widgets tab Mouse press on a Tree chevron toggles the node") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('2')))
+    val initiallyExpanded = d.model.treeExpanded.contains("termflow")
+    assert(initiallyExpanded, "tree starts with 'termflow' expanded")
+    // Click the chevron of the first visible row (the `termflow` root).
+    // Origin of the tree is r.col + 1, r.row + 4. The widgets-tab rect
+    // starts at col=1, row=topRowY=3, so the tree origin is (2, 7).
+    // Click col 3 (inside `[-] `).
+    val mods = termflow.tui.KeyDecoder.Modifiers(false, false, false)
+    val ev   = termflow.tui.MouseEvent.Press(termflow.tui.MouseButton.Left, col = 3, row = 7, mods)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Mouse(ev)))
+    assert(!d.model.treeExpanded.contains("termflow"), "chevron click should collapse the node")
+  }
+
   test("Layout tab Mouse press on the divider arms the SplitPane drag") {
     val d = driver
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('5')))

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -810,6 +810,15 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(d.model.themeName != themeBefore, "first-row click should fire CycleTheme")
   }
 
+  test("Esc on the Editor tab returns to the Showcase tab") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('9')))
+    assert(d.model.activeTab == 8)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Escape))
+    assert(d.model.activeTab == 0, "Esc should switch back to the Showcase tab, not open a dialog")
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.None)
+  }
+
   test("Layout tab '=' resets the split ratio to 0.5") {
     val d = driver
     d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('5')))

--- a/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/showcase/Stage1ShowcaseAppSpec.scala
@@ -746,6 +746,65 @@ class Stage1ShowcaseAppSpec extends AnyFunSuite:
     assert(rendered.contains("'z'"), "LogView should render the just-pressed key event")
   }
 
+  // ---- Stage 3 final components --------------------------------------------
+
+  test("'a' opens the actionList dialog at index 0") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('a')))
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.ActionList(selectedIndex = 0))
+  }
+
+  test("ArrowDown inside actionList moves the focused row") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('a')))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.ArrowDown))
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.ActionList(selectedIndex = 1))
+  }
+
+  test("Enter inside actionList runs the action and closes the dialog") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('a')))
+    val themeBefore = d.model.themeName
+    // Default focus is on item 0 = "Cycle theme".
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Enter))
+    assert(d.model.dialog == Stage1ShowcaseApp.Dialog.None)
+    assert(d.model.themeName != themeBefore, "actionList Enter should fire CycleTheme")
+  }
+
+  test("'9' switches to the Editor tab and types feed the MultiLineInput") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('9')))
+    assert(d.model.activeTab == 8)
+    val before = d.model.editorState.text
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.End))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('!')))
+    val after = d.model.editorState.text
+    assert(after.endsWith("!"), s"editor should accept text input — before=$before  after=$after")
+  }
+
+  test("Enter on the Editor tab inserts a newline") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('9')))
+    val rowsBefore = d.model.editorState.lines.size
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.End))
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Enter))
+    assert(d.model.editorState.lines.size == rowsBefore + 1)
+  }
+
+  test("Layout tab Mouse press on the divider arms the SplitPane drag") {
+    val d = driver
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.CharKey('5')))
+    // The divider is somewhere mid-panel; press a column close to the
+    // initial split ratio (0.55 of an 80-cell-wide region).
+    val mods = termflow.tui.KeyDecoder.Modifiers(false, false, false)
+    val ev   = termflow.tui.MouseEvent.Press(termflow.tui.MouseButton.Left, col = 45, row = 12, mods)
+    d.send(Stage1ShowcaseApp.Msg.Key(InputKey.Mouse(ev)))
+    // After the press the drag should be armed (regardless of whether
+    // the click landed exactly on the divider — just verify the
+    // Layout-tab dispatch routes through LayoutMouse without error).
+    assert(d.model.activeTab == 4) // 5 Layout = idx 4
+  }
+
   // Silence unused-import lint warning for AnsiRenderer (it's referenced
   // implicitly through TuiTestDriver, but the file would warn otherwise).
   private val _ = AnsiRenderer.getClass

--- a/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/widgets/WidgetsDemoAppSnapshotSpec.scala
@@ -94,7 +94,7 @@ class WidgetsDemoAppSnapshotSpec extends AnyFunSuite with GoldenSupport:
 
   test("ConsoleInputKey dispatches via the Keymap — Tab cycles focus"):
     val d = driver()
-    d.send(Msg.ConsoleInputKey(KeyDecoder.InputKey.Ctrl('I')))
+    d.send(Msg.ConsoleInputKey(KeyDecoder.InputKey.Tab))
     assert(d.model.fm.isFocused(CancelFocus))
 
   test("ConsoleInputKey dispatches via the Keymap — q quits"):
@@ -107,7 +107,7 @@ class WidgetsDemoAppSnapshotSpec extends AnyFunSuite with GoldenSupport:
     // dropped without breaking this test.
     val k = WidgetsDemoApp.Keys
     import KeyDecoder.InputKey.*
-    assert(k.lookup(Ctrl('I')).contains(Msg.NextFocus))
+    assert(k.lookup(Tab).contains(Msg.NextFocus))
     assert(k.lookup(Enter).contains(Msg.Activate))
     assert(k.lookup(CharKey(' ')).contains(Msg.Activate))
     assert(k.lookup(CharKey('t')).contains(Msg.ToggleTheme))

--- a/modules/termflow-sample/src/test/scala/termflow/apps/wizard/WizardAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/wizard/WizardAppSpec.scala
@@ -91,6 +91,21 @@ class WizardAppSpec extends AnyFunSuite:
     assert(d.model.currentFocus.current.contains(WizardApp.NameId))
   }
 
+  test("Enter on the Plan radio commits and advances focus to Next") {
+    val d = driver
+    typeText(d, "Alice")
+    d.send(WizardApp.Msg.NextFocus)
+    typeText(d, "alice@example.com")
+    d.send(WizardApp.Msg.NextFocus)           // focus the Next button
+    d.send(WizardApp.Msg.Key(InputKey.Enter)) // advance to Plan step
+    assert(d.model.step == WizardApp.Step.Plan)
+    assert(d.model.currentFocus.current.contains(WizardApp.PlanRadioId))
+    d.send(WizardApp.Msg.Key(InputKey.ArrowDown)) // pick Pro
+    d.send(WizardApp.Msg.Key(InputKey.Enter))     // commit + advance focus
+    assert(d.model.planIndex == 1, "Pro should still be selected")
+    assert(d.model.currentFocus.current.contains(WizardApp.NextPlanId), "focus should have moved to Next")
+  }
+
   test("Enter on the Next button submits Account → Plan when valid") {
     val d = driver
     typeText(d, "Alice")

--- a/modules/termflow-sample/src/test/scala/termflow/apps/wizard/WizardAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/wizard/WizardAppSpec.scala
@@ -82,12 +82,12 @@ class WizardAppSpec extends AnyFunSuite:
   test("Tab cycles focus inside the Account step") {
     val d = driver
     assert(d.model.currentFocus.current.contains(WizardApp.NameId))
-    d.send(WizardApp.Msg.Key(InputKey.CharKey('\t')))
+    d.send(WizardApp.Msg.Key(InputKey.Tab))
     assert(d.model.currentFocus.current.contains(WizardApp.EmailId))
-    d.send(WizardApp.Msg.Key(InputKey.CharKey('\t')))
+    d.send(WizardApp.Msg.Key(InputKey.Tab))
     assert(d.model.currentFocus.current.contains(WizardApp.NextAccountId))
     // Wraps around.
-    d.send(WizardApp.Msg.Key(InputKey.CharKey('\t')))
+    d.send(WizardApp.Msg.Key(InputKey.Tab))
     assert(d.model.currentFocus.current.contains(WizardApp.NameId))
   }
 

--- a/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -383,13 +383,20 @@ object AnsiRenderer:
       val text = fixedPrefix + visibleSuffix
       if text.length >= width then text.take(width)
       else text + (" " * (width - text.length))
-    val unclampedCursorIndex =
+
+    // Cursor column = sum of WCWidth across visible characters up to the
+    // cursor's char index. This makes wide-char input (CJK, emoji) and
+    // combining-mark sequences land the hardware cursor at the right
+    // visual column, not the character count.
+    val cursorCharIndex =
       if clampedCursor <= prefixLength then clampedCursor
       else fixedPrefix.length + (suffixCursor - suffixStart)
+    val unclampedCursorColumn =
+      WCWidth.stringWidth(visibleText.take(math.max(0, cursorCharIndex)))
     val cursorLimit =
       if inp.x.value + width <= rootWidth then width
       else width - 1
-    val cursorIndex = math.max(0, math.min(cursorLimit, unclampedCursorIndex))
+    val cursorIndex = math.max(0, math.min(cursorLimit, unclampedCursorColumn))
     VisibleInput(visibleText, cursorIndex, width)
 
   private def renderInput(

--- a/modules/termflow-screen/src/main/scala/termflow/tui/HitTest.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/HitTest.scala
@@ -1,0 +1,102 @@
+package termflow.tui
+
+/**
+ * A rectangular region on the terminal grid (1-based, inclusive).
+ *
+ * Used by the [[HitTest]] cache to map a `(col, row)` mouse coordinate
+ * back to the layout zone it landed in.
+ *
+ * @param x      Top-left column (1-based).
+ * @param y      Top-left row (1-based).
+ * @param width  Width in cells. `width <= 0` makes the rect empty —
+ *               `contains` will always return false.
+ * @param height Height in cells. Same `<= 0` rule.
+ */
+final case class Rect(x: Int, y: Int, width: Int, height: Int):
+
+  /** Right edge column, inclusive. Equal to `x + width - 1`. */
+  def right: Int = x + math.max(0, width) - 1
+
+  /** Bottom edge row, inclusive. Equal to `y + height - 1`. */
+  def bottom: Int = y + math.max(0, height) - 1
+
+  /** True when `(col, row)` lies inside this rectangle, edges inclusive. */
+  def contains(col: Int, row: Int): Boolean =
+    width > 0 && height > 0 &&
+      col >= x && col <= right &&
+      row >= y && row <= bottom
+
+  /** Top-left corner as a [[Coord]]. */
+  def at: Coord = Coord(XCoord(x), YCoord(y))
+
+object Rect:
+
+  /** An empty rectangle (`contains` always false). */
+  val empty: Rect = Rect(0, 0, 0, 0)
+
+  /** Build a rectangle from a [[Coord]] origin and `(width, height)`. */
+  def at(origin: Coord, width: Int, height: Int): Rect =
+    Rect(origin.x.value, origin.y.value, width, height)
+
+/**
+ * A registry of named rectangles produced by the layout pass, used to
+ * map mouse coordinates to the widget / zone the click landed in.
+ *
+ * Zones are registered in document order. [[hit]] searches in **reverse
+ * insertion order** — later (z-top) zones win over earlier ones. Apps
+ * pair this with `InputKey.Mouse(...)` events:
+ *
+ * {{{
+ * msg match
+ *   case Msg.Mouse(MouseEvent.Press(_, col, row, _)) =>
+ *     model.hitTest.hit(col, row) match
+ *       case Some("submit-button") => submit(model)
+ *       case Some(s"list-row-$idx") => selectRow(model, idx.toInt)
+ *       case _ => model.tui
+ * }}}
+ *
+ * Apps drive how zones are populated: either explicitly via
+ * [[HitTest.add]] when constructing the view, or implicitly via
+ * [[Layout.Zone]] which registers the resolved rect during layout.
+ *
+ * Type parameter `Id` is the zone identifier — strings are the most
+ * common, but apps preferring an enum or a sealed ADT for compile-time
+ * exhaustiveness can use that instead.
+ */
+final case class HitTest[Id](zones: Vector[(Id, Rect)]):
+
+  /** Append a zone to the registry. Later zones win in [[hit]]. */
+  def add(id: Id, rect: Rect): HitTest[Id] =
+    HitTest(zones :+ (id, rect))
+
+  /** Append a zone using a [[Coord]] origin and `(width, height)`. */
+  def add(id: Id, origin: Coord, width: Int, height: Int): HitTest[Id] =
+    add(id, Rect.at(origin, width, height))
+
+  /** Append all zones from `other`, after this registry's existing entries. */
+  def ++(other: HitTest[Id]): HitTest[Id] =
+    HitTest(zones ++ other.zones)
+
+  /**
+   * Return the id of the topmost zone containing `(col, row)`, or
+   * `None` if no registered zone covers the cell.
+   */
+  def hit(col: Int, row: Int): Option[Id] =
+    zones.reverseIterator.collectFirst {
+      case (id, rect) if rect.contains(col, row) => id
+    }
+
+  /** Number of registered zones. */
+  def size: Int = zones.size
+
+  /** True when no zones are registered. */
+  def isEmpty: Boolean = zones.isEmpty
+
+object HitTest:
+
+  /** An empty hit-test registry. */
+  def empty[Id]: HitTest[Id] = HitTest[Id](Vector.empty)
+
+  /** Build a registry from a sequence of `(id, rect)` pairs. */
+  def of[Id](zones: (Id, Rect)*): HitTest[Id] =
+    HitTest(zones.toVector)

--- a/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
@@ -127,6 +127,28 @@ enum Layout:
    */
   case Fill(content: Layout)
 
+  /**
+   * Tag a layout subtree with a zone identifier so that the layout pass
+   * records its resolved rectangle in a [[HitTest]] cache.
+   *
+   * Pure presentation: the wrapped `content` is resolved exactly as it
+   * would be without the wrapper — the zone wrapping is invisible to the
+   * renderer. The id is only consulted by [[Layout.resolveTracked]],
+   * which threads a hit-test accumulator through the resolve pass.
+   *
+   * Apps that don't use mouse hit-testing can ignore this case
+   * altogether; it costs nothing in the regular `resolve` /
+   * `resolveTo` paths.
+   *
+   * @param id      Identifier to register under. The id type is
+   *                deliberately `Any` here so a single layout tree can
+   *                mix zone id types — the [[Layout.resolveTracked]]
+   *                call is what fixes the registry's id type.
+   * @param content Layout subtree whose resolved rectangle should be
+   *                registered.
+   */
+  case Zone(id: Any, content: Layout)
+
   /** Natural `(width, height)` of this layout, in cells. */
   def measure: (Int, Int) = Layout.measure(this)
 
@@ -184,15 +206,29 @@ object Layout:
   extension (v: VNode) def asLayout: Layout = Elem(v)
 
   /**
+   * Tag `content` with a hit-test `id`. Sugar for [[Zone]] that lets
+   * the wrapper read like a method call:
+   *
+   * {{{
+   * Layout.zone("submit", Layout.Elem(buttonNode))
+   * }}}
+   */
+  def zone(id: Any, content: Layout): Layout = Zone(id, content)
+
+  /** Tag a bare [[VNode]] with a hit-test id, lifting it into [[Elem]]. */
+  def zone(id: Any, vnode: VNode): Layout = Zone(id, Elem(vnode))
+
+  /**
    * Natural size of a layout, ignoring any container it will be placed in.
    *
    * Public for tests and for callers who want to size a surrounding box
    * from measured layout dimensions.
    */
   def measure(layout: Layout): (Int, Int) = layout match
-    case Elem(v)      => measureVNode(v)
-    case Spacer(w, h) => (math.max(0, w), math.max(0, h))
-    case Fill(inner)  => measure(inner)
+    case Elem(v)        => measureVNode(v)
+    case Spacer(w, h)   => (math.max(0, w), math.max(0, h))
+    case Fill(inner)    => measure(inner)
+    case Zone(_, inner) => measure(inner)
 
     case Row(gap, cs) =>
       if cs.isEmpty then (0, 0)
@@ -254,6 +290,11 @@ object Layout:
    */
   def resolveTo(layout: Layout, at: Coord, availableWidth: Int, availableHeight: Int): List[VNode] =
     layout match
+      case Zone(_, inner) =>
+        // Hit-test zones are transparent to the regular resolver — they
+        // only matter when callers use [[resolveTracked]].
+        resolveTo(inner, at, availableWidth, availableHeight)
+
       case Elem(v) =>
         val dx = at.x.value - v.x.value
         val dy = at.y.value - v.y.value
@@ -385,3 +426,117 @@ object Layout:
 
     case in: InputNode =>
       in.copy(x = in.x + dx, y = in.y + dy)
+
+  /**
+   * Resolve a layout into both `(VNode list, hit-test registry)`. The
+   * registry is populated from any [[Layout.Zone]] wrappers encountered
+   * during resolution, so apps wiring mouse interaction can map a click
+   * coordinate back to a logical zone without recomputing rectangles.
+   *
+   * Zones outside the resolver's wrapping always pick up a real
+   * rectangle regardless of `availableWidth` / `availableHeight`: the
+   * tracked rect uses each subtree's *resolved* size, so [[Layout.Fill]]
+   * children record their post-fill rectangle, not their natural size.
+   *
+   * Type parameter `Id` declares the registry's id type at the call
+   * site. Because of JVM erasure the cast is unchecked at runtime —
+   * apps are responsible for using uniform id types within a single
+   * tracked layout tree (sealed enums / strings / ints; not mixed).
+   * Mixing id types and recovering the right ones from the registry
+   * requires the caller to pattern-match on each entry's runtime
+   * value.
+   *
+   * @param layout          Layout to resolve.
+   * @param at              Top-left of the layout's allocated rectangle.
+   * @param availableWidth  Width budget along the major axis. `-1` =
+   *                        unbounded (same convention as [[resolveTo]]).
+   * @param availableHeight Height budget along the major axis. `-1` =
+   *                        unbounded.
+   */
+  def resolveTracked[Id](
+    layout: Layout,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    availableWidth: Int = -1,
+    availableHeight: Int = -1
+  ): (List[VNode], HitTest[Id]) =
+    val builder = Vector.newBuilder[(Id, Rect)]
+    val nodes   = resolveTrackedImpl(layout, at, availableWidth, availableHeight, builder)
+    (nodes, HitTest(builder.result()))
+
+  private def resolveTrackedImpl[Id](
+    layout: Layout,
+    at: Coord,
+    availableWidth: Int,
+    availableHeight: Int,
+    builder: scala.collection.mutable.Builder[(Id, Rect), Vector[(Id, Rect)]]
+  ): List[VNode] = layout match
+    case Zone(id, inner) =>
+      val (w, h) = trackedSize(inner, availableWidth, availableHeight)
+      // Cast is unchecked at runtime due to erasure. Callers should use a
+      // uniform id type across a single tracked tree.
+      builder += id.asInstanceOf[Id] -> Rect(at.x.value, at.y.value, w, h)
+      resolveTrackedImpl(inner, at, availableWidth, availableHeight, builder)
+
+    case Elem(v) =>
+      val dx = at.x.value - v.x.value
+      val dy = at.y.value - v.y.value
+      if dx == 0 && dy == 0 then List(v)
+      else List(translate(v, dx, dy))
+
+    case Spacer(_, _) => Nil
+
+    case Fill(inner) =>
+      inner match
+        case Elem(v) if availableWidth >= 0 || availableHeight >= 0 =>
+          val resized = resizeForFill(v, availableWidth, availableHeight)
+          val dx      = at.x.value - resized.x.value
+          val dy      = at.y.value - resized.y.value
+          if dx == 0 && dy == 0 then List(resized)
+          else List(translate(resized, dx, dy))
+        case _ =>
+          resolveTrackedImpl(inner, at, availableWidth, availableHeight, builder)
+
+    case Row(gap, cs) =>
+      val g         = math.max(0, gap)
+      val n         = cs.size
+      val widths    = distributeMajor(cs, availableWidth, g, axisIsRow = true)
+      val rowHeight = if availableHeight >= 0 then availableHeight else cs.map(measure(_)._2).maxOption.getOrElse(0)
+      var xCursor   = at.x.value
+      val out       = List.newBuilder[VNode]
+      var i         = 0
+      while i < n do
+        val child = cs(i)
+        val cw    = widths(i)
+        out ++= resolveTrackedImpl(child, Coord(XCoord(xCursor), at.y), cw, rowHeight, builder)
+        xCursor += cw
+        if i < n - 1 then xCursor += g
+        i += 1
+      out.result()
+
+    case Column(gap, cs) =>
+      val g        = math.max(0, gap)
+      val n        = cs.size
+      val heights  = distributeMajor(cs, availableHeight, g, axisIsRow = false)
+      val colWidth = if availableWidth >= 0 then availableWidth else cs.map(measure(_)._1).maxOption.getOrElse(0)
+      var yCursor  = at.y.value
+      val out      = List.newBuilder[VNode]
+      var i        = 0
+      while i < n do
+        val child = cs(i)
+        val ch    = heights(i)
+        out ++= resolveTrackedImpl(child, Coord(at.x, YCoord(yCursor)), colWidth, ch, builder)
+        yCursor += ch
+        if i < n - 1 then yCursor += g
+        i += 1
+      out.result()
+
+  /**
+   * Tracked rectangle size for a layout subtree. Mirrors the budget
+   * semantics of [[resolveTo]] — passed-down budgets win over the
+   * subtree's natural size when present.
+   */
+  private def trackedSize(layout: Layout, availableWidth: Int, availableHeight: Int): (Int, Int) =
+    val (natW, natH) = measure(layout)
+    val w            = if availableWidth >= 0 then availableWidth else natW
+    val h            = if availableHeight >= 0 then availableHeight else natH
+    (w, h)

--- a/modules/termflow-screen/src/test/scala/termflow/tui/HitTestSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/HitTestSpec.scala
@@ -1,0 +1,130 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.Layout.asLayout
+import termflow.tui.ScreenPrelude.*
+
+class HitTestSpec extends AnyFunSuite:
+
+  // --- Rect ---------------------------------------------------------------
+
+  test("Rect.contains is inclusive on both edges"):
+    val r = Rect(x = 5, y = 3, width = 4, height = 2)
+    assert(r.contains(5, 3))
+    assert(r.contains(8, 4)) // 5 + 4 - 1 = 8 ; 3 + 2 - 1 = 4
+    assert(!r.contains(4, 3))
+    assert(!r.contains(9, 4))
+    assert(!r.contains(5, 5))
+
+  test("Rect.contains is false for empty rectangles"):
+    assert(!Rect(x = 1, y = 1, width = 0, height = 5).contains(1, 1))
+    assert(!Rect(x = 1, y = 1, width = 5, height = 0).contains(1, 1))
+    assert(!Rect.empty.contains(1, 1))
+
+  test("Rect.at builds from a Coord origin"):
+    val r = Rect.at(Coord(3.x, 4.y), width = 5, height = 6)
+    assert(r.x == 3 && r.y == 4 && r.width == 5 && r.height == 6)
+
+  // --- HitTest ------------------------------------------------------------
+
+  test("hit returns the topmost zone under the click"):
+    val reg = HitTest
+      .empty[String]
+      .add("background", Rect(1, 1, 10, 10))
+      .add("button", Rect(3, 3, 4, 2))
+    assert(reg.hit(4, 4).contains("button"), "button overlays the background")
+    assert(reg.hit(1, 1).contains("background"), "outside the button — falls through")
+
+  test("hit returns None when no zone covers the cell"):
+    val reg = HitTest.empty[String].add("a", Rect(1, 1, 5, 5))
+    assert(reg.hit(10, 10).isEmpty)
+
+  test("HitTest.++ concatenates registries in order"):
+    val a      = HitTest.of("a" -> Rect(1, 1, 5, 5))
+    val b      = HitTest.of("b" -> Rect(2, 2, 3, 3))
+    val merged = a ++ b
+    assert(merged.size == 2)
+    // b is later — should win on overlap.
+    assert(merged.hit(3, 3).contains("b"))
+
+  // --- Layout.Zone --------------------------------------------------------
+
+  private def tn(text: String): TextNode =
+    TextNode(1.x, 1.y, List(Text(text, Style())))
+
+  test("resolveTracked records a Zone's resolved rect"):
+    val layout       = Layout.zone("title", tn("Hello"))
+    val (nodes, reg) = Layout.resolveTracked[String](layout, at = Coord(2.x, 3.y))
+    assert(nodes.size == 1, "the zone wrapper is transparent to node output")
+    assert(reg.size == 1)
+    val (id, rect) = reg.zones.head
+    assert(id == "title")
+    // Natural size of "Hello" is (5, 1); origin is (2, 3).
+    assert(rect.x == 2 && rect.y == 3)
+    assert(rect.width == 5 && rect.height == 1)
+
+  test("resolveTracked threads ids through Row/Column children"):
+    val layout = Layout.Column(
+      gap = 0,
+      children = List(
+        Layout.zone("row-1", tn("A")),
+        Layout.zone("row-2", tn("BC")),
+        Layout.zone("row-3", tn("DEF"))
+      )
+    )
+    val (_, reg) = Layout.resolveTracked[String](layout)
+    assert(reg.size == 3)
+    val rows = reg.zones.toList
+    assert(rows.map(_._1) == List("row-1", "row-2", "row-3"))
+    // Successive y values, x stays at 1.
+    assert(rows.head._2.y == 1)
+    assert(rows(1)._2.y == 2)
+    assert(rows(2)._2.y == 3)
+
+  test("resolveTracked records the post-Fill rectangle when there's a budget"):
+    val box = BoxNode(1.x, 1.y, 5, 1, children = Nil, Style(border = true))
+    val layout = Layout.Row(
+      gap = 0,
+      children = List(
+        Layout.Fill(Layout.zone("fill", Layout.Elem(box))),
+        Layout.Elem(tn("end"))
+      )
+    )
+    val (_, reg) = Layout.resolveTracked[String](layout, at = Coord(1.x, 1.y), availableWidth = 20, availableHeight = 1)
+    assert(reg.size == 1)
+    val (id, rect) = reg.zones.head
+    assert(id == "fill")
+    // tn("end") natural width is 3, so fill consumes 17 cells.
+    assert(rect.width == 17, s"fill rect should be 17 cells wide, got ${rect.width}")
+
+  test("resolveTracked records all zones — caller picks an id type"):
+    // Erasure makes runtime type filtering impossible, so apps must use a
+    // uniform id type per tracked tree. Mixed-type trees still resolve;
+    // the registry just contains whatever the call sites supplied.
+    val layout = Layout.Column(
+      gap = 0,
+      children = List(
+        Layout.zone("a", tn("first")),
+        Layout.zone("b", tn("second"))
+      )
+    )
+    val (_, reg) = Layout.resolveTracked[String](layout)
+    assert(reg.size == 2)
+    assert(reg.zones.map(_._1).toList == List("a", "b"))
+
+  test("resolveTracked id type can be a sealed enum"):
+    enum ZoneId:
+      case Header, Body, Footer
+    val layout = Layout.Column(
+      gap = 0,
+      children = List(
+        Layout.zone(ZoneId.Header, tn("h")),
+        Layout.zone(ZoneId.Body, tn("b")),
+        Layout.zone(ZoneId.Footer, tn("f"))
+      )
+    )
+    val (_, reg) = Layout.resolveTracked[ZoneId](layout)
+    assert(reg.size == 3)
+    assert(reg.hit(1, 1).contains(ZoneId.Header))
+    assert(reg.hit(1, 2).contains(ZoneId.Body))
+    assert(reg.hit(1, 3).contains(ZoneId.Footer))

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/Grapheme.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/Grapheme.scala
@@ -1,0 +1,76 @@
+package termflow.tui
+
+import java.text.BreakIterator
+import java.util.Locale
+
+/**
+ * Grapheme-cluster boundary helpers, used by editing widgets so that
+ * cursor navigation, backspace, and delete operate on user-perceived
+ * characters rather than UTF-16 code units.
+ *
+ * Backed by `java.text.BreakIterator.getCharacterInstance`, which the
+ * JDK implements per Unicode UAX #29 (extended grapheme clusters). That
+ * covers the cases TUI input cares about — combining marks, surrogate
+ * pairs, regional-indicator flag sequences (🇺🇸), and ZWJ-joined emoji
+ * (👨‍👩‍👧).
+ *
+ * The API is index-based so it composes with the existing `Vector[Char]`
+ * buffer in `Prompt.State`: indices are UTF-16 code-unit offsets into
+ * the equivalent `String`, which is the same model `Vector[Char]` uses
+ * (one slot per code unit, surrogates split across two slots).
+ */
+object Grapheme:
+
+  /**
+   * Index of the grapheme boundary immediately before `index`, or `0`
+   * if `index` is already at the start.
+   *
+   * @param s     The current text.
+   * @param index UTF-16 code-unit position to step back from. Clamped
+   *              to `[0, s.length]`.
+   */
+  def previousBoundary(s: String, index: Int): Int =
+    if s.isEmpty || index <= 0 then 0
+    else
+      val idx  = math.min(index, s.length)
+      val it   = iterator(s)
+      val prev = it.preceding(idx)
+      if prev == BreakIterator.DONE then 0 else prev
+
+  /**
+   * Index of the grapheme boundary immediately after `index`, or
+   * `s.length` if `index` is already at the end.
+   *
+   * @param s     The current text.
+   * @param index UTF-16 code-unit position to step forward from.
+   *              Clamped to `[0, s.length]`.
+   */
+  def nextBoundary(s: String, index: Int): Int =
+    if s.isEmpty || index >= s.length then s.length
+    else
+      val idx = math.max(index, 0)
+      val it  = iterator(s)
+      // BreakIterator.following(idx) returns the boundary strictly after idx.
+      val next = it.following(idx)
+      if next == BreakIterator.DONE then s.length else next
+
+  /**
+   * Total number of graphemes in `s`. Convenience for callers that
+   * want grapheme counts (e.g. truncate-to-N-graphemes display).
+   */
+  def count(s: String): Int =
+    if s.isEmpty then 0
+    else
+      val it = iterator(s)
+      var n  = 0
+      it.first()
+      var nxt = it.next()
+      while nxt != BreakIterator.DONE do
+        n += 1
+        nxt = it.next()
+      n
+
+  private def iterator(s: String): BreakIterator =
+    val it = BreakIterator.getCharacterInstance(Locale.ROOT)
+    it.setText(s)
+    it

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/KeyDecoder.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/KeyDecoder.scala
@@ -71,6 +71,13 @@ object KeyDecoder:
 
     /** Shift+Tab — produced by the `\u001b[Z` escape sequence on most terminals. */
     case BackTab
+
+    /**
+     * Tab — ASCII 9 (HT). On most terminals Ctrl+I produces the same
+     * byte; we surface that as `Tab` rather than `Ctrl('I')` so focus
+     * dispatchers don't have to know the encoding detail.
+     */
+    case Tab
     case F1
     case F2
     case F3
@@ -137,6 +144,7 @@ object KeyDecoder:
       // CR-to-LF translation is disabled) and LF (10) decode as Enter.
       // Ctrl+M produces byte 13 too — at this layer we cannot distinguish
       // it from Enter, so we standardise on the higher-level intent.
+      case 9       => Tab
       case 10 | 13 => Enter
       case 127     => Backspace
       case code if code >= 1 && code <= 26 =>

--- a/modules/termflow-terminal/src/test/scala/termflow/tui/GraphemeSpec.scala
+++ b/modules/termflow-terminal/src/test/scala/termflow/tui/GraphemeSpec.scala
@@ -1,0 +1,66 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class GraphemeSpec extends AnyFunSuite:
+
+  // --- previousBoundary -----------------------------------------------------
+
+  test("previousBoundary on plain ASCII steps back one char"):
+    val s = "hello"
+    assert(Grapheme.previousBoundary(s, 5) == 4)
+    assert(Grapheme.previousBoundary(s, 1) == 0)
+    assert(Grapheme.previousBoundary(s, 0) == 0)
+
+  test("previousBoundary skips a combining mark with its base"):
+    // "é" = e + COMBINING ACUTE ACCENT — one grapheme, two chars.
+    val s = "éf"
+    assert(s.length == 3)
+    // Cursor at end; previous boundary should jump back over BOTH e and the
+    // combining mark to land at 0 (or 1 depending on interpretation —
+    // BreakIterator returns 1 for "before f").
+    // From end-of-string the previous boundary is between the combining
+    // mark and 'f' (idx 2). Two boundaries exist: 0, 2, and 3.
+    assert(Grapheme.previousBoundary(s, 3) == 2)
+    // From between the e+mark cluster and 'f' (idx 2), the previous
+    // boundary is 0 — stepping over the combining mark + base together.
+    assert(Grapheme.previousBoundary(s, 2) == 0, "step back over the cluster as one unit")
+
+  test("previousBoundary handles a surrogate pair as one unit"):
+    // U+1F600 GRINNING FACE — surrogate pair, one grapheme.
+    val emoji = "a😀b"
+    assert(emoji.length == 4)
+    // From after b, previous boundary skips back to after the emoji.
+    assert(Grapheme.previousBoundary(emoji, 4) == 3)
+    // From after the emoji (idx 3), step back jumps the surrogate pair to idx 1.
+    assert(Grapheme.previousBoundary(emoji, 3) == 1)
+
+  test("previousBoundary clamps index to s.length"):
+    val s = "abc"
+    assert(Grapheme.previousBoundary(s, 999) == 2)
+
+  // --- nextBoundary ---------------------------------------------------------
+
+  test("nextBoundary on plain ASCII steps forward one char"):
+    val s = "hello"
+    assert(Grapheme.nextBoundary(s, 0) == 1)
+    assert(Grapheme.nextBoundary(s, 4) == 5)
+    assert(Grapheme.nextBoundary(s, 5) == 5)
+
+  test("nextBoundary skips a surrogate pair"):
+    val emoji = "a😀b"
+    assert(Grapheme.nextBoundary(emoji, 1) == 3, "after a, jump to after the emoji")
+
+  test("nextBoundary skips a combining mark"):
+    val s = "éf"
+    // After 'e' (idx 1), the combining mark at idx 1..2 attaches to e —
+    // nextBoundary from idx 0 should land at idx 2.
+    assert(Grapheme.nextBoundary(s, 0) == 2)
+
+  // --- count ---------------------------------------------------------------
+
+  test("count returns the grapheme count"):
+    assert(Grapheme.count("") == 0)
+    assert(Grapheme.count("hello") == 5)
+    assert(Grapheme.count("éf") == 2, "é + f = 2 graphemes")
+    assert(Grapheme.count("a😀b") == 3, "a + 😀 + b = 3 graphemes")

--- a/modules/termflow-terminal/src/test/scala/termflow/tui/KeyDecoderSpec.scala
+++ b/modules/termflow-terminal/src/test/scala/termflow/tui/KeyDecoderSpec.scala
@@ -32,6 +32,12 @@ class KeyDecoderSpec extends AnyFunSuite:
     assert(KeyDecoder.decode(4) == InputKey.Ctrl('D'))
     assert(KeyDecoder.decode(26) == InputKey.Ctrl('Z'))
 
+  test("decode Tab as InputKey.Tab — not Ctrl('I')"):
+    // ASCII 9 (HT) is the byte produced by both Tab and Ctrl+I; we
+    // surface it as Tab so focus dispatchers don't have to know the
+    // encoding detail.
+    assert(KeyDecoder.decode(9) == InputKey.Tab)
+
   test("decode unknown codes"):
     assert(KeyDecoder.decode(0) == InputKey.Unknown("0"))
     assert(KeyDecoder.decode(200) == InputKey.Unknown("200"))

--- a/modules/termflow-testkit/src/main/scala/termflow/testkit/KeySim.scala
+++ b/modules/termflow-testkit/src/main/scala/termflow/testkit/KeySim.scala
@@ -45,7 +45,7 @@ object KeySim:
   val ArrowLeft: InputKey  = InputKey.ArrowLeft
   val ArrowRight: InputKey = InputKey.ArrowRight
   val BackTab: InputKey    = InputKey.BackTab
-  val Tab: InputKey        = InputKey.CharKey('\t')
+  val Tab: InputKey        = InputKey.Tab
 
   // ---- Character + control ------------------------------------------------
 
@@ -151,6 +151,11 @@ object KeySim:
           if i + 1 < s.length && s.charAt(i + 1) == '\n' then i += 1
         case '\n' =>
           builder += InputKey.Enter
+        case '\t' =>
+          // Tab is a distinct InputKey, not a CharKey. Match what the
+          // real-terminal decoder produces so test inputs and
+          // production inputs agree.
+          builder += InputKey.Tab
         case other =>
           builder += InputKey.CharKey(other)
       i += 1

--- a/modules/termflow-testkit/src/test/scala/termflow/testkit/KeySimSpec.scala
+++ b/modules/termflow-testkit/src/test/scala/termflow/testkit/KeySimSpec.scala
@@ -29,7 +29,7 @@ class KeySimSpec extends AnyFunSuite:
     assert(KeySim.ArrowLeft == InputKey.ArrowLeft)
     assert(KeySim.ArrowRight == InputKey.ArrowRight)
     assert(KeySim.BackTab == InputKey.BackTab)
-    assert(KeySim.Tab == InputKey.CharKey('\t'))
+    assert(KeySim.Tab == InputKey.Tab)
   }
 
   test("f produces F1..F12 cases") {
@@ -94,9 +94,9 @@ class KeySimSpec extends AnyFunSuite:
     assert(keys == Vector(InputKey.CharKey('h'), InputKey.CharKey('i')))
   }
 
-  test("typeString returns a CharKey for tab") {
+  test("typeString turns tab into InputKey.Tab") {
     val keys = KeySim.typeString("a\tb")
-    assert(keys == Vector(InputKey.CharKey('a'), InputKey.CharKey('\t'), InputKey.CharKey('b')))
+    assert(keys == Vector(InputKey.CharKey('a'), InputKey.Tab, InputKey.CharKey('b')))
   }
 
   test("typeString turns LF into Enter") {

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Autocomplete.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Autocomplete.scala
@@ -146,7 +146,8 @@ object Autocomplete:
     width: Int,
     maxVisible: Int = 6,
     at: Coord = Coord(XCoord(1), YCoord(1)),
-    prefix: String = ""
+    prefix: String = "",
+    focused: Boolean = true
   )(using theme: Theme): List[VNode] =
     val rendered = Prompt.renderWithPrefix(state.input, prefix)
     val inputNode = VNode.InputNode(
@@ -158,11 +159,34 @@ object Autocomplete:
       lineWidth = math.max(1, width),
       prefixLength = rendered.prefixLength
     )
-    val visible = state.filtered.take(maxVisible)
+
+    val all  = state.filtered
+    val size = all.size
+    // Keep the cursor visible: anchor the visible window so selectedIdx
+    // is always in `[anchor, anchor + maxVisible)`. Without this scroll
+    // the list silently truncates and a cursor past the fold disappears.
+    val visibleCount = math.max(1, math.min(maxVisible, math.max(1, size)))
+    val anchor =
+      if size == 0 then 0
+      else
+        val sel    = math.max(0, math.min(size - 1, state.selectedIdx))
+        val maxTop = math.max(0, size - visibleCount)
+        if sel < 0 then 0
+        else if sel >= visibleCount then math.min(maxTop, sel - (visibleCount - 1))
+        else 0
+    val visible = all.slice(anchor, anchor + visibleCount)
+
     val rows = visible.zipWithIndex.toList.map { case (item, i) =>
-      val isSelected = i == state.selectedIdx
+      val absIdx     = anchor + i
+      val isSelected = absIdx == state.selectedIdx
+      // When the widget is focused the cursor row uses the full
+      // primary-bar highlight (active-editing affordance). When the
+      // widget is unfocused we drop the bar and use a subtle
+      // foreground-only marker so the row doesn't compete for attention
+      // with the field that actually owns focus now.
       val style =
-        if isSelected then Style(fg = theme.background, bg = theme.primary, bold = true)
+        if isSelected && focused then Style(fg = theme.background, bg = theme.primary, bold = true)
+        else if isSelected then Style(fg = theme.primary, bold = true)
         else Style(fg = theme.foreground)
       val marker = if isSelected then "▸ " else "  "
       val label  = state.render(item)

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MultiLineInput.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MultiLineInput.scala
@@ -174,6 +174,16 @@ object MultiLineInput:
       case InputKey.End =>
         (clamp(s.copy(cursorCol = s.currentLine.length)), None)
 
+      case InputKey.Tab =>
+        // Insert a literal `\t` so Tab in a text editor does what users
+        // typing into one expect. Apps that want focus traversal across
+        // multiple widgets should intercept Tab before feeding the key
+        // into [[handleKey]].
+        val line   = s.currentLine
+        val newCol = s.cursorCol + 1
+        val newLn  = line.substring(0, s.cursorCol) + '\t' + line.substring(s.cursorCol)
+        (clamp(s.copy(lines = s.lines.updated(s.cursorRow, newLn), cursorCol = newCol)), None)
+
       case _ => (s, None)
 
   /**

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MultiLineInput.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MultiLineInput.scala
@@ -1,0 +1,296 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+import termflow.tui.KeyDecoder.InputKey
+
+/**
+ * Multi-line text editor widget.
+ *
+ * Maintains a `Vector[String]` of lines plus a `(row, col)` cursor.
+ * Editing keys (`CharKey`, `Enter`, `Backspace`, `Delete`, arrow keys,
+ * `Home`/`End`) compose to a small fixed-pitch text editor — enough
+ * for a comments box, a description field, or the body of a chat
+ * message. For single-line input use [[termflow.tui.Prompt]] instead.
+ *
+ * Cursor navigation is **grapheme-aware** within a line: arrow keys
+ * step over surrogate pairs and combining marks as one unit, mirroring
+ * the single-line `Prompt`. The cursor is stored in UTF-16 code-unit
+ * offsets to match the underlying `String` model — apps composing with
+ * other text APIs can pass it straight through.
+ *
+ * The widget renders one `TextNode` per visible row. The cursor row
+ * uses a reverse-video cell so the caret is visible without having to
+ * commandeer the hardware cursor — same approach as
+ * [[termflow.tui.widgets.TextField]]. Lines too wide for the viewport
+ * are clipped with a trailing `…`; vertical scrolling lifts the top
+ * row off-screen when the cursor moves below the visible window.
+ *
+ * The widget is purely presentational. State lives in the calling app:
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * MultiLineInput.render(
+ *   state = m.editor,
+ *   width = 60,
+ *   height = 8,
+ *   at = Coord(2.x, 5.y)
+ * )
+ * }}}
+ *
+ * Apps wire the keyboard with `MultiLineInput.handleKey(state, key)`
+ * which returns `(newState, Option[Cmd[Msg]])` — the optional command
+ * is only ever `None` today (no submit semantics are baked in), but
+ * the shape matches `Prompt.handleKey` so swapping the two is a small
+ * change.
+ */
+object MultiLineInput:
+
+  /**
+   * Editor state.
+   *
+   * Invariant: `lines` always contains at least one entry — an empty
+   * editor is `lines = Vector("")` with cursor `(0, 0)`. The cursor
+   * row is clamped to `[0, lines.size - 1]` and the column to
+   * `[0, currentLine.length]` after every transition.
+   *
+   * @param lines      The editor's lines, top-to-bottom. UTF-16
+   *                   code-unit strings, no trailing newline.
+   * @param cursorRow  Zero-based row of the cursor.
+   * @param cursorCol  Zero-based UTF-16 column on the cursor's row.
+   * @param scrollTop  First visible row (vertical scroll offset).
+   *                   Internal-state-ish; apps generally don't manage
+   *                   it directly — [[handleKey]] keeps it consistent
+   *                   with the cursor.
+   */
+  final case class State(
+    lines: Vector[String] = Vector(""),
+    cursorRow: Int = 0,
+    cursorCol: Int = 0,
+    scrollTop: Int = 0
+  ):
+
+    /** Convenience: the current row's text. */
+    def currentLine: String = lines(math.max(0, math.min(lines.size - 1, cursorRow)))
+
+    /** All lines joined with `\n`, no trailing newline. */
+    def text: String = lines.mkString("\n")
+
+  object State:
+
+    /** Empty editor at `(0, 0)`. */
+    val empty: State = State()
+
+    /** Initial state seeded with `text`, cursor at the end. */
+    def of(text: String): State =
+      val lines   = if text.isEmpty then Vector("") else text.split("\n", -1).toVector
+      val lastRow = lines.size - 1
+      val lastCol = lines.last.length
+      State(lines, cursorRow = lastRow, cursorCol = lastCol)
+
+  /**
+   * Feed a key event into the editor and return the updated state.
+   *
+   * Returns `(state, None)` for handled keys; `(state, None)` for
+   * unhandled keys (no-op) — the `Option[Cmd]` shape is reserved for
+   * future submit semantics so callers don't have to refactor when
+   * those land.
+   */
+  def handleKey[Msg](state: State, key: InputKey): (State, Option[Cmd[Msg]]) =
+    val s = clamp(state)
+    key match
+      case InputKey.CharKey(ch) =>
+        val line   = s.currentLine
+        val newCol = s.cursorCol + 1
+        val newLn  = line.substring(0, s.cursorCol) + ch + line.substring(s.cursorCol)
+        (clamp(s.copy(lines = s.lines.updated(s.cursorRow, newLn), cursorCol = newCol)), None)
+
+      case InputKey.Enter =>
+        val line     = s.currentLine
+        val before   = line.substring(0, s.cursorCol)
+        val after    = line.substring(s.cursorCol)
+        val newLines = s.lines.patch(s.cursorRow, Vector(before, after), 1)
+        (clamp(s.copy(lines = newLines, cursorRow = s.cursorRow + 1, cursorCol = 0)), None)
+
+      case InputKey.Backspace =>
+        if s.cursorCol > 0 then
+          val line  = s.currentLine
+          val prev  = Grapheme.previousBoundary(line, s.cursorCol)
+          val newLn = line.substring(0, prev) + line.substring(s.cursorCol)
+          (clamp(s.copy(lines = s.lines.updated(s.cursorRow, newLn), cursorCol = prev)), None)
+        else if s.cursorRow > 0 then
+          // Join with the previous line; cursor lands at the join point.
+          val prevLine = s.lines(s.cursorRow - 1)
+          val curLine  = s.currentLine
+          val joined   = prevLine + curLine
+          val newLines = s.lines.patch(s.cursorRow - 1, Vector(joined), 2)
+          (clamp(s.copy(lines = newLines, cursorRow = s.cursorRow - 1, cursorCol = prevLine.length)), None)
+        else (s, None)
+
+      case InputKey.Delete =>
+        val line = s.currentLine
+        if s.cursorCol < line.length then
+          val nxt   = Grapheme.nextBoundary(line, s.cursorCol)
+          val newLn = line.substring(0, s.cursorCol) + line.substring(nxt)
+          (clamp(s.copy(lines = s.lines.updated(s.cursorRow, newLn))), None)
+        else if s.cursorRow < s.lines.size - 1 then
+          val nextLine = s.lines(s.cursorRow + 1)
+          val joined   = line + nextLine
+          val newLines = s.lines.patch(s.cursorRow, Vector(joined), 2)
+          (clamp(s.copy(lines = newLines)), None)
+        else (s, None)
+
+      case InputKey.ArrowLeft =>
+        if s.cursorCol > 0 then
+          val prev = Grapheme.previousBoundary(s.currentLine, s.cursorCol)
+          (clamp(s.copy(cursorCol = prev)), None)
+        else if s.cursorRow > 0 then
+          val above = s.lines(s.cursorRow - 1)
+          (clamp(s.copy(cursorRow = s.cursorRow - 1, cursorCol = above.length)), None)
+        else (s, None)
+
+      case InputKey.ArrowRight =>
+        val line = s.currentLine
+        if s.cursorCol < line.length then
+          val nxt = Grapheme.nextBoundary(line, s.cursorCol)
+          (clamp(s.copy(cursorCol = nxt)), None)
+        else if s.cursorRow < s.lines.size - 1 then (clamp(s.copy(cursorRow = s.cursorRow + 1, cursorCol = 0)), None)
+        else (s, None)
+
+      case InputKey.ArrowUp =>
+        if s.cursorRow > 0 then
+          val above = s.lines(s.cursorRow - 1)
+          (clamp(s.copy(cursorRow = s.cursorRow - 1, cursorCol = math.min(s.cursorCol, above.length))), None)
+        else (s, None)
+
+      case InputKey.ArrowDown =>
+        if s.cursorRow < s.lines.size - 1 then
+          val below = s.lines(s.cursorRow + 1)
+          (clamp(s.copy(cursorRow = s.cursorRow + 1, cursorCol = math.min(s.cursorCol, below.length))), None)
+        else (s, None)
+
+      case InputKey.Home =>
+        (clamp(s.copy(cursorCol = 0)), None)
+
+      case InputKey.End =>
+        (clamp(s.copy(cursorCol = s.currentLine.length)), None)
+
+      case _ => (s, None)
+
+  /**
+   * Render the editor at `(at, width, height)`. Returns a list of
+   * VNodes — one per visible row plus an [[InputNode]] for the cursor
+   * row. Apps typically embed this in a `BoxNode` border for a nicer
+   * visual; the widget doesn't draw the border itself.
+   *
+   * @param state  Current editor state.
+   * @param width  Visible width in cells (rows are clipped past this).
+   * @param height Visible height in rows.
+   * @param at     Top-left of the viewport.
+   */
+  def render(
+    state: State,
+    width: Int,
+    height: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  )(using theme: Theme): List[VNode] =
+    if width <= 0 || height <= 0 then return Nil
+    val s         = clamp(scrollFor(state, height))
+    val viewBegin = s.scrollTop
+    val viewEnd   = math.min(s.lines.size, viewBegin + height)
+    val style     = Style(fg = theme.foreground, bg = theme.background)
+
+    val cursorStyle = Style(fg = theme.background, bg = theme.primary)
+    val rows = (viewBegin until viewEnd).toList.map { rowIdx =>
+      val viewRow  = rowIdx - viewBegin
+      val rowAt    = Coord(at.x, at.y + viewRow)
+      val isCursor = rowIdx == s.cursorRow
+      val text     = s.lines(rowIdx)
+      if isCursor then
+        // Render the cursor row as a TextNode with a reverse-video cell
+        // at the cursor column. Same pattern as TextField — the renderer
+        // needs no help and the cursor stays visible inside any embedding.
+        renderCursorRow(text, s.cursorCol, width, rowAt, style, cursorStyle)
+      else
+        val clipped =
+          if WCWidth.stringWidth(text) <= width then text
+          else clipToWidth(text, math.max(1, width - 1)) + "…"
+        TextNode(rowAt.x, rowAt.y, List(Text(clipped, style)))
+    }
+    rows
+
+  /** Adjust `scrollTop` so the cursor row is visible in `height` rows. */
+  def scrollFor(state: State, height: Int): State =
+    val s = clamp(state)
+    if height <= 0 then s
+    else if s.cursorRow < s.scrollTop then s.copy(scrollTop = s.cursorRow)
+    else if s.cursorRow >= s.scrollTop + height then s.copy(scrollTop = s.cursorRow - height + 1)
+    else s
+
+  /** Clamp the cursor and scroll to valid ranges given `lines`. */
+  private def clamp(state: State): State =
+    val lines     = if state.lines.isEmpty then Vector("") else state.lines
+    val maxRow    = lines.size - 1
+    val row       = math.max(0, math.min(maxRow, state.cursorRow))
+    val maxCol    = lines(row).length
+    val col       = math.max(0, math.min(maxCol, state.cursorCol))
+    val scrollTop = math.max(0, math.min(maxRow, state.scrollTop))
+    state.copy(lines = lines, cursorRow = row, cursorCol = col, scrollTop = scrollTop)
+
+  /**
+   * Build the cursor row's TextNode with a reverse-video cell at the
+   * cursor's UTF-16 position. Mirrors [[widgets.TextField]]'s caret
+   * approach so embedded use stays straightforward.
+   */
+  private def renderCursorRow(
+    text: String,
+    cursorCol: Int,
+    viewportWidth: Int,
+    at: Coord,
+    base: Style,
+    cursorStyle: Style
+  ): VNode =
+    val width = math.max(1, viewportWidth)
+    val cur   = math.max(0, math.min(text.length, cursorCol))
+    val before =
+      if cur > 0 then text.substring(0, cur) else ""
+    val cursorChar =
+      if cur < text.length then text.substring(cur, math.min(text.length, cur + 1))
+      else " "
+    val after =
+      if cur < text.length then text.substring(math.min(text.length, cur + 1)) else ""
+
+    // Pad the row out to the viewport so reverse-video cell stays visible
+    // even when the buffer is shorter than the row.
+    val tail   = math.max(0, width - WCWidth.stringWidth(before) - WCWidth.stringWidth(cursorChar))
+    val padded = if after.length < tail then after + (" " * (tail - after.length)) else after
+    TextNode(
+      at.x,
+      at.y,
+      List(
+        Text(before, base),
+        Text(cursorChar, cursorStyle),
+        Text(padded, base)
+      )
+    )
+
+  /**
+   * Truncate `text` so that the rendered cell width is at most
+   * `maxWidth`. Used by the renderer for non-cursor rows that are too
+   * wide for the viewport.
+   */
+  private def clipToWidth(text: String, maxWidth: Int): String =
+    if maxWidth <= 0 then ""
+    else
+      val sb = new StringBuilder
+      var w  = 0
+      var i  = 0
+      while i < text.length do
+        val cp  = text.codePointAt(i)
+        val cw  = WCWidth.codePointWidth(cp)
+        val n   = java.lang.Character.charCount(cp)
+        val add = math.max(0, cw)
+        if w + add > maxWidth then return sb.toString
+        sb.append(text.substring(i, i + n))
+        w += add
+        i += n
+      sb.toString

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/ScrollBar.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/ScrollBar.scala
@@ -1,0 +1,182 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Vertical or horizontal scroll indicator.
+ *
+ * Renders a track (filled with the theme's `secondary` slot) plus a
+ * proportional thumb (the theme's `primary` slot). The thumb size is a
+ * fraction of the track corresponding to `visible / total`, and its
+ * position corresponds to `offset / (total - visible)`.
+ *
+ * The widget is purely presentational. State lives in the calling app:
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * ScrollBar(
+ *   state = ScrollBar.State(offset = 12, visible = 20, total = 100),
+ *   length = 20,
+ *   at = Coord(80.x, 1.y)
+ * )
+ * }}}
+ *
+ * For mouse interaction the companion [[hitTest]] maps a click on the
+ * track to a target offset (page-up / page-down / direct seek). Apps
+ * pair that with [[clampOffset]] when handling drag gestures.
+ *
+ * The bar is hidden — emitted as no nodes — when `total <= visible`,
+ * mirroring the typical "no scrollbar when everything fits" convention.
+ */
+object ScrollBar:
+
+  /** Direction of the scrollbar's track. */
+  enum Direction:
+    case Vertical, Horizontal
+
+  /**
+   * Scroll position the bar visualises.
+   *
+   * @param offset  Index of the first visible item. Clamped to
+   *                `[0, max(0, total - visible)]` at render time.
+   * @param visible Number of items currently in view.
+   * @param total   Total number of items in the underlying collection.
+   */
+  final case class State(offset: Int, visible: Int, total: Int):
+
+    /** True when the bar should be drawn (more items than fit). */
+    def needed: Boolean = total > visible && visible > 0
+
+    /** Clamp `offset` to a valid range given `visible` and `total`. */
+    def clamped: State =
+      val maxOffset = math.max(0, total - visible)
+      val cl        = math.max(0, math.min(maxOffset, offset))
+      if cl == offset then this else copy(offset = cl)
+
+  /** Default thumb glyph (vertical track). */
+  val verticalThumb: Char = '█'
+
+  /** Default thumb glyph (horizontal track). */
+  val horizontalThumb: Char = '█'
+
+  /** Default track glyph (vertical track). */
+  val verticalTrack: Char = '│'
+
+  /** Default track glyph (horizontal track). */
+  val horizontalTrack: Char = '─'
+
+  /**
+   * Render a scrollbar. `length` is the number of cells along the
+   * primary axis (rows for vertical, cols for horizontal). Returns the
+   * empty list when no bar is needed (`total <= visible`).
+   */
+  def apply(
+    state: State,
+    length: Int,
+    direction: Direction = Direction.Vertical,
+    at: Coord = Coord(XCoord(1), YCoord(1))
+  )(using theme: Theme): List[VNode] =
+    if length <= 0 || !state.needed then Nil
+    else
+      val (thumbStart, thumbLen) = thumbRange(state, length)
+      val trackStyle             = Style(fg = theme.secondary)
+      val thumbStyle             = Style(fg = theme.primary, bold = true)
+      direction match
+        case Direction.Vertical =>
+          (0 until length).toList.map { i =>
+            val ch =
+              if i >= thumbStart && i < thumbStart + thumbLen then verticalThumb
+              else verticalTrack
+            val style = if i >= thumbStart && i < thumbStart + thumbLen then thumbStyle else trackStyle
+            TextNode(at.x, at.y + i, List(Text(ch.toString, style)))
+          }
+        case Direction.Horizontal =>
+          val buf = Array.fill(length)(horizontalTrack)
+          var i   = thumbStart
+          while i < thumbStart + thumbLen && i < length do
+            buf(i) = horizontalThumb
+            i += 1
+          // Two segments: track-thumb-track is fine in a single TextNode if we
+          // split the run into styled chunks.
+          val segments = chunkByThumb(buf.mkString, thumbStart, thumbLen, trackStyle, thumbStyle)
+          List(TextNode(at.x, at.y, segments))
+
+  /**
+   * Compute `(startOffset, lengthInCells)` of the thumb along the bar.
+   *
+   * Both values are 0-based cell indices into the bar of `length` cells.
+   * The thumb is at least one cell long (so it's visible even on a
+   * massive backing collection) and is clamped to fit inside the track.
+   */
+  def thumbRange(state: State, length: Int): (Int, Int) =
+    if length <= 0 || !state.needed then (0, 0)
+    else
+      val s         = state.clamped
+      val visible   = math.max(1, s.visible)
+      val total     = math.max(visible + 1, s.total)
+      val thumbLen0 = (length.toDouble * visible / total).round.toInt
+      val thumbLen  = math.max(1, math.min(length, thumbLen0))
+      val maxStart  = length - thumbLen
+      val maxOffset = math.max(1, total - visible)
+      val start0    = (s.offset.toDouble / maxOffset * maxStart).round.toInt
+      val start     = math.max(0, math.min(maxStart, start0))
+      (start, thumbLen)
+
+  /**
+   * Map a click on the bar (cell index 0..length-1) to the target
+   * `offset` the app should snap to.
+   *
+   * Strategy mirrors typical desktop scrollbars:
+   *   - Click on the thumb itself returns the unchanged offset (the app
+   *     should treat that as the start of a drag gesture).
+   *   - Click before the thumb returns `offset - visible` (page up).
+   *   - Click after the thumb returns `offset + visible` (page down).
+   *
+   * Result is clamped to `[0, total - visible]`.
+   */
+  def hitTest(state: State, length: Int, cellIndex: Int): Int =
+    if !state.needed || length <= 0 then state.clamped.offset
+    else
+      val (thumbStart, thumbLen) = thumbRange(state, length)
+      val cl                     = state.clamped
+      val raw =
+        if cellIndex < thumbStart then cl.offset - cl.visible
+        else if cellIndex >= thumbStart + thumbLen then cl.offset + cl.visible
+        else cl.offset
+      math.max(0, math.min(math.max(0, cl.total - cl.visible), raw))
+
+  /**
+   * Compute the offset implied by a "drag the thumb to cell N" gesture.
+   *
+   * Linear mapping: `offset = (cellIndex / (length - thumbLen)) *
+   * (total - visible)`. Clamped to `[0, total - visible]`.
+   */
+  def offsetForDrag(state: State, length: Int, cellIndex: Int): Int =
+    if !state.needed || length <= 0 then state.clamped.offset
+    else
+      val (_, thumbLen) = thumbRange(state, length)
+      val maxStart      = math.max(1, length - thumbLen)
+      val cl            = state.clamped
+      val maxOffset     = math.max(0, cl.total - cl.visible)
+      val raw           = (cellIndex.toDouble / maxStart * maxOffset).round.toInt
+      math.max(0, math.min(maxOffset, raw))
+
+  /** Clamp an offset to the valid scroll range for `visible` / `total`. */
+  def clampOffset(offset: Int, visible: Int, total: Int): Int =
+    val maxOffset = math.max(0, total - visible)
+    math.max(0, math.min(maxOffset, offset))
+
+  private def chunkByThumb(
+    line: String,
+    thumbStart: Int,
+    thumbLen: Int,
+    trackStyle: Style,
+    thumbStyle: Style
+  ): List[Text] =
+    val segs = List.newBuilder[Text]
+    if thumbStart > 0 then segs += Text(line.substring(0, thumbStart), trackStyle)
+    if thumbLen > 0 then
+      segs += Text(line.substring(thumbStart, math.min(line.length, thumbStart + thumbLen)), thumbStyle)
+    val tail = math.min(line.length, thumbStart + thumbLen)
+    if tail < line.length then segs += Text(line.substring(tail), trackStyle)
+    segs.result()

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Separator.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Separator.scala
@@ -1,0 +1,105 @@
+package termflow.tui.widgets
+
+import termflow.tui.*
+
+/**
+ * Single-cell-thick line used to visually separate two regions.
+ *
+ * Renders a horizontal or vertical run of the active theme's
+ * [[BorderChars]] glyphs (defaulting to the same style used by box
+ * borders). Optionally embeds a centred title in the run, in which case
+ * the line is broken with a small leader / trailer:
+ *
+ * {{{
+ * ──── Title ────
+ * }}}
+ *
+ * The widget is purely presentational — it owns no state and emits a
+ * single [[TextNode]]. Apps typically place it between rows in a
+ * `Layout.column` or between columns in a `Layout.row`:
+ *
+ * {{{
+ * given Theme = Theme.dark
+ * Layout.column(gap = 0)(
+ *   Header(...),
+ *   Separator.horizontal(width = 80),
+ *   Body(...)
+ * )
+ * }}}
+ *
+ * Alignment within a multi-cell row / column is the caller's job; the
+ * separator just draws the line at the supplied `at`.
+ */
+object Separator:
+
+  /** Direction of the separator. */
+  enum Direction:
+    case Horizontal, Vertical
+
+  /**
+   * Horizontal separator of `width` cells.
+   *
+   * @param width  Length of the run in cells. `width <= 0` yields no node
+   *               (returns an empty list), which keeps `Layout.column`
+   *               composition simple.
+   * @param at     Top-left cell. Defaults to `(1, 1)`.
+   * @param title  Optional centred title. Rendered with the theme's
+   *               primary slot; the surrounding rule uses the theme's
+   *               border slot. If `width` cannot fit the title plus
+   *               at least one cell of leader / trailer the title is
+   *               dropped and the rule fills the row.
+   * @param chars  Glyph set to draw with. Defaults to the theme's chars.
+   */
+  def horizontal(
+    width: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    title: String = "",
+    chars: BorderChars = null
+  )(using theme: Theme): List[VNode] =
+    if width <= 0 then Nil
+    else
+      val activeChars = if chars eq null then theme.chars else chars
+      val rule        = activeChars.horizontal.toString
+      val ruleStyle   = Style(fg = theme.foreground)
+      val titleStyle  = Style(fg = theme.primary, bold = true)
+      val titleText   = if title.isEmpty then "" else s" $title "
+      // Need at least one cell of leader and one of trailer around the title.
+      if titleText.isEmpty || titleText.length + 2 > width then
+        List(TextNode(at.x, at.y, List(Text(rule * width, ruleStyle))))
+      else
+        val leader  = (width - titleText.length) / 2
+        val trailer = width - titleText.length - leader
+        List(
+          TextNode(
+            at.x,
+            at.y,
+            List(
+              Text(rule * leader, ruleStyle),
+              Text(titleText, titleStyle),
+              Text(rule * trailer, ruleStyle)
+            )
+          )
+        )
+
+  /**
+   * Vertical separator of `height` cells.
+   *
+   * Emits one single-character `TextNode` per row — the simplest model
+   * given the renderer's row-per-text-node convention. Like
+   * [[horizontal]], a non-positive `height` yields no nodes.
+   *
+   * @param height Number of cells in the run.
+   * @param at     Top-left cell. Defaults to `(1, 1)`.
+   * @param chars  Glyph set to draw with. Defaults to the theme's chars.
+   */
+  def vertical(
+    height: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    chars: BorderChars = null
+  )(using theme: Theme): List[VNode] =
+    if height <= 0 then Nil
+    else
+      val activeChars = if chars eq null then theme.chars else chars
+      val style       = Style(fg = theme.foreground)
+      val glyph       = activeChars.vertical.toString
+      (0 until height).map(i => TextNode(at.x, at.y + i, List(Text(glyph, style)))).toList

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
@@ -11,11 +11,13 @@ import termflow.tui.*
  * receive the resolved `(at, width, height)` of their pane and return
  * the `VNode`s to draw into it.
  *
- * Mouse-drag to resize the divider is not yet implemented — that needs
- * the layout-pass hit-test cache (deferred to Stage 3 mouse follow-up).
- * Until then apps drive `splitRatio` via their own keymap (or simply
- * leave it fixed). Scaffolding for the divider rect is exposed via
- * [[dividerRect]] so apps that want to wire mouse drag themselves can.
+ * Mouse-drag to resize the divider is supported via the [[handleMouse]]
+ * companion: hold a [[DragState]] in the app's model, feed each
+ * `MouseEvent` (typically extracted from `InputKey.Mouse(...)`) through
+ * `handleMouse`, and use the returned `splitRatio` when constructing
+ * the next frame. The divider rectangle is exposed via [[dividerRect]]
+ * so apps that want to wire their own drag handling can; `gap >= 1` is
+ * required for the divider to be pickable.
  *
  * {{{
  * given Theme = Theme.dark
@@ -120,6 +122,138 @@ object SplitPane:
     gap: Int = 0
   ): Option[Pane] =
     layout(direction, width, height, at, splitRatio, gap).divider
+
+  /**
+   * Drag state for mouse-driven divider resize.
+   *
+   * Apps hold a single `DragState` per `SplitPane`, default
+   * [[DragState.idle]], and feed every [[InputKey.Mouse]] event into
+   * [[handleMouse]]. The `splitRatio` field is what the next frame
+   * should use; `dragging` is true while the user is mid-gesture so the
+   * app can render a focused divider style if it likes.
+   *
+   * @param splitRatio Current split ratio. Always clamped to
+   *                   `[MinSizeRatio, 1 - MinSizeRatio]`.
+   * @param dragging   True between [[MouseEvent.Press]] on the divider
+   *                   and the next [[MouseEvent.Release]].
+   */
+  final case class DragState(splitRatio: Double, dragging: Boolean):
+    /** Reset back to the idle state at the supplied ratio. */
+    def reset(ratio: Double): DragState = DragState(clampRatio(ratio), dragging = false)
+
+  object DragState:
+    /** Idle drag state at `0.5`. */
+    val idle: DragState = DragState(0.5, dragging = false)
+
+    /** Idle drag state at the supplied ratio (clamped). */
+    def at(ratio: Double): DragState = DragState(clampRatio(ratio), dragging = false)
+
+  /**
+   * Feed a mouse event into a [[DragState]] and return the updated
+   * state. Apps wire this from their `update` handler:
+   *
+   * {{{
+   * case Msg.Mouse(ev) =>
+   *   val drag = SplitPane.handleMouse(
+   *     state = m.drag,
+   *     event = ev,
+   *     direction = SplitPane.Direction.Horizontal,
+   *     width = m.width, height = m.height,
+   *     gap = 1
+   *   )
+   *   m.copy(drag = drag).tui
+   * }}}
+   *
+   * Press on the divider rect arms the drag; subsequent Drag events
+   * update the ratio based on the cursor's position along the major
+   * axis; Release ends the gesture. Events outside the divider while
+   * not dragging are ignored.
+   *
+   * `gap` must be >= 1 for the divider to be pickable; with `gap = 0`
+   * there is nowhere to click.
+   *
+   * @param state     Current drag state.
+   * @param event     Mouse event to process.
+   * @param direction Split direction.
+   * @param width     Total cell width of the splittable region.
+   * @param height    Total cell height of the splittable region.
+   * @param at        Top-left of the splittable region. Defaults to `(1, 1)`.
+   * @param gap       Divider gap in cells. Must be >= 1 for drag.
+   */
+  def handleMouse(
+    state: DragState,
+    event: MouseEvent,
+    direction: Direction,
+    width: Int,
+    height: Int,
+    at: Coord = Coord(XCoord(1), YCoord(1)),
+    gap: Int = 1
+  ): DragState =
+    if gap < 1 then state
+    else
+      val l       = layout(direction, width, height, at, state.splitRatio, gap)
+      val divider = l.divider
+      event match
+        case MouseEvent.Press(MouseButton.Left, col, row, _) =>
+          if divider.exists(_.contains(col, row)) then state.copy(dragging = true)
+          else state
+
+        case MouseEvent.Drag(MouseButton.Left, col, row, _) if state.dragging =>
+          state.copy(splitRatio = ratioAt(direction, width, height, at, col, row))
+
+        case MouseEvent.Release(MouseButton.Left, col, row, _) =>
+          if state.dragging then
+            // If the release lands inside the splittable region, snap to the
+            // pointer's final ratio; otherwise leave the ratio where the last
+            // Drag put it.
+            val withinRegion = isInside(width, height, at, col, row)
+            val ratio = if withinRegion then ratioAt(direction, width, height, at, col, row) else state.splitRatio
+            DragState(clampRatio(ratio), dragging = false)
+          else state
+
+        case _ => state
+
+  private def isInside(
+    width: Int,
+    height: Int,
+    at: Coord,
+    col: Int,
+    row: Int
+  ): Boolean =
+    val left = at.x.value
+    val top  = at.y.value
+    col >= left && col < left + width && row >= top && row < top + height
+
+  private def ratioAt(
+    direction: Direction,
+    width: Int,
+    height: Int,
+    at: Coord,
+    col: Int,
+    row: Int
+  ): Double =
+    direction match
+      case Direction.Horizontal =>
+        val span    = math.max(1, width)
+        val rel     = col - at.x.value + 1 // 1..width inside the region
+        val clamped = math.max(1, math.min(span, rel))
+        clamped.toDouble / span
+      case Direction.Vertical =>
+        val span    = math.max(1, height)
+        val rel     = row - at.y.value + 1
+        val clamped = math.max(1, math.min(span, rel))
+        clamped.toDouble / span
+
+  private def clampRatio(ratio: Double): Double =
+    math.max(MinSizeRatio, math.min(1.0 - MinSizeRatio, ratio))
+
+  /** Extension for [[Pane]] hit-testing — used by [[handleMouse]]. */
+  extension (pane: Pane)
+    private def contains(col: Int, row: Int): Boolean =
+      val left = pane.at.x.value
+      val top  = pane.at.y.value
+      col >= left && col < left + pane.width &&
+      row >= top && row < top + pane.height
 
   /**
    * Render both panes. The renderer functions are called with the

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/TextField.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/TextField.scala
@@ -251,8 +251,10 @@ object TextField:
         )
       )
     else
+      // Placeholder text renders dimmed in the theme's secondary slot
+      // so users can tell the sample value isn't real input.
       val style =
-        if showPlaceholder then Style(fg = theme.foreground)
+        if showPlaceholder then Style(fg = theme.secondary, dim = true, italic = true)
         else Style(fg = theme.foreground)
       TextNode(at.x, at.y, List(Text(padded, style)))
 

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Tree.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Tree.scala
@@ -17,10 +17,12 @@ import termflow.tui.*
  *   - **Indentation.** Each level adds two cells of left padding so
  *     ancestor relationships are visually obvious. Override with
  *     `indentWidth`.
- *   - **Markers.** Internal nodes (those with children) get a `▾`
- *     (expanded) or `▸` (collapsed) chevron, two columns wide
- *     (chevron + space). Leaves get two spaces. ASCII fallbacks are
- *     `v ` / `> ` / `  ` when `unicode = false`.
+ *   - **Markers.** Internal nodes (those with children) get a `+`
+ *     (collapsed, "click to open") or `-` (expanded, "click to
+ *     collapse") glyph, three columns wide (`[+] ` / `[-] `). Leaves
+ *     get four spaces of leading padding. The `unicode` flag is kept
+ *     for backwards compatibility but no longer changes the glyph
+ *     since `+` / `-` are already ASCII.
  *   - **Selection.** The row at `selectedIndex` (an index into the
  *     *visible* row list) is highlighted in the theme's primary slot,
  *     bolded.
@@ -102,13 +104,12 @@ object Tree:
     roots.foreach(walk(_, 0))
     builder.result()
 
-  // Marker glyphs.
-  private val expandedGlyph       = "▾ "
-  private val collapsedGlyph      = "▸ "
-  private val leafGlyph           = "  "
-  private val expandedGlyphAscii  = "v "
-  private val collapsedGlyphAscii = "> "
-  private val leafGlyphAscii      = "  "
+  // Marker glyphs. `[+] ` for collapsed, `[-] ` for expanded —
+  // unambiguous click targets that survive any font / locale combo.
+  // Leaves get four spaces so the label column lines up across rows.
+  private val expandedGlyph  = "[-] "
+  private val collapsedGlyph = "[+] "
+  private val leafGlyph      = "    "
 
   /**
    * Render the tree as a list of `TextNode`s.
@@ -148,15 +149,70 @@ object Tree:
 
   /** Marker glyph for an expanded internal node. */
   def expandedFor(unicode: Boolean = true): String =
-    if unicode then expandedGlyph else expandedGlyphAscii
+    val _ = unicode // glyphs are now ASCII-only; param kept for source compat
+    expandedGlyph
 
   /** Marker glyph for a collapsed internal node. */
   def collapsedFor(unicode: Boolean = true): String =
-    if unicode then collapsedGlyph else collapsedGlyphAscii
+    val _ = unicode
+    collapsedGlyph
 
   /** Padding used in place of a marker for leaf nodes. */
   def leafFor(unicode: Boolean = true): String =
-    if unicode then leafGlyph else leafGlyphAscii
+    val _ = unicode
+    leafGlyph
+
+  /**
+   * Region of a tree row a click landed in. Apps map a
+   * [[HitResult.Chevron]] to "toggle expand" and a
+   * [[HitResult.Label]] to "select this row".
+   */
+  enum HitResult:
+    case Chevron(rowIndex: Int)
+    case Label(rowIndex: Int)
+
+  /**
+   * Map a click `(col, row)` to a [[HitResult]] over the rendered
+   * row list.
+   *
+   * The chevron region is the column span occupied by the `[+] ` /
+   * `[-] ` glyph (skipped for leaves since they have no toggle). Apps
+   * pre-compute `rows = Tree.visibleRows(...)` once per frame and pass
+   * it in alongside the same `at` / `indentWidth` they used to render.
+   *
+   * Returns `None` for clicks outside any rendered row.
+   *
+   * @param rows         Row list returned by [[visibleRows]].
+   * @param at           Top-left of the first row (mirrors the
+   *                     rendering call).
+   * @param indentWidth  Cells per depth level (mirrors the rendering call).
+   * @param col          Click column (1-based, absolute).
+   * @param row          Click row (1-based, absolute).
+   * @param labelLength  Maximum label width for the click target.
+   *                     Pass `Int.MaxValue` if rows can be any length.
+   */
+  def hitTest[A](
+    rows: Vector[Row[A]],
+    at: Coord,
+    indentWidth: Int,
+    col: Int,
+    row: Int,
+    labelLength: Int = Int.MaxValue
+  ): Option[HitResult] =
+    val rowIdx = row - at.y.value
+    if rowIdx < 0 || rowIdx >= rows.size then None
+    else
+      val r           = rows(rowIdx)
+      val rowLeft     = at.x.value
+      val pad         = r.depth * indentWidth
+      val markerLeft  = rowLeft + pad
+      val markerLen   = if r.hasChildren then expandedGlyph.length else leafGlyph.length
+      val markerRight = markerLeft + markerLen - 1
+      val labelLeft   = markerLeft + markerLen
+      val labelRight  = labelLeft + math.max(0, labelLength) - 1
+      if r.hasChildren && col >= markerLeft && col <= markerRight then Some(HitResult.Chevron(rowIdx))
+      else if col >= labelLeft && col <= labelRight then Some(HitResult.Label(rowIdx))
+      else None
 
   /** Cell width of a tree row at `depth` carrying the given label. */
   def rowWidth(label: String, depth: Int, indentWidth: Int = 2, unicode: Boolean = true): Int =

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/AutocompleteSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/AutocompleteSpec.scala
@@ -96,3 +96,25 @@ class AutocompleteSpec extends AnyFunSuite:
     val empty = initial.copy(input = Prompt.State("xyz".toVector, cursor = 3))
     assert(Autocomplete.height(empty, maxVisible = 6) == 1)
   }
+
+  test("view scrolls the dropdown so the cursor row stays visible") {
+    val many     = Autocomplete.State.of((1 to 20).map(i => s"item-$i").toVector).copy(selectedIdx = 12)
+    val nodes    = Autocomplete.view(many, width = 16, maxVisible = 5)
+    val rowTexts = nodes.tail.map { case n: VNode.TextNode => n.txt.map(_.txt).mkString; case _ => "" }
+    // Cursor at 12 with maxVisible=5 should anchor so item-13 (index 12) is the last visible row.
+    assert(rowTexts.exists(_.contains("item-13")), s"expected 'item-13' visible — got $rowTexts")
+    // ...and items before the window should NOT appear.
+    assert(!rowTexts.exists(_.contains("item-1 ")), s"items above the scroll should not render — got $rowTexts")
+  }
+
+  test("view drops the primary-bar highlight when not focused") {
+    val state   = initial.copy(selectedIdx = 1) // some non-zero selection
+    val focused = Autocomplete.view(state, width = 16, maxVisible = 6, focused = true)
+    val blurred = Autocomplete.view(state, width = 16, maxVisible = 6, focused = false)
+    def rowStyle(nodes: List[VNode], i: Int): Style = nodes.tail(i) match
+      case t: VNode.TextNode => t.txt.head.style
+      case _                 => fail("expected TextNode")
+    // Focused selection has a primary background; unfocused only has a primary fg.
+    assert(rowStyle(focused, 1).bg != Color.Default, "focused row should have a bg")
+    assert(rowStyle(blurred, 1).bg == Color.Default, "unfocused row should drop the bg bar")
+  }

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MultiLineInputSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MultiLineInputSpec.scala
@@ -85,6 +85,13 @@ class MultiLineInputSpec extends AnyFunSuite:
     val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.ArrowLeft)
     assert(s.cursorCol == 1, "should jump back over the surrogate pair")
 
+  // ---- Tab ---------------------------------------------------------------
+
+  test("Tab inserts a literal '\\t' into the cursor row"):
+    val (s, _) = MultiLineInput.handleKey[String](MultiLineInput.State.empty, InputKey.Tab)
+    assert(s.lines == Vector("\t"))
+    assert(s.cursorCol == 1)
+
   // ---- Home / End ---------------------------------------------------------
 
   test("Home moves to col 0; End moves to end of line"):

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MultiLineInputSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MultiLineInputSpec.scala
@@ -1,0 +1,120 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+import termflow.tui.KeyDecoder.InputKey
+
+class MultiLineInputSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  // ---- State.of -----------------------------------------------------------
+
+  test("State.of seeds empty editor with one empty line"):
+    val s = MultiLineInput.State.of("")
+    assert(s.lines == Vector(""))
+    assert(s.cursorRow == 0 && s.cursorCol == 0)
+
+  test("State.of splits text on newlines and parks cursor at the end"):
+    val s = MultiLineInput.State.of("a\nbb\nccc")
+    assert(s.lines == Vector("a", "bb", "ccc"))
+    assert(s.cursorRow == 2)
+    assert(s.cursorCol == 3)
+
+  // ---- CharKey ------------------------------------------------------------
+
+  test("CharKey inserts at the cursor and advances col"):
+    val (s, _) = MultiLineInput.handleKey[String](MultiLineInput.State.empty, InputKey.CharKey('a'))
+    assert(s.lines == Vector("a"))
+    assert(s.cursorCol == 1)
+
+  // ---- Enter --------------------------------------------------------------
+
+  test("Enter splits the current line at the cursor"):
+    val initial = MultiLineInput.State.of("hello").copy(cursorCol = 2)
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.Enter)
+    assert(s.lines == Vector("he", "llo"))
+    assert(s.cursorRow == 1 && s.cursorCol == 0)
+
+  // ---- Backspace ----------------------------------------------------------
+
+  test("Backspace at start of a line joins with the previous line"):
+    val initial = MultiLineInput.State(lines = Vector("foo", "bar"), cursorRow = 1, cursorCol = 0)
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.Backspace)
+    assert(s.lines == Vector("foobar"))
+    assert(s.cursorRow == 0 && s.cursorCol == 3)
+
+  test("Backspace inside a line deletes a grapheme"):
+    val initial = MultiLineInput.State.of("a😀b").copy(cursorCol = 3) // after the emoji
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.Backspace)
+    assert(s.lines == Vector("ab"))
+    assert(s.cursorCol == 1)
+
+  // ---- Delete -------------------------------------------------------------
+
+  test("Delete at end of a line joins with the following line"):
+    val initial = MultiLineInput.State(lines = Vector("foo", "bar"), cursorRow = 0, cursorCol = 3)
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.Delete)
+    assert(s.lines == Vector("foobar"))
+    assert(s.cursorRow == 0 && s.cursorCol == 3)
+
+  // ---- Arrows -------------------------------------------------------------
+
+  test("ArrowUp/ArrowDown moves the cursor between rows, clamping col"):
+    val initial = MultiLineInput.State(lines = Vector("ab", "longer"), cursorRow = 1, cursorCol = 5)
+    val (up, _) = MultiLineInput.handleKey[String](initial, InputKey.ArrowUp)
+    assert(up.cursorRow == 0)
+    assert(up.cursorCol == 2, "col clamps to the shorter row")
+    val (down, _) = MultiLineInput.handleKey[String](up, InputKey.ArrowDown)
+    assert(down.cursorRow == 1)
+    // Clamping doesn't restore the original column.
+    assert(down.cursorCol == 2)
+
+  test("ArrowLeft at start of a line moves to the end of the previous line"):
+    val initial = MultiLineInput.State(lines = Vector("ab", "cd"), cursorRow = 1, cursorCol = 0)
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.ArrowLeft)
+    assert(s.cursorRow == 0 && s.cursorCol == 2)
+
+  test("ArrowRight at end of a line moves to start of the next line"):
+    val initial = MultiLineInput.State(lines = Vector("ab", "cd"), cursorRow = 0, cursorCol = 2)
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.ArrowRight)
+    assert(s.cursorRow == 1 && s.cursorCol == 0)
+
+  test("ArrowLeft steps over a surrogate pair"):
+    val initial = MultiLineInput.State.of("a😀b").copy(cursorCol = 3)
+    val (s, _)  = MultiLineInput.handleKey[String](initial, InputKey.ArrowLeft)
+    assert(s.cursorCol == 1, "should jump back over the surrogate pair")
+
+  // ---- Home / End ---------------------------------------------------------
+
+  test("Home moves to col 0; End moves to end of line"):
+    val initial = MultiLineInput.State.of("hello").copy(cursorCol = 2)
+    val (h, _)  = MultiLineInput.handleKey[String](initial, InputKey.Home)
+    val (e, _)  = MultiLineInput.handleKey[String](initial, InputKey.End)
+    assert(h.cursorCol == 0)
+    assert(e.cursorCol == 5)
+
+  // ---- render -------------------------------------------------------------
+
+  test("render emits one node per visible row"):
+    val s     = MultiLineInput.State(lines = Vector("a", "b", "c"), cursorRow = 0, cursorCol = 0)
+    val nodes = MultiLineInput.render(s, width = 10, height = 3)
+    assert(nodes.size == 3)
+    // Every visible row is a TextNode — the cursor row uses a
+    // reverse-video cell rather than commandeering the hardware cursor.
+    assert(nodes.forall(_.isInstanceOf[TextNode]))
+
+  test("render scrolls so the cursor row stays visible"):
+    val lines = (0 until 10).map(i => s"line-$i").toVector
+    val s     = MultiLineInput.State(lines = lines, cursorRow = 9, cursorCol = 0)
+    val nodes = MultiLineInput.render(s, width = 20, height = 3)
+    assert(nodes.size == 3)
+    // The cursor row (#9) is the last visible row. Concatenate text
+    // segments to recover its rendered string.
+    val texts = nodes.map { case t: TextNode => t.txt.map(_.txt).mkString; case _ => "" }
+    assert(texts.last.startsWith("line-9"))
+
+  test("render returns Nil for non-positive size"):
+    val s = MultiLineInput.State.empty
+    assert(MultiLineInput.render(s, width = 0, height = 5).isEmpty)
+    assert(MultiLineInput.render(s, width = 5, height = 0).isEmpty)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/ScrollBarSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/ScrollBarSpec.scala
@@ -1,0 +1,84 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+
+class ScrollBarSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  test("hidden when total <= visible"):
+    val state = ScrollBar.State(offset = 0, visible = 10, total = 10)
+    assert(!state.needed)
+    assert(ScrollBar(state, length = 10).isEmpty)
+
+  test("hidden when length <= 0"):
+    val state = ScrollBar.State(offset = 0, visible = 5, total = 100)
+    assert(ScrollBar(state, length = 0).isEmpty)
+
+  test("vertical bar emits one node per cell along the length"):
+    val state = ScrollBar.State(offset = 0, visible = 10, total = 100)
+    val nodes = ScrollBar(state, length = 20)
+    assert(nodes.size == 20)
+
+  test("thumbRange thumb is at the top when offset = 0"):
+    val state      = ScrollBar.State(offset = 0, visible = 10, total = 100)
+    val (start, _) = ScrollBar.thumbRange(state, length = 20)
+    assert(start == 0)
+
+  test("thumbRange thumb is at the bottom when offset is at the max"):
+    val state        = ScrollBar.State(offset = 90, visible = 10, total = 100)
+    val (start, len) = ScrollBar.thumbRange(state, length = 20)
+    assert(start + len == 20, s"thumb should end at the bar bottom — start=$start, len=$len, length=20")
+
+  test("thumbRange thumb is at least one cell long"):
+    val state    = ScrollBar.State(offset = 0, visible = 1, total = 1_000_000)
+    val (_, len) = ScrollBar.thumbRange(state, length = 10)
+    assert(len >= 1)
+
+  test("thumbRange thumb size scales with visible/total"):
+    val small     = ScrollBar.State(offset = 0, visible = 10, total = 100)
+    val big       = ScrollBar.State(offset = 0, visible = 50, total = 100)
+    val (_, sLen) = ScrollBar.thumbRange(small, length = 20)
+    val (_, bLen) = ScrollBar.thumbRange(big, length = 20)
+    assert(bLen > sLen, s"larger viewport should mean larger thumb (small=$sLen, big=$bLen)")
+
+  test("hitTest above the thumb returns offset - visible (page up)"):
+    val state  = ScrollBar.State(offset = 50, visible = 10, total = 100)
+    val target = ScrollBar.hitTest(state, length = 20, cellIndex = 0)
+    assert(target == 40, s"expected page-up to 40, got $target")
+
+  test("hitTest below the thumb returns offset + visible (page down)"):
+    val state  = ScrollBar.State(offset = 50, visible = 10, total = 100)
+    val target = ScrollBar.hitTest(state, length = 20, cellIndex = 19)
+    assert(target == 60, s"expected page-down to 60, got $target")
+
+  test("hitTest is clamped to [0, total - visible]"):
+    val low  = ScrollBar.State(offset = 0, visible = 10, total = 100)
+    val high = ScrollBar.State(offset = 90, visible = 10, total = 100)
+    assert(ScrollBar.hitTest(low, length = 20, cellIndex = 0) == 0)
+    assert(ScrollBar.hitTest(high, length = 20, cellIndex = 19) == 90)
+
+  test("hitTest on the thumb returns the unchanged offset"):
+    val state        = ScrollBar.State(offset = 50, visible = 10, total = 100)
+    val (start, len) = ScrollBar.thumbRange(state, length = 20)
+    val mid          = start + len / 2
+    val target       = ScrollBar.hitTest(state, length = 20, cellIndex = mid)
+    assert(target == 50)
+
+  test("offsetForDrag at cell 0 returns 0"):
+    val state = ScrollBar.State(offset = 50, visible = 10, total = 100)
+    assert(ScrollBar.offsetForDrag(state, length = 20, cellIndex = 0) == 0)
+
+  test("offsetForDrag at the bottom returns the max offset"):
+    val state  = ScrollBar.State(offset = 0, visible = 10, total = 100)
+    val target = ScrollBar.offsetForDrag(state, length = 20, cellIndex = 19)
+    assert(target == 90, s"expected end-of-track to map to 90 (total-visible), got $target")
+
+  test("clampOffset clamps below zero and above max"):
+    assert(ScrollBar.clampOffset(-5, visible = 10, total = 100) == 0)
+    assert(ScrollBar.clampOffset(200, visible = 10, total = 100) == 90)
+
+  test("State.clamped clamps the offset field"):
+    val s = ScrollBar.State(offset = 200, visible = 10, total = 100).clamped
+    assert(s.offset == 90)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SeparatorSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SeparatorSpec.scala
@@ -1,0 +1,50 @@
+package termflow.tui.widgets
+
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.tui.*
+
+class SeparatorSpec extends AnyFunSuite:
+
+  given Theme = Theme.dark
+
+  private def textOf(node: VNode): String = node match
+    case t: TextNode => t.txt.map(_.txt).mkString
+    case _           => ""
+
+  test("horizontal renders one TextNode width cells long"):
+    val nodes = Separator.horizontal(width = 10)
+    assert(nodes.size == 1)
+    val s = textOf(nodes.head)
+    assert(s.length == 10, s"expected 10 cells, got '${s}'")
+
+  test("horizontal with non-positive width yields no nodes"):
+    assert(Separator.horizontal(width = 0).isEmpty)
+    assert(Separator.horizontal(width = -3).isEmpty)
+
+  test("horizontal embeds a centred title with ' Title ' padding"):
+    val nodes = Separator.horizontal(width = 20, title = "Header")
+    val s     = textOf(nodes.head)
+    assert(s.length == 20)
+    assert(s.contains(" Header "))
+    // Centred — one or two leader cells before " Header " on either side.
+    val titleIdx = s.indexOf(" Header ")
+    val trailer  = s.length - titleIdx - " Header ".length
+    assert(math.abs(titleIdx - trailer) <= 1)
+
+  test("horizontal drops the title when there isn't room for leader + trailer"):
+    // " Header " = 8 cells, +2 for one cell of leader and trailer = 10, so 9 too narrow.
+    val nodes = Separator.horizontal(width = 9, title = "Header")
+    val s     = textOf(nodes.head)
+    assert(!s.contains("Header"))
+    assert(s.length == 9)
+
+  test("vertical emits one TextNode per row"):
+    val nodes = Separator.vertical(height = 5)
+    assert(nodes.size == 5)
+    nodes.zipWithIndex.foreach { case (n, i) =>
+      assert(n.y.value == 1 + i, s"row $i should be at y=${1 + i}, got ${n.y.value}")
+    }
+
+  test("vertical with non-positive height yields no nodes"):
+    assert(Separator.vertical(height = 0).isEmpty)
+    assert(Separator.vertical(height = -2).isEmpty)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
@@ -70,3 +70,75 @@ class SplitPaneSpec extends AnyFunSuite:
     val nodes = SplitPane((_, _, _) => List(n1), (_, _, _) => List(n2), width = 6, height = 1)
     assert(nodes == List(n1, n2))
   }
+
+  // ---- handleMouse (drag-to-resize) ---------------------------------------
+
+  private def mods = KeyDecoder.Modifiers(false, false, false)
+
+  test("Press on the divider arms the drag") {
+    val state = SplitPane.DragState.at(0.5)
+    val l     = SplitPane.layout(SplitPane.Direction.Horizontal, width = 20, height = 5, splitRatio = 0.5, gap = 1)
+    val d     = l.divider.get
+    val ev    = MouseEvent.Press(MouseButton.Left, d.at.x.value, d.at.y.value, mods)
+    val next  = SplitPane.handleMouse(state, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    assert(next.dragging, "press on the divider should arm the drag")
+  }
+
+  test("Press outside the divider does nothing") {
+    val state = SplitPane.DragState.at(0.5)
+    val ev    = MouseEvent.Press(MouseButton.Left, 1, 1, mods)
+    val next  = SplitPane.handleMouse(state, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    assert(!next.dragging)
+    assert(next.splitRatio == 0.5)
+  }
+
+  test("Drag while armed updates splitRatio based on column position") {
+    val armed = SplitPane.DragState(0.5, dragging = true)
+    val ev    = MouseEvent.Drag(MouseButton.Left, col = 15, row = 3, mods)
+    val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    // 15 / 20 = 0.75
+    assert(math.abs(next.splitRatio - 0.75) < 1e-6, s"expected ~0.75, got ${next.splitRatio}")
+    assert(next.dragging, "still dragging")
+  }
+
+  test("Release ends the drag and snaps to the cursor's ratio") {
+    val armed = SplitPane.DragState(0.5, dragging = true)
+    val ev    = MouseEvent.Release(MouseButton.Left, col = 5, row = 3, mods)
+    val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    assert(!next.dragging, "release ends the drag")
+    // 5 / 20 = 0.25
+    assert(math.abs(next.splitRatio - 0.25) < 1e-6, s"expected 0.25, got ${next.splitRatio}")
+  }
+
+  test("Release outside the region keeps the previous ratio (no snap-back)") {
+    val armed = SplitPane.DragState(0.4, dragging = true)
+    val ev    = MouseEvent.Release(MouseButton.Left, col = 200, row = 200, mods)
+    val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    assert(!next.dragging)
+    assert(next.splitRatio == 0.4)
+  }
+
+  test("handleMouse does nothing when gap < 1 (no divider to pick)") {
+    val state = SplitPane.DragState.at(0.5)
+    val ev    = MouseEvent.Press(MouseButton.Left, 10, 3, mods)
+    val next  = SplitPane.handleMouse(state, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 0)
+    assert(next == state)
+  }
+
+  test("Drag clamps to MinSizeRatio so panes can't collapse") {
+    val armed = SplitPane.DragState(0.5, dragging = true)
+    val drag0 = MouseEvent.Drag(MouseButton.Left, col = 1, row = 3, mods)
+    val next0 = SplitPane.handleMouse(armed, drag0, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    // While dragging, ratio is the raw cursor ratio — clamp happens on Release.
+    val release0 = MouseEvent.Release(MouseButton.Left, col = 1, row = 3, mods)
+    val final0   = SplitPane.handleMouse(next0, release0, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
+    assert(final0.splitRatio >= SplitPane.MinSizeRatio)
+  }
+
+  test("Vertical split uses row position for the ratio") {
+    val armed = SplitPane.DragState(0.5, dragging = true)
+    val ev    = MouseEvent.Drag(MouseButton.Left, col = 5, row = 8, mods)
+    val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Vertical, 10, 16, gap = 1)
+    // 8 / 16 = 0.5 — but cursor inside the region from the top.
+    assert(math.abs(next.splitRatio - 0.5) < 1e-6, s"expected ~0.5, got ${next.splitRatio}")
+  }

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/TreeSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/TreeSpec.scala
@@ -67,7 +67,7 @@ class TreeSpec extends AnyFunSuite:
 
   // ---- apply --------------------------------------------------------------
 
-  test("apply renders one row per visible node with the right indentation + chevron") {
+  test("apply renders one row per visible node with the right indentation + glyph") {
     val nodes = Tree(
       roots = sampleTree,
       expanded = Set("src"),
@@ -75,13 +75,15 @@ class TreeSpec extends AnyFunSuite:
       render = (_: Node).name
     )
     val texts = textsOf(nodes)
-    assert(texts(0) == "▾ src")
-    assert(texts(1) == "    Main.scala", s"expected leaf indented + leaf glyph, got: '${texts(1)}'")
-    assert(texts(2) == "  ▸ util")
-    assert(texts(3) == "  README.md")
+    // `[-] ` for expanded internal, `[+] ` for collapsed, four spaces for leaves.
+    assert(texts(0) == "[-] src")
+    assert(texts(1) == "      Main.scala", s"expected depth-1 leaf indented + glyph, got: '${texts(1)}'")
+    assert(texts(2) == "  [+] util")
+    // README.md is at depth 0 — no per-depth pad, just the 4-cell leaf glyph.
+    assert(texts(3) == "    README.md")
   }
 
-  test("ASCII fallback uses v / > / `  ` markers") {
+  test("unicode flag is ignored — glyphs are now ASCII by default") {
     val nodes = Tree(
       roots = sampleTree,
       expanded = Set("src"),
@@ -90,8 +92,8 @@ class TreeSpec extends AnyFunSuite:
       unicode = false
     )
     val texts = textsOf(nodes)
-    assert(texts(0).startsWith("v src"))
-    assert(texts(2).contains("> util"), s"got: '${texts(2)}'")
+    assert(texts(0).startsWith("[-] src"))
+    assert(texts(2).contains("[+] util"), s"got: '${texts(2)}'")
   }
 
   test("selectedIndex highlights exactly one row in the theme primary slot") {
@@ -152,6 +154,40 @@ class TreeSpec extends AnyFunSuite:
   // ---- companions ---------------------------------------------------------
 
   test("Tree.rowWidth = depth*indent + marker + label") {
-    assert(Tree.rowWidth("name", depth = 0) == 0 + 2 + 4)
-    assert(Tree.rowWidth("name", depth = 2, indentWidth = 4) == 8 + 2 + 4)
+    // Marker is now 4 cells wide (`[+] ` / `[-] ` / four spaces).
+    assert(Tree.rowWidth("name", depth = 0) == 0 + 4 + 4)
+    assert(Tree.rowWidth("name", depth = 2, indentWidth = 4) == 8 + 4 + 4)
+  }
+
+  // ---- hitTest ------------------------------------------------------------
+
+  test("hitTest returns Chevron for a click on the [+] / [-] glyph cells") {
+    val rows = Tree.visibleRows(sampleTree, Set("src"))
+    // First row at (1,1) — chevron occupies cols 1..4. Try col 2.
+    val r = Tree.hitTest(rows, at = Coord(1.x, 1.y), indentWidth = 2, col = 2, row = 1)
+    assert(r.contains(Tree.HitResult.Chevron(0)), s"got $r")
+  }
+
+  test("hitTest returns Label for a click past the chevron") {
+    val rows = Tree.visibleRows(sampleTree, Set("src"))
+    // First row label starts at col 5 ("[-] " is 4 cells from col 1).
+    val r = Tree.hitTest(rows, at = Coord(1.x, 1.y), indentWidth = 2, col = 6, row = 1, labelLength = 30)
+    assert(r.contains(Tree.HitResult.Label(0)), s"got $r")
+  }
+
+  test("hitTest returns None for clicks outside any row") {
+    val rows = Tree.visibleRows(sampleTree, Set("src"))
+    val r    = Tree.hitTest(rows, at = Coord(1.x, 1.y), indentWidth = 2, col = 2, row = 99)
+    assert(r.isEmpty)
+  }
+
+  test("hitTest treats leaves as Label-only — no Chevron region") {
+    val rows = Tree.visibleRows(sampleTree, Set("src"))
+    // Row 1 = "Main.scala" leaf at depth 1; chevron region is empty.
+    val rChevron = Tree.hitTest(rows, at = Coord(1.x, 1.y), indentWidth = 2, col = 4, row = 2)
+    // Col 4 sits inside the leading padding of the leaf row, before the
+    // label column begins — so neither Chevron nor Label fires.
+    assert(rChevron.isEmpty || rChevron.exists(_.isInstanceOf[Tree.HitResult.Label]))
+    val rLabel = Tree.hitTest(rows, at = Coord(1.x, 1.y), indentWidth = 2, col = 8, row = 2, labelLength = 30)
+    assert(rLabel.contains(Tree.HitResult.Label(1)), s"got $rLabel")
   }


### PR DESCRIPTION
## Summary

Closes the remaining Stage 3 leftovers from `docs/ROADMAP.md` and fixes a string of UX issues turned up by eyeballing the showcase.

### Stage 3 components (§6.1 / §6.2 / §5.1 / §5.3)

- **§6.1 `Dialogs.actionList`** — vertical menu of `Choice` actions; auto-sized; no OK/Cancel row.
- **§6.2 widgets** — `Separator` (horizontal/vertical rule + optional centred title), `ScrollBar` (proportional thumb + `hitTest` / `offsetForDrag` helpers), `MultiLineInput` (multi-line editor with grapheme-aware nav + TextField-style reverse-video caret), and `SplitPane.handleMouse` + `DragState` for mouse-driven divider resize.
- **§5.1 hit-test cache** — `HitTest[Id]` + `Rect` + `Layout.Zone(id, content)` + `Layout.resolveTracked[Id]`. Apps map a click coord to a logical zone without re-deriving rectangles.
- **§5.3 grapheme + column cursor** — `Prompt.{Backspace, Delete, ArrowLeft, ArrowRight}` step by Unicode UAX #29 grapheme boundaries (via `BreakIterator`, exposed as a `Grapheme` helper); `AnsiRenderer.visibleInput` positions the hardware cursor by display column, not character count.

### Showcase wiring

| Component | Where | Key |
|---|---|---|
| `Dialogs.actionList` | Showcase tab | `a` |
| `widgets.Separator` | Help tab section rules | — |
| `widgets.ScrollBar` | Data tab next to ListView | — |
| `widgets.SplitPane.handleMouse` | Layout tab | drag divider |
| `widgets.MultiLineInput` | New `9 Editor` tab | type |
| `HitTest` registry | actionList dialog row clicks | click |
| Grapheme + column cursor | Editor tab + textInput dialog | wide-char input |

### Bug fixes (eyeballed in the showcase)

- **`InputKey.Tab` decoder** — ASCII 9 was decoded as `Ctrl('I')`, so every focus dispatcher's `CharKey('\t')` matcher silently failed in real terminals (only tests hand-constructing the value worked). New `InputKey.Tab`; decoder special-cases `9 => Tab` (mirrors `10|13 => Enter`); every dispatcher and `KeySim` updated.
- **Layout tab `[ / ]` confusion** — help footer rendered "[ / ]" which parses as three keys; `/` had no handler. Added `=` and `/` reset shortcuts, rewrote help text as "[ shrink, ] grow, = reset".
- **TextField placeholder vs input** — placeholders rendered in the same style as user input so wizard / form users couldn't tell sample values weren't real. Now dimmed + italic + secondary fg.
- **Tree widget** — `▾`/`▸` chevrons replaced with `[+] ` / `[-] ` glyphs (clear click targets, font/locale-proof). Added `Tree.HitResult` + `Tree.hitTest` companion mapping clicks to chevron-vs-label regions. Showcase Widgets tab wires mouse clicks + scroll wheel.
- **Autocomplete scroll + focus** — dropdown silently truncated past `maxVisible`. Added a viewport offset that keeps the cursor visible. Added a `focused` view param; when blurred, the selected row drops the bg bar so a static field doesn't compete visually with whichever widget actually owns focus.
- **Wizard Plan radio** — Enter on the radio did nothing. Now commits + jumps focus straight to the Next button.
- **Editor tab keyboard exit** — every key including digits flowed into the editor, so `1..9` tab-switch was unreachable. Esc now switches back to the Showcase tab.

### Tests

~80 new specs across `DialogsSpec`, `PromptSpec`, `HitTestSpec`, `GraphemeSpec`, `MultiLineInputSpec`, `ScrollBarSpec`, `SeparatorSpec`, `SplitPaneSpec`, `TreeSpec`, `AutocompleteSpec`, `Stage1ShowcaseAppSpec`, `WizardAppSpec`, `KeyDecoderSpec`, `KeySimSpec`. Full suite ~1020 tests across 6 modules. `sbt ciCheck` clean.

### Roadmap

§6.1 / §6.2 marked complete; §5.1 / §5.3 status notes updated; decision-log entry records the cursor-rendering choice (TextField-style reverse cell vs `InputNode`) and the hit-test-id-at-call-site design.

## Test plan

- [x] `sbt ciCheck` passes
- [ ] Run `sbt showcase` and exercise each tab:
  - **1 Showcase** — `a` opens actionList; click rows selects via HitTest; `b`/`t` cycle border/theme
  - **2 Widgets** — click `[+]`/`[-]` toggles, click label selects, scroll wheel moves
  - **3 Inputs** — Tab/Shift+Tab cycles focus; placeholder renders dimmed; Autocomplete scrolls past 5 items
  - **4 Data** — ListView selection drives the ScrollBar
  - **5 Layout** — `[`/`]` shrink/grow, `=` resets, drag divider with mouse
  - **6 Wizard** — Tab focus works; on Plan step, Enter commits + advances to Next
  - **9 Editor** — type CJK + emoji, Backspace deletes by grapheme, Esc returns to Showcase