### PR TITLE
docs: tutorials 02–04 (Stage 4 §7.2 Phase B)

### DIFF
--- a/docs/tut/02-counter.md
+++ b/docs/tut/02-counter.md
@@ -1,14 +1,305 @@
 # Counter
 
-> *Stub — full content lands in Phase B of the docs roll-out.*
+The Hello World tutorial showed the four `TuiApp` methods. This tutorial
+takes the next step: a model that **changes over time** in response to
+input. By the end you'll have a counter you can drive with keystrokes
+and with a typed prompt.
 
-This tutorial will walk through `termflow.apps.counter.SyncCounter`, the
-canonical "model + update + view" demo. The headline points it covers:
+The full source lives at
+[`termflow.apps.counter.SyncCounter`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/counter/SyncCounter.scala)
+in the sample module — launch with `sbt counterDemo` if you want to see
+the finished version first.
 
-- Pattern-matching multiple `Msg` cases in `update`.
-- Building a `Layout.Column` and resolving it at a coordinate.
-- Reading a styled `Prompt` so users can type `increment` / `decrement`.
+## What you'll build
 
-In the meantime, the source lives at
-[`modules/termflow-sample/src/main/scala/termflow/apps/counter/SyncCounter.scala`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/counter/SyncCounter.scala)
-— launch with `sbt counterDemo` to see it run.
+A small panel showing:
+
+```text
+┌──────────────────────────────────────┐
+│ Current count: 3                     │
+│                                      │
+│ Commands:                            │
+│   increment | + -> increase counter  │
+│   decrement | - -> decrease counter  │
+│   exit          -> quit              │
+└──────────────────────────────────────┘
+[]> _
+```
+
+Type `increment` (or `+`) at the prompt, hit Enter, the count goes up.
+`decrement` / `-` decreases. `exit` quits.
+
+## 1. Model the domain
+
+We want the count to live in its own type so the rest of the app can
+treat it as opaque. An opaque type alias is perfect:
+
+```scala
+opaque type Counter = Int
+
+object Counter:
+  def apply(count: Int): Counter = count
+
+  extension (c: Counter)
+    def count: Int                   = c
+    def syncIncrement(): Counter     = Counter(c.count + 1)
+    def syncDecrement(): Counter     = Counter(c.count - 1)
+```
+
+The application model wraps the counter together with the runtime bits
+we need to keep alive — the keyboard subscription, the prompt state,
+and the latest known terminal size:
+
+```scala
+final case class Model(
+  terminalWidth: Int,
+  terminalHeight: Int,
+  counter: Counter,
+  input: Sub[Msg],
+  prompt: Prompt.State
+)
+```
+
+`Sub[Msg]` and `Prompt.State` are stored on the model on purpose:
+
+- The `Sub` keeps the keyboard pump alive for the lifetime of the app
+  and gives the runtime something to cancel on exit.
+- `Prompt.State` is the typed-but-not-yet-submitted buffer plus its
+  cursor — every keystroke is funnelled through `Prompt.handleKey` and
+  the new state is stored back on the model.
+
+## 2. Define the message vocabulary
+
+```scala
+enum Msg:
+  case Increment
+  case Decrement
+  case Exit
+  case ConsoleInputKey(key: KeyDecoder.InputKey)
+  case ConsoleInputError(error: Throwable)
+```
+
+Two interesting things compared to Hello World:
+
+- **Domain messages and infra messages live in the same enum.**
+  `Increment` / `Decrement` / `Exit` are what your domain cares about;
+  `ConsoleInputKey` is a low-level key event the runtime delivers.
+  Keeping both in the same `Msg` keeps `update` total — the compiler
+  enforces that every event has a handler.
+- **Errors get a Msg too.** `Sub.InputKey` accepts an `onError`
+  callback; mapping errors into a regular `Msg` means `update` decides
+  what to do (here: silently ignore).
+
+## 3. Wire up `init`
+
+```scala
+override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  Model(
+    terminalWidth  = ctx.terminal.width,
+    terminalHeight = ctx.terminal.height,
+    counter        = Counter(0),
+    input          = Sub.InputKey(
+                       msg     = ConsoleInputKey.apply,
+                       onError = ConsoleInputError.apply,
+                       ctx     = ctx
+                     ),
+    prompt         = Prompt.State()
+  ).tui
+```
+
+`Sub.InputKey` constructor signatures take `msg: KeyDecoder.InputKey =>
+Msg` and `onError: Throwable => Msg`. We can pass `ConsoleInputKey.apply`
+and `ConsoleInputError.apply` directly — Scala 3 happily eta-expands the
+case-class constructors into functions of the right shape.
+
+The third argument, `ctx`, is the `RuntimeCtx[Msg]` — by passing it
+here, the subscription **auto-registers** with the runtime, so we don't
+need a `Cmd.RegisterSub`.
+
+## 4. The shape of `update`
+
+`update` is the only place state changes. With domain plus infra
+messages it becomes a five-arm pattern match:
+
+```scala
+override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  val sized = syncTerminalSize(m, ctx)
+  msg match
+    case Increment =>
+      sized.copy(counter = sized.counter.syncIncrement()).tui
+    case Decrement =>
+      sized.copy(counter = sized.counter.syncDecrement()).tui
+    case Exit =>
+      Tui(sized, Cmd.Exit)
+    case ConsoleInputKey(k) =>
+      val (nextPrompt, maybeCmd) = Prompt.handleKey[Msg](sized.prompt, k)(toMsg)
+      maybeCmd match
+        case Some(cmd) => Tui(sized.copy(prompt = nextPrompt), cmd)
+        case None      => sized.copy(prompt = nextPrompt).tui
+    case ConsoleInputError(_) => sized.tui
+```
+
+Walk through it:
+
+- **`syncTerminalSize`** is a tiny helper that re-reads the terminal
+  size from `ctx.terminal` and updates the model if it changed. We do
+  this on every message, not just resize events — the cost is negligible
+  and it catches the "terminal resized while no key was pressed" case.
+- **`Increment` / `Decrement`** call into `Counter` and use the `.tui`
+  extension to lift the new model into a `Tui[Model, Msg]` with no
+  follow-up command.
+- **`Exit`** pairs the model with `Cmd.Exit`, which tells the runtime to
+  break out of the loop.
+- **`ConsoleInputKey(k)`** delegates to `Prompt.handleKey`. The Prompt
+  widget owns the cursor, history, paste, and everything else a real
+  text input needs. It returns the next state plus an optional `Cmd`
+  produced when the user pressed Enter — that's where `toMsg` runs.
+
+## 5. Prompts and `toMsg`
+
+`Prompt.handleKey` calls `toMsg(input: PromptLine)` whenever the user
+presses Enter. The Prompt-widget API is "give me a function from a
+submitted line to either an error or a Msg":
+
+```scala
+override def toMsg(input: PromptLine): Result[Msg] =
+  Try {
+    input.value.trim.toLowerCase match
+      case "increment" | "+" => Increment
+      case "decrement" | "-" => Decrement
+      case "exit"            => Exit
+  }.toEither.left.map(e => TermFlowError.Unexpected(e.getMessage))
+```
+
+`Result[A]` is `Either[TermFlowError, A]`. The `Try { … }.toEither` form
+turns `MatchError` into a `Left` so a typo in the prompt surfaces a
+validation message instead of crashing the runtime.
+
+> If you want richer parsing — multiple commands, arguments, history —
+> the Cookbook covers that. For a counter, three branches and a
+> fall-through is plenty.
+
+## 6. Drawing the panel with `Layout.Column`
+
+Hand-positioning every `TextNode` doesn't scale beyond a few rows.
+`Layout` lets you describe a vertical (or horizontal) stack and resolve
+it to a list of children at a given coordinate:
+
+```scala
+val textColumn = Layout.Column(
+  gap = 0,
+  children = List(
+    Layout.Elem(
+      TextNode(
+        1.x, 1.y,
+        List(
+          "Current count: ".text,
+          Text(s"${m.counter.count}", renderCount(m.counter.count))
+        )
+      )
+    ),
+    Layout.Spacer(1, 1),
+    Layout.Elem(TextNode(1.x, 1.y, List("Commands:".text(fg = Yellow)))),
+    Layout.Elem(TextNode(1.x, 1.y, List("  increment | + -> increase counter".text))),
+    Layout.Elem(TextNode(1.x, 1.y, List("  decrement | - -> decrease counter".text))),
+    Layout.Elem(TextNode(1.x, 1.y, List("  exit          -> quit".text)))
+  )
+)
+val textChildren = textColumn.resolve(Coord(2.x, 2.y))
+```
+
+Notes:
+
+- `Layout.Elem` wraps a `VNode` so it lives in the layout tree.
+- `Layout.Spacer(1, 1)` is a one-row vertical gap.
+- The `(1.x, 1.y)` coordinates inside each `TextNode` are
+  **layout-local** — the `resolve(Coord(2.x, 2.y))` call adds the
+  column's origin so everything ends up in the right absolute spot.
+- Style your text using the `.text` extension (`"foo".text(fg = Yellow)`)
+  or build a `Text(string, style)` directly when you need different
+  styles in one row.
+
+## 7. Putting `view` together
+
+```scala
+override def view(m: Model): RootNode =
+  val prefix         = "[]> "
+  val renderedPrompt = Prompt.renderWithPrefix(m.prompt, prefix)
+  val boxWidth       = math.max(2, m.terminalWidth - 4)
+
+  // … textColumn defined above …
+  val textChildren = textColumn.resolve(Coord(2.x, 2.y))
+
+  val border = BoxNode(
+    1.x, 1.y, boxWidth, 6,
+    children = Nil,
+    style    = Style(border = true, fg = Blue)
+  )
+
+  RootNode(
+    m.terminalWidth,
+    13,
+    children = border :: textChildren,
+    input = Some(
+      InputNode(
+        2.x, 10.y,
+        renderedPrompt.text,
+        Style(fg = Green),
+        cursor       = renderedPrompt.cursorIndex,
+        prefixLength = renderedPrompt.prefixLength
+      )
+    )
+  )
+```
+
+A few things to call out:
+
+- **`BoxNode` is visual-only.** It draws a border but doesn't lay out
+  its children. We keep it as a sibling of the resolved column rather
+  than wrapping it.
+- **Box width tracks the terminal.** `boxWidth = terminalWidth - 4` plus
+  the resize sync from `update` means the panel grows and shrinks with
+  the window.
+- **`InputNode` is the prompt.** It carries the rendered prefix + buffer
+  text, the cursor index, and the prefix length so `AnsiRenderer` can
+  position the hardware cursor correctly. `Prompt.renderWithPrefix`
+  returns all three in one shot.
+- **`renderCount(c)`** is a tiny styling helper that picks a colour
+  based on sign — black for zero, red for negative, green for positive.
+  Live styling like that is one of the wins of having `view` be a pure
+  function of the model.
+
+## 8. Wiring it up
+
+Same as Hello World:
+
+```scala
+def main(args: Array[String]): Unit =
+  val _ = args
+  TuiRuntime.run(App)
+```
+
+Run it:
+
+```bash
+sbt counterDemo
+```
+
+You can also drive the same logic from `update` keystrokes if you'd
+rather not type commands. That extension is left as an exercise — the
+cookbook covers it.
+
+## What you've learned
+
+- **State that changes over time.** `update` is a pattern match on
+  `Msg` returning the next model.
+- **Layout DSL.** `Layout.Column` + `resolve(at)` beats hand-positioning
+  every node.
+- **Prompts.** `Prompt.handleKey` turns key events into either a new
+  buffer or a Submit-time `Cmd` driven by `toMsg`.
+- **Adaptive sizing.** `syncTerminalSize` keeps `view` honest when the
+  user resizes their window.
+
+Next up: [Async work](03-async.md) — replacing the synchronous counter
+with a `Cmd.FCmd` that does work on a background thread, plus a spinner
+driven by `Sub.Every`.

--- a/docs/tut/03-async.md
+++ b/docs/tut/03-async.md
@@ -1,17 +1,304 @@
 # Async work
 
-> *Stub — full content lands in Phase B of the docs roll-out.*
+The Counter tutorial built a synchronous counter — `Increment` ran inline
+on the runtime thread. Real apps rarely have that luxury: HTTP calls, LLM
+streams, file I/O, and database queries all need to happen *off* the
+event loop while the UI keeps drawing.
 
-This tutorial will cover `Cmd.FCmd` and `Sub.Every`, building on
-[`termflow.apps.counter.FutureCounter`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/counter/FutureCounter.scala)
-— a counter where increment/decrement are asynchronous and a spinner
-keeps drawing while the work is in flight.
+This tutorial swaps the synchronous counter for an asynchronous one and
+shows three patterns:
 
-Headline points it will cover:
+1. **`Cmd.FCmd`** — bridge a `Future` into the runtime so its result
+   shows up as a `Msg`.
+2. **`Sub.Every`** — fire a recurring `Msg` on a fixed cadence, which
+   we'll use to animate a spinner while async work is in flight.
+3. **Subscription lifecycle** — start a sub when work begins, cancel it
+   when work ends.
 
-- Returning `Cmd.FCmd[A, Msg]` from `update` to fire async work.
-- Wrapping the result back into a `Msg` so `update` stays pure.
-- Using `Sub.Every` to drive a spinner on a fixed cadence.
-- Cancelling subscriptions cleanly on `Cmd.Exit`.
+Source: [`termflow.apps.counter.FutureCounter`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/counter/FutureCounter.scala).
+Run with `sbt futureDemo`.
 
-For now, run it with `sbt futureDemo`.
+## What you'll build
+
+```text
+┌──────────────────────────────────────┐
+│ Current count: 2                     │
+│ incrementing::14:22:07 /             │
+│                                      │
+│ Commands:                            │
+│   increment | + -> increase counter  │
+│   decrement | - -> decrease counter  │
+│   exit          -> quit              │
+└──────────────────────────────────────┘
+[]> _
+```
+
+The `/` rotates through `| / - \` while the async work runs (~5 seconds
+for increment, ~10 for decrement). Once the work completes, the spinner
+disappears and the count updates.
+
+## 1. Two `Counter` shapes
+
+The domain stays minimal — same `Counter` opaque type, with async
+variants alongside the sync ones:
+
+```scala
+opaque type Counter = Int
+
+object Counter:
+  def apply(count: Int): Counter = count
+
+  extension (c: Counter)
+    def count: Int = c
+
+    def asyncIncrement()(using ec: ExecutionContext): Future[Counter] =
+      Future:
+        Thread.sleep(5000)
+        Counter(c.count + 1)
+
+    def asyncDecrement()(using ec: ExecutionContext): Future[Counter] =
+      Future:
+        Thread.sleep(10000)
+        Counter(c.count - 1)
+```
+
+`Future` is a stand-in for "any async work". In a real app it would be
+an HTTP call or a database round-trip, not `Thread.sleep`.
+
+## 2. A richer model
+
+The model carries everything Counter had, plus enough state to drive a
+spinner:
+
+```scala
+final case class Model(
+  terminalWidth: Int,
+  terminalHeight: Int,
+  count: Counter,
+  status: String,         // human-readable status line
+  input: Sub[Msg],        // keyboard subscription
+  prompt: Prompt.State,
+  spinner: Sub[Msg],      // timer subscription — Sub.NoSub when idle
+  spinnerIndex: Int       // current frame of the spinner animation
+)
+```
+
+Two new fields worth highlighting:
+
+- **`status: String`** is the line under the count. We'll write
+  `"incrementing::14:22:07"` while work is in flight,
+  `"done::14:22:12"` when it completes. Useful for both humans and for
+  asserting in tests.
+- **`spinner: Sub[Msg]`** is *the* live timer subscription. When idle
+  it's `Sub.NoSub` — a no-op sub. When async work starts we replace it
+  with `Sub.Every(200ms, …)`. When the work finishes we call
+  `spinner.cancel()`.
+
+## 3. Five new messages
+
+```scala
+enum Msg:
+  case Increment
+  case Decrement
+  case Exit
+  case UpdateWith(counter: Counter)
+  case Busy(action: String)
+  case SpinnerTick
+  case ConsoleInputKey(key: KeyDecoder.InputKey)
+  case ConsoleInputError(error: Throwable)
+```
+
+Compared to Counter:
+
+- **`Increment` / `Decrement`** no longer carry the state change inline
+  — they just *kick off* the async work.
+- **`UpdateWith(c)`** is the message produced when the `Future`
+  completes with a new counter value.
+- **`Busy(action)`** is dispatched the moment work is enqueued so the
+  UI can flip into "working" mode immediately, not after the future
+  completes.
+- **`SpinnerTick`** is the Msg the timer fires on every tick.
+
+The split between `Increment` / `Busy` / `UpdateWith` is the
+**bracketing pattern** that comes up over and over in async TUIs:
+
+```text
+Increment ─▶ FCmd kicks off Future + dispatches Busy
+                                          │
+                                          ▼
+                                    Busy ─▶ start spinner
+                                              │
+                                              ▼
+                                       SpinnerTick × N
+                                              │
+                                              ▼
+                                  UpdateWith ─▶ stop spinner
+```
+
+## 4. `Cmd.FCmd` — bridging `Future` into the runtime
+
+Inside `update`, the `Increment` arm returns this:
+
+```scala
+case Increment =>
+  Tui(
+    sized,
+    Cmd.FCmd(
+      sized.count.asyncIncrement(),
+      (c: Counter) => Cmd.GCmd(UpdateWith(c)),
+      onEnqueue = Some(Busy(s"incrementing::${TimeFormatter.getCurrentTime}"))
+    )
+  )
+```
+
+`Cmd.FCmd` takes three things:
+
+| Parameter | What |
+|---|---|
+| `task` | The `Future[A]` you want the runtime to await. |
+| `onComplete` | A function from the future's result to the next `Cmd`. |
+| `onEnqueue` | An optional `Msg` to dispatch *immediately* when the FCmd is enqueued — before the future completes. |
+
+What happens at runtime:
+
+1. `update` returns the `Tui(model, FCmd(...))`.
+2. The runtime sees the `FCmd`, registers a callback on the future, and
+   if `onEnqueue` was supplied, immediately dispatches that `Msg`.
+3. When the future completes (after ~5 seconds here),
+   `onComplete(result)` runs and the resulting `Cmd` (here
+   `Cmd.GCmd(UpdateWith(c))`) is enqueued.
+
+The result: `Busy("incrementing::...")` arrives within microseconds of
+pressing Enter, and `UpdateWith(newCount)` arrives ~5 seconds later.
+
+> If your future could fail, use `Cmd.FCmd` together with the `Result[A]`
+> alias. The Cookbook has a recipe for the pattern.
+
+## 5. Starting a `Sub.Every`
+
+The `Busy` handler decides whether the spinner needs to start:
+
+```scala
+case Busy(action) =>
+  if sized.spinner.isActive then
+    sized.copy(status = action).tui
+  else
+    sized.copy(
+      status  = action,
+      spinner = Sub.Every(200, () => SpinnerTick, ctx)
+    ).tui
+```
+
+`Sub.Every(millis, () => Msg, ctx)` schedules a single-thread executor
+that publishes `Cmd.GCmd(SpinnerTick)` to the bus every 200 ms. The
+thunk re-evaluates each tick — useful when the message itself is
+time-stamped or counter-keyed, although here `SpinnerTick` is constant.
+
+Like `Sub.InputKey`, passing `ctx` auto-registers the sub for cleanup
+when the runtime exits — you don't have to remember to cancel it on
+`Exit` (though we will, defensively).
+
+The `spinner.isActive` guard matters. If the user fires `Increment`
+twice in quick succession, two `Busy` messages arrive. Without the
+guard you'd start two timers and leak the first one.
+
+## 6. Animating with `SpinnerTick`
+
+Each tick advances the frame index modulo the frame count:
+
+```scala
+case SpinnerTick =>
+  sized.copy(spinnerIndex = (sized.spinnerIndex + 1) % 4).tui
+```
+
+And in `view`:
+
+```scala
+private def statusWithSpinner(m: Model): String =
+  val frames = Array("|", "/", "-", "\\")
+  if m.spinner.isActive then s"${m.status} ${frames(m.spinnerIndex % frames.length)}"
+  else m.status
+```
+
+The `m.spinner.isActive` check means the spinner glyph disappears the
+instant we cancel the sub.
+
+## 7. Stopping the spinner — `Sub.cancel`
+
+When the future completes, `UpdateWith` runs:
+
+```scala
+case UpdateWith(c) =>
+  if sized.spinner.isActive then sized.spinner.cancel()
+  sized.copy(
+    count        = c,
+    status       = s"done::${TimeFormatter.getCurrentTime}",
+    spinner      = Sub.NoSub,
+    spinnerIndex = 0
+  ).tui
+```
+
+Two things happen here:
+
+- **`spinner.cancel()`** stops the executor. It's idempotent — calling
+  it on an already-cancelled sub or on `Sub.NoSub` is safe.
+- **`spinner = Sub.NoSub`** clears the model field so subsequent ticks
+  (if any are in flight) become no-ops.
+
+We also defensively cancel on `Exit`:
+
+```scala
+case Exit =>
+  if sized.spinner.isActive then sized.spinner.cancel()
+  Tui(sized, Cmd.Exit)
+```
+
+Strictly speaking the runtime would clean it up because `ctx`
+auto-registered the sub, but explicit cancellation is a safe habit —
+especially if you have multiple subs and want predictable shutdown
+order.
+
+## 8. Drawing the status line
+
+The `view` is barely changed from Counter — we just slot
+`statusWithSpinner(m)` into a new row:
+
+```scala
+TextNode(
+  2.x, 3.y,
+  List(Text(statusWithSpinner(m), Style(fg = Green)))
+)
+```
+
+One subtle point: the spinner advances at 5 frames per second
+(200 ms = 5 fps). That's deliberate — slow enough to be readable, fast
+enough to feel alive. If you push it down to 50 ms you'll notice the
+ANSI repaint flicker; if you push it up to 1 s it stops feeling
+responsive.
+
+## 9. Run it
+
+```bash
+sbt futureDemo
+```
+
+Type `increment`, hit Enter, and watch the `/` rotate for ~5 seconds
+before the count updates. Try `decrement` next — that one waits ~10
+seconds. Both can be queued back-to-back; the FCmd machinery handles
+that correctly.
+
+## What you've learned
+
+- **`Cmd.FCmd`** is the bridge from `Future[A]` to the runtime. It
+  takes the future, a result mapper to a follow-up `Cmd`, and an
+  optional immediate `Msg` to dispatch at enqueue time.
+- **`Sub.Every`** is the timer subscription. Auto-registers when given
+  a `RuntimeCtx`; cancellable explicitly via `.cancel()`.
+- **Sub fields on the model** keep async lifecycles addressable —
+  always know which subs are live, store them so you can cancel them.
+- **`Busy` / `UpdateWith` bracketing** is the standard pattern for
+  signalling "work in progress" before the work itself completes.
+
+Next up: [Forms and dialogs](04-forms-and-dialogs.md) — the Wizard
+sample with multi-step focus management, validation, and modal
+dialogs.

--- a/docs/tut/04-forms-and-dialogs.md
+++ b/docs/tut/04-forms-and-dialogs.md
@@ -1,18 +1,425 @@
 # Forms and dialogs
 
-> *Stub — full content lands in Phase B of the docs roll-out.*
+The first three tutorials covered the runtime, state transitions, and
+async work. The hard part of *real* TUI apps is everything that wraps
+those primitives: focus management, validation, multi-step navigation,
+and modal dialogs.
 
-This tutorial will cover `FocusManager`, the `Form` builder, and the
-shipped `Dialogs` helpers (confirm, textInput, listSelect, waiting,
-fileDialog, actionList), grounding everything in
+This tutorial walks through the **wizard** sample — a three-step
+account-creation flow with per-step focus, per-field validation, a
+radio-group, and a final review screen. Source:
 [`termflow.apps.wizard.WizardApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/wizard/WizardApp.scala).
+Run with `sbt wizardDemo`.
 
-Headline points:
+## What you'll build
 
-- Per-step `FocusManager` and `Tab`/`Shift+Tab` cycling.
-- Routing keystrokes by current focus (the *focus dispatch* pattern).
-- `Form.column` validation and the `errors` map.
-- Mounting a dialog as an overlay with a continuation.
-- The `Submit` button and exit flow.
+```text
+TermFlow Wizard
+●  Account  ─  ○  Plan  ─  ○  Confirm
 
-For now, run it with `sbt wizardDemo`.
+ Tab focus   Enter activate   ↑/↓ (Plan)   q quit
+
+Name:    [Alice                ]
+Email:   [alice@example.com    ]
+                                      [ Next → ]
+```
+
+Three screens — Account, Plan, Confirm — connected by Next/Back
+buttons. Tab cycles focus inside the current step; Enter activates the
+focused control; arrow keys move the radio selection on the Plan step.
+Validation errors appear inline next to fields when you try to advance
+past Account with empty inputs.
+
+## 1. The step state machine
+
+A wizard is a state machine over its steps. Model the steps as an enum
+and store the current one on the model:
+
+```scala
+enum Step:
+  case Account, Plan, Confirm
+
+val stepOrder: Vector[Step] = Vector(Step.Account, Step.Plan, Step.Confirm)
+```
+
+`stepOrder` is the canonical ordering — used both for the progress
+indicator at the top and for next/back navigation. Don't compare
+ordinals directly; query `stepOrder.indexOf(step)` so that adding a new
+step in the middle is a one-line change.
+
+## 2. Focus IDs per step
+
+Each focusable control needs a `FocusId`. Group them by step so the
+focus order on each screen is local:
+
+```scala
+// Account step
+val NameId         = FocusId("wiz-name")
+val EmailId        = FocusId("wiz-email")
+val NextAccountId  = FocusId("wiz-account-next")
+val accountFocusOrder = Vector(NameId, EmailId, NextAccountId)
+
+// Plan step
+val PlanRadioId  = FocusId("wiz-plan")
+val BackPlanId   = FocusId("wiz-plan-back")
+val NextPlanId   = FocusId("wiz-plan-next")
+val planFocusOrder = Vector(PlanRadioId, BackPlanId, NextPlanId)
+
+// Confirm step
+val BackConfirmId  = FocusId("wiz-confirm-back")
+val SubmitId       = FocusId("wiz-submit")
+val confirmFocusOrder = Vector(BackConfirmId, SubmitId)
+```
+
+Two design choices worth noting:
+
+- **`FocusId` is opaque over `String`.** You can't accidentally pass an
+  arbitrary string where a `FocusId` is wanted, but two `FocusId`s
+  built from the same string are equal — useful for testing.
+- **String prefixes scope IDs.** `wiz-` keeps the wizard's IDs from
+  colliding with other parts of the app when this gets embedded as a
+  sub-component (which is exactly what the showcase tab does).
+
+## 3. A `FocusManager` per step
+
+The model carries one `FocusManager` per step:
+
+```scala
+final case class Model(
+  step:       Step,
+  name:       widgets.TextField.State,
+  email:      widgets.TextField.State,
+  planIndex:  Int,
+  submitted:  Boolean,
+  focus:      Map[Step, FocusManager],
+  pendingKey: Option[KeyDecoder.InputKey],
+  errors:     Map[String, String]
+):
+  def currentFocus: FocusManager = focus(step)
+```
+
+Why one per step instead of one global manager?
+
+- **Stable per-screen focus.** When the user steps from Plan back to
+  Account, focus returns to whichever field they last touched, not to
+  the screen-zero default.
+- **Clean tab cycle.** Tab on the Plan screen mustn't loop through
+  Account fields. Per-step orders make this fall out naturally.
+
+The `currentFocus` helper just looks up the manager for the active
+step. Every focus-related operation in `update` calls it.
+
+## 4. Pure update via `step(model, msg)`
+
+This sample factors update into a pure `step(m, msg): Model` function
+that the embeddable showcase reuses:
+
+```scala
+def step(m: Model, msg: Msg): Model =
+  msg match
+    case NextStep    => /* validate, advance */
+    case PrevStep    => /* go back */
+    case NextFocus   => m.copy(focus = m.focus.updated(m.step, m.currentFocus.next))
+    case PrevFocus   => m.copy(focus = m.focus.updated(m.step, m.currentFocus.previous))
+    case Activate    => stepActivate(m)
+    case PlanUp      => m.copy(planIndex = math.max(0, m.planIndex - 1))
+    case PlanDown    => m.copy(planIndex = math.min(planOptions.size - 1, m.planIndex + 1))
+    case Submitted   => m.copy(submitted = true)
+    case Key(k)      => stepKey(m, k)
+    case _           => m
+```
+
+Then the runtime `update` becomes a thin shim that delegates to `step`
+for everything except quit:
+
+```scala
+override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Quit        => Tui(m, Cmd.Exit)
+    case Key(k)      => /* check quit-on-q-when-not-in-text-field, else delegate */
+    case _           => step(m, msg).tui
+```
+
+This factoring is the *embeddable wizard* pattern: the model, the
+messages, and the pure transition function are all reusable; only the
+runtime glue ties to `Cmd.Exit`. The wizard ships as a tab inside the
+showcase by reusing `step` directly.
+
+## 5. Per-step validation
+
+Validation is a pure function from `Model` to a `Map[String, String]`
+keyed by `FocusId.value`:
+
+```scala
+def validateAccount(m: Model): Map[String, String] =
+  val builder = Map.newBuilder[String, String]
+  if m.name.buffer.trim.isEmpty then
+    builder += (NameId.value -> "Name is required")
+  val emailRaw = m.email.buffer.trim
+  if emailRaw.isEmpty then
+    builder += (EmailId.value -> "Email is required")
+  else if !emailRaw.contains("@") then
+    builder += (EmailId.value -> "Email must contain '@'")
+  builder.result()
+```
+
+The keying-by-`FocusId.value` matters because `widgets.Form.column`
+takes the same map shape — error text is drawn next to the field with
+that id. No extra wiring.
+
+`NextStep` consumes the result:
+
+```scala
+case NextStep =>
+  m.step match
+    case Step.Account =>
+      val errs = validateAccount(m)
+      if errs.nonEmpty then m.copy(errors = errs)
+      else m.copy(step = Step.Plan, errors = Map.empty)
+    case Step.Plan    => m.copy(step = Step.Confirm, errors = Map.empty)
+    case Step.Confirm => m
+```
+
+The pattern is **validate-on-advance**: errors don't appear while
+typing, only when the user tries to move forward with bad data. Less
+noisy, gives the user space to think.
+
+## 6. Focus dispatch
+
+The single most important pattern in this sample:
+
+```scala
+private def stepKeyForStep(m: Model, k: KeyDecoder.InputKey): Model =
+  m.step match
+    case Step.Account =>
+      m.currentFocus.current match
+        case Some(id) if id == NameId =>
+          val (next, _) = widgets.TextField.handleKey[Msg](m.name, k)(_ => None)
+          m.copy(name = next)
+
+        case Some(id) if id == EmailId =>
+          val (next, _) = widgets.TextField.handleKey[Msg](m.email, k)(_ => None)
+          m.copy(email = next)
+
+        case Some(id) if id == NextAccountId =>
+          k match
+            case Enter | CharKey(' ') => step(m, NextStep)
+            case ArrowLeft            => step(m, PrevFocus)
+            case _                    => m
+
+        case _ => m
+    /* … other steps … */
+```
+
+A keystroke is **dispatched by current focus**:
+
+- If a `TextField` is focused, the key feeds through
+  `TextField.handleKey` and updates the corresponding field.
+- If a button is focused, the key activates it (`Enter`/`Space`) or
+  navigates focus (arrow keys).
+
+Two implementation details that matter:
+
+- **`TextField.handleKey` returns `(nextState, Option[Msg])`** — the
+  same shape as `Prompt.handleKey`. The widget owns its cursor and
+  buffer. Mapping the optional Msg through `_ => None` says "this
+  TextField never produces a Submit message" — pressing Enter inside
+  the field is just a literal character.
+- **Top-level Tab dispatch** is in `stepKey`, not here:
+  ```scala
+  k match
+    case Tab     => step(m, NextFocus)
+    case BackTab => step(m, PrevFocus)
+    case _       => stepKeyForStep(m, k)
+  ```
+  Tab is *always* focus navigation, regardless of which control owns
+  focus. It's tempting to put Tab handling inside each focus arm; one
+  central handler keeps it consistent.
+
+## 7. Quit semantics — quit-when-not-in-text-field
+
+```scala
+private def stepKey(m: Model, k: KeyDecoder.InputKey): Model =
+  val isQuitKey = k match
+    case CharKey('q') | CharKey('Q') | Escape => !m.isFocusedTextField
+    case _                                    => false
+  if isQuitKey then m
+  else /* … */
+```
+
+`q` quits — except when the user is typing into a TextField, where it's
+just the letter q. The `isFocusedTextField` helper checks the current
+focus:
+
+```scala
+def isFocusedTextField: Boolean =
+  step == Step.Account && (currentFocus.isFocused(NameId) || currentFocus.isFocused(EmailId))
+```
+
+This is one of those small details that makes a TUI feel professional.
+Without it, typing `quentin@example.com` into the Email field would
+quit the wizard halfway through.
+
+## 8. Building forms with `widgets.Form.column`
+
+The Account screen is rendered with the `Form.column` helper:
+
+```scala
+private def accountStep(m: Model)(using theme: Theme): List[VNode] =
+  val rows = Vector(
+    widgets.Form.Row(
+      NameId,
+      "Name:",
+      focused => widgets.TextField.view(m.name, lineWidth = 28, focused = focused)
+    ),
+    widgets.Form.Row(
+      EmailId,
+      "Email:",
+      focused => widgets.TextField.view(m.email, lineWidth = 28, focused = focused)
+    ),
+    widgets.Form.Row(
+      NextAccountId,
+      "",
+      focused => widgets.Button(label = "Next →", focused = focused),
+      height = 1
+    )
+  )
+  widgets.Form.column(
+    rows         = rows,
+    focusManager = m.currentFocus,
+    at           = Coord(2.x, 6.y),
+    labelWidth   = 8,
+    gap          = 1,
+    errors       = m.errors
+  )
+```
+
+Each `Form.Row` is `(focusId, label, focused => VNode)`. The
+`focused => VNode` closure is a small but powerful trick — the row
+doesn't *know* whether it owns focus until `Form.column` resolves it
+against the focus manager. That keeps focus state out of every widget's
+constructor.
+
+`Form.column` then:
+
+- Looks up `focusManager.isFocused(row.focusId)` for each row.
+- Calls `row.viewFor(focused)` to get the actual widget.
+- Stacks rows vertically with `gap` between them.
+- For each `errors.get(row.focusId.value)`, draws the error in red
+  beneath the row.
+
+## 9. The Plan step — RadioGroup
+
+```scala
+val radio = widgets.RadioGroup(
+  options       = planOptions,
+  selectedIndex = m.planIndex,
+  focusedIndex  = m.planIndex,
+  at            = Coord(4.x, 8.y)
+)
+```
+
+`RadioGroup` is a stateless renderer — you pass the option list, the
+selected index, and the focused index. State updates happen in
+`update`:
+
+```scala
+case Some(id) if id == PlanRadioId =>
+  k match
+    case ArrowUp   => step(m, PlanUp)
+    case ArrowDown => step(m, PlanDown)
+    case Enter | CharKey(' ') =>
+      // Commit the selection and skip the Back button —
+      // the user is advancing, not retreating.
+      m.copy(focus = m.focus.updated(m.step, m.currentFocus.focus(NextPlanId)))
+    case _ => m
+```
+
+The `focus(NextPlanId)` call **explicitly sets focus to a specific id**
+— equivalent to "Tab past Back, land on Next". This skips the Back
+button in the focus order because the user just committed to advance.
+A small touch that turns radio + button into a smooth one-keystroke
+flow.
+
+## 10. The Confirm step — read-only summary + Submit
+
+```scala
+private def confirmStep(m: Model)(using theme: Theme): List[VNode] =
+  val title    = TextNode(2.x, 6.y, List("Review:".themed(_.primary)))
+  val summary  = m.summary.zipWithIndex.map { case (line, i) =>
+    TextNode(4.x, (8 + i).y, List(line.text))
+  }
+  val backBtn  = widgets.Button(label = "← Back", focused = m.currentFocus.isFocused(BackConfirmId))
+  val submit   = widgets.Button(label = "Submit", focused = m.currentFocus.isFocused(SubmitId))
+  /* … plus a "✓ Submitted!" line if m.submitted … */
+```
+
+Notes:
+
+- **`m.summary`** is a tiny pure helper on `Model` that returns the
+  three review lines as `List[String]`. Keeping it on the model makes
+  it trivially testable.
+- **`Layout.translate(node, dx, dy)`** offsets a sub-node — a quick way
+  to position two buttons side-by-side on the same row.
+- **The submitted state is just a flag.** Once `Submit` runs, the
+  model's `submitted = true` and `view` adds a confirmation line. We
+  don't navigate away — the user reads "Submitted!" then presses `q`
+  to quit.
+
+## 11. Step indicator at the top
+
+```scala
+private def renderStepIndicator(m: Model)(using theme: Theme): List[Text] =
+  stepOrder.zipWithIndex.flatMap { case (s, i) =>
+    val visited = i <= m.stepIndex
+    val current = i == m.stepIndex
+    val glyph   = if visited then "●" else "○"
+    val style   =
+      if current then Style(fg = theme.primary, bold = true)
+      else if visited then Style(fg = theme.success)
+      else Style(fg = theme.foreground)
+    val sep = if i == stepOrder.size - 1 then "" else "  ─  "
+    List(Text(s"$glyph ", style), Text(stepLabel(s), style), Text(sep, Style(fg = theme.border)))
+  }.toList
+```
+
+A trio of glyph / label / separator per step, joined into a single
+`List[Text]` that goes inside one `TextNode`. The progress shape —
+filled-and-bold for the current step, filled-and-coloured for visited,
+empty for upcoming — is the kind of detail you can swap to your taste
+without touching the logic.
+
+## What you've learned
+
+- **`FocusManager` per screen** keeps tab cycles local and lets each
+  screen restore its own focus when revisited.
+- **Focus dispatch in `update`** is the central pattern — the focused
+  widget id determines how a keystroke is interpreted.
+- **`widgets.Form.column`** turns rows of `(focusId, label, viewFor)`
+  into a styled, focus-aware, error-decorated form.
+- **Validate-on-advance, not on every keystroke.** Map `FocusId.value`
+  to error strings; pass the same map to `Form.column`.
+- **Quit-when-not-in-text-field** is what makes `q` feel right.
+- **Pure `step(model, msg)`** factors the wizard so it can be embedded
+  somewhere else (the showcase) without dragging the runtime in.
+
+## Beyond the tutorial
+
+The wizard is just the start of what `widgets.Form` and the dialog
+helpers can do. Keep going:
+
+- **Modal dialogs.** `Dialogs.confirm` / `Dialogs.textInput` /
+  `Dialogs.listSelect` / `Dialogs.fileDialog` — see the
+  [showcase app](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala)'s
+  Dialogs tab for every variant.
+- **`Dialogs.actionList(title, actions, position)`** — a vertical menu
+  of `Choice` items with mouse hit-testing.
+- **Keymaps.** Replace ad-hoc pattern matches with `Keymap.focus`
+  bindings — see the [Keymap guide](../guide/keymap.md) (stub for now).
+- **Multi-line input.** `widgets.MultiLineInput` for full editor
+  embedding — see the showcase's Editor tab.
+
+That wraps the four tutorials. Heading back to the
+[user guide index](../intro/what-is-termflow.md) is a good next step,
+or jump straight into the [Widgets guide](../guide/widgets.md) for the
+full component catalogue.


### PR DESCRIPTION
## Summary

Phase B of the docs site — the tutorial ladder. Each tutorial walks
through an existing sample app rather than introducing a new one, so
the code is already exercised by \`sbt compile\` and can't drift.

- **02 Counter** — `apps.counter.SyncCounter`. Multi-arm `update`,
  `Layout.Column` + `resolve`, `Prompt.handleKey` + `toMsg`, adaptive
  sizing.
- **03 Async work** — `apps.counter.FutureCounter`. `Cmd.FCmd` bridging
  `Future` into the runtime, `Sub.Every` for the spinner, the
  `Busy`/`UpdateWith` bracketing pattern, sub lifecycle and `cancel()`.
- **04 Forms and dialogs** — `apps.wizard.WizardApp`. Per-step
  `FocusManager`, focus dispatch in `update` (the central pattern),
  validation keyed by `FocusId.value` feeding `Form.column`, the
  embeddable pure-step factoring used by the showcase, the
  quit-when-not-in-text-field idiom, and the step-indicator at the top.

Stubs from Phase A are replaced; the SUMMARY nav is unchanged.

## Stacked on #182

This PR targets `feat/docs-site-phase-a`. **Merge #182 first**, then
re-target this one to `main` — at which point the diff narrows to just
the three tutorial files. Or squash-merge in order.

## Test plan

- [x] `mdbook build` — clean (linkcheck enabled, zero broken links)
- [x] `sbt ciCheck` — green
- [ ] CI green on this PR
- [ ] After merge: tutorials render at `/tut/02-counter`, `/tut/03-async`, `/tut/04-forms-and-dialogs`