### PR TITLE
docs: layer guides + widgets/keymap/theming/testing (Stage 4 §7.2 Phase C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Scala 3 style syntax gate
         run: ./scripts/check_scala3_style.sh
 
+      - name: Widget docs coverage gate
+        run: ./scripts/check_widget_docs.sh
+
       - name: CI checks (format, scalafix, test)
         run: sbt --batch ciCheck
 

--- a/docs/guide/app-layer.md
+++ b/docs/guide/app-layer.md
@@ -1,24 +1,269 @@
 # Application layer
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`termflow-app` is the layer most apps live in. It ties the terminal
+and screen layers together with an Elm-style runtime, plus everything
+you need to build a real interactive program: focus management,
+keymaps, prompts, modal dialogs, async commands, timer subscriptions.
 
-This guide covers `termflow-app` — the runtime loop, the `TuiApp`
-contract, `Cmd`, `Sub`, `FocusManager`, and the `Dialogs` helpers.
+```scala
+libraryDependencies += "org.llm4s" %% "termflow" % "0.2.0"
+```
 
-Topics planned for this page:
+The umbrella `termflow` artefact pulls in the whole stack. Most apps
+should depend on it rather than the four modules separately.
 
-- The `TuiRuntime` driver and the `CmdBus` blocking queue.
-- The four-method `TuiApp[Model, Msg]` contract in detail.
-- The `Cmd` ADT — `NoCmd`, `Exit`, `GCmd`, `FCmd`, `TermFlowErrorCmd`.
-- Subscriptions — `Sub.InputKey`, `Sub.Every`, `Sub.TerminalResize`,
-  and the `RuntimeCtx` auto-registration pattern.
-- `FocusManager` — focus order, cycling, and explicit `focus(id)`.
-- `Dialogs` overlays — confirm, textInput, listSelect, waiting,
-  fileDialog, directoryDialog, actionList.
+## `TuiApp[Model, Msg]`
 
-This layer is what most TermFlow users build on top of. The
-[Hello, World tutorial](../tut/01-hello-world.md) is the gentlest
-introduction; the [Counter tutorial](../tut/02-counter.md) covers
-synchronous `update` patterns; the
-[Async work tutorial](../tut/03-async.md) covers `Cmd.FCmd` and
-`Sub.Every`.
+The four-method contract:
+
+```scala
+trait TuiApp[Model, Msg]:
+  def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg]
+  def update(model: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg]
+  def view(model: Model): RootNode
+  def toMsg(input: PromptLine): Result[Msg]
+```
+
+The four tutorials cover this contract end-to-end:
+[Hello, World](../tut/01-hello-world.md), [Counter](../tut/02-counter.md),
+[Async work](../tut/03-async.md), and
+[Forms and dialogs](../tut/04-forms-and-dialogs.md). This page
+catalogues the surrounding pieces.
+
+## `Tui[Model, Msg]`
+
+```scala
+final case class Tui[Model, Msg](model: Model, cmd: Cmd[Msg] = Cmd.NoCmd)
+
+extension [Model](m: Model)
+  def tui[Msg]: Tui[Model, Msg]                = Tui(m)
+  def gCmd[Msg](msg: Msg): Tui[Model, Msg]     = Tui(m, Cmd.GCmd(msg))
+```
+
+A `Tui` is a model paired with a `Cmd`. `update` returns one. The
+`.tui` and `.gCmd` extensions are the ergonomic way to construct
+them inline.
+
+## Cmd — effects
+
+```scala
+enum Cmd[+Msg]:
+  case NoCmd                                                       extends Cmd[Nothing]
+  case Exit                                                        extends Cmd[Nothing]
+  case GCmd(msg: Msg)                                              extends Cmd[Msg]
+  case FCmd[A, M](task: Future[A], toCmd: A => Cmd[M], onEnqueue: Option[M] = None) extends Cmd[M]
+  case TermFlowErrorCmd(msg: TermFlowError)                        extends Cmd[Msg]
+```
+
+| Cmd | When |
+|---|---|
+| `NoCmd` | Pure state transitions (the common case). |
+| `Exit` | Tear down the runtime, restore the terminal, return from `TuiRuntime.run`. |
+| `GCmd(msg)` | Dispatch a follow-up `Msg` through `update`. Used to chain transitions. |
+| `FCmd(task, toCmd, onEnqueue)` | Bridge a `Future[A]` into the runtime — covered in the [async tutorial](../tut/03-async.md). |
+| `TermFlowErrorCmd(err)` | Surface a `TermFlowError` to the renderer (logged, not fatal). |
+
+Plus the helper:
+
+```scala
+def Cmd.asyncResult[A, Msg](
+  task:      AsyncResult[A],
+  toCmd:     A => Cmd[Msg],
+  onEnqueue: Option[Msg] = None
+): Cmd[Msg]
+```
+
+`AsyncResult[A]` is `Future[Result[A]]`. Wrap fallible async work in
+this and the runtime will fold a `Left(err)` into a
+`TermFlowErrorCmd`.
+
+## Sub — subscriptions
+
+Subscriptions are how the outside world delivers events into
+`update`. They run on background threads and publish `Cmd`s to the
+runtime's command bus.
+
+```scala
+trait Sub[+Msg]:
+  def isActive: Boolean
+  def cancel(): Unit
+  def start(): Unit
+```
+
+The factories you use day-to-day:
+
+```scala
+Sub.Every(millis: Long, msg: () => Msg, sink: EventSink[Msg]): Sub[Msg]
+
+Sub.InputKey(
+  msg:     KeyDecoder.InputKey => Msg,
+  onError: Throwable => Msg,
+  ctx:     RuntimeCtx[Msg]
+): Sub[Msg]
+
+Sub.TerminalResize(msg: () => Msg, sink: EventSink[Msg]): Sub[Msg]
+
+val Sub.NoSub: Sub[Nothing]   // inert placeholder for model fields
+```
+
+When the third argument is a `RuntimeCtx[Msg]`, the sub
+**auto-registers** for cleanup on `Cmd.Exit`. When it's a bare
+`EventSink`, you're responsible for the lifecycle.
+
+`.cancel()` is idempotent — safe to call on `NoSub` or on an
+already-cancelled sub.
+
+## RuntimeCtx — the ambient context
+
+```scala
+trait RuntimeCtx[Msg] extends EventSink[Msg]:
+  def terminal:    TerminalBackend
+  def config:      TermFlowConfig
+  def registerSub(sub: Sub[Msg]): Sub[Msg]
+  def publish(cmd: Cmd[Msg]): Unit
+```
+
+The runtime hands a `RuntimeCtx[Msg]` to `init` and to every `update`.
+Use it to:
+
+- read `terminal.width` / `terminal.height` for adaptive layout
+- register subscriptions
+- publish commands directly (rare — usually you return a `Cmd` from
+  `update`)
+- access `config` (logging, telemetry)
+
+## TuiRuntime.run
+
+```scala
+TuiRuntime.run(app: TuiApp[Model, Msg])  // simplest form
+
+TuiRuntime.run(
+  app:             TuiApp[Model, Msg],
+  renderer:        Option[TuiRenderer]    = None,
+  terminalBackend: Option[TerminalBackend] = None,
+  config:          Option[TermFlowConfig] = None
+): Unit
+```
+
+The driver does, in order:
+
+1. Open the terminal (alternate buffer, hide cursor, raw mode).
+2. Set up the `CmdBus` queue.
+3. Run `init`.
+4. Loop: drain the bus, run `update` per message, run `view`,
+   diff-render to ANSI, sleep up to ~60 fps.
+5. On `Cmd.Exit`: cancel subs, restore terminal, return.
+
+Pass a custom `TerminalBackend` for tests (the testkit's
+`TestTerminalBackend` is what `TuiTestDriver` uses).
+
+> Files: `Tui.scala`, `Sub.scala`, `TuiRuntime.scala`.
+
+## FocusManager
+
+```scala
+opaque type FocusId = String
+
+object FocusId:
+  def apply(s: String): FocusId
+  extension (id: FocusId) def value: String
+
+final case class FocusManager(ids: Vector[FocusId], current: Option[FocusId]):
+  def isFocused(id: FocusId):    Boolean
+  def next:                      FocusManager
+  def previous:                  FocusManager
+  def focus(id: FocusId):        FocusManager
+  def clear:                     FocusManager
+  def withIds(newIds: Vector[FocusId]): FocusManager
+```
+
+Pure value, immutable transitions, wraps at either end. Construct via
+`FocusManager(Vector(NameId, EmailId))` — the first id becomes the
+initial focus.
+
+The forms tutorial shows the full pattern:
+[per-step `FocusManager`s](../tut/04-forms-and-dialogs.md#3-a-focusmanager-per-step),
+[focus dispatch](../tut/04-forms-and-dialogs.md#6-focus-dispatch),
+[explicit `focus(id)`](../tut/04-forms-and-dialogs.md#9-the-plan-step--radiogroup).
+
+> File: `FocusManager.scala`.
+
+## Dialogs — modal overlays
+
+`Dialogs` builds `Overlay` values. Mount them on `RootNode.overlays`
+and the renderer composites them on top of the rest of the frame.
+
+```scala
+import termflow.tui.Dialogs
+
+Dialogs.message(title, body: List[String], choices: List[Choice], position, theme): Overlay
+Dialogs.confirm(prompt: String, yesFocused: Boolean, …): Overlay
+Dialogs.textInput(title, prompt, value, cursor, okFocused, …): Overlay
+Dialogs.listSelect[A](title, items, selectedIdx, visibleRows, itemLabel, …): Overlay
+Dialogs.waiting(title, message, …): Overlay
+Dialogs.fileDialog(basePath, onSelect, onCancel, …): Overlay
+Dialogs.directoryDialog(basePath, onSelect, onCancel, …): Overlay
+Dialogs.actionList[A](title, items, itemLabel, onSelect, …): Overlay
+```
+
+Every helper takes a `position` and an implicit `Theme`. The
+showcase's *Dialogs* tab exercises all of them — see
+[`Stage1ShowcaseApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala)
+for working examples of each one.
+
+> File: `Dialogs.scala`.
+
+## Prompt — single-line text input
+
+```scala
+final case class Prompt.State(buffer: Vector[Char] = Vector.empty, cursor: Int = 0)
+
+def Prompt.handleKey[G](state: State, k: InputKey)(toMsg: PromptLine => Result[G])
+  : (State, Option[Cmd[G]])
+
+def Prompt.renderWithPrefix(state: State, prefix: String): RenderedLine
+
+def Prompt.cursorColumn(state: State): Int
+```
+
+`handleKey` is grapheme-aware — Backspace deletes a whole cluster, not
+a code point. `renderWithPrefix` returns the rendered text plus the
+cursor index and prefix length so you can hand it straight to an
+`InputNode`. `cursorColumn` uses `WCWidth` for the column position
+(matters for CJK / emoji inputs).
+
+> File: `Prompt.scala`.
+
+## TuiPrelude — the import you always want
+
+```scala
+import termflow.tui.TuiPrelude.*
+
+opaque type PromptLine = String
+type Result[A]         = Either[TermFlowError, A]
+type AsyncResult[+A]   = Future[Result[A]]
+
+def AsyncResult.success[A](value: A): AsyncResult[A]
+def AsyncResult.failure[A](err: TermFlowError): AsyncResult[A]
+def AsyncResult.fromResult[A](r: Result[A]): AsyncResult[A]
+def AsyncResult.fromFuture[A](task: Future[A])(using ec: ExecutionContext): AsyncResult[A]
+```
+
+Plus the screen-prelude conversions (`.x`, `.y`, `.text`).
+
+`TermFlowError` is the closed error ADT:
+`ConfigError | ModelNotFound | Unexpected | Validation | CommandError | UnknownApp`.
+
+> File: `TuiPrelude.scala`.
+
+## Where to next
+
+- **Widgets.** The component catalogue: [Widgets guide](widgets.md).
+- **Keymaps.** Replace ad-hoc match-on-key with declarative bindings:
+  [Keymap guide](keymap.md).
+- **Theming.** Override colours and box-drawing glyphs:
+  [Theming guide](theming.md).
+- **Testing.** Drive the runtime synchronously in tests:
+  [Testing guide](testing.md).
+
+The full per-type API is in the [Scaladoc](../reference/api.md).

--- a/docs/guide/keymap.md
+++ b/docs/guide/keymap.md
@@ -1,12 +1,133 @@
-# Keymap and chords
+# Keymap
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`Keymap` turns ad-hoc `match` blocks against `KeyDecoder.InputKey`
+into declarative bindings. The win is a single
+`Map[InputKey, Msg]` you can pass around, merge, and override —
+useful for global shortcuts, modal overrides, and feature flags.
 
-This guide will cover the `Keymap` framework: chord parsing, modes,
-the help overlay, and how it integrates with `FocusManager` so focused
-widgets can override global bindings.
+```scala
+import termflow.tui.Keymap
+import termflow.tui.KeyDecoder.InputKey
+```
 
-Until the page is filled in, see
-[`termflow.apps.forms.FormDemoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala)
-for a working example, and the
-[Scaladoc for `Keymap`](../reference/api.md) for the full API.
+## Building a keymap
+
+```scala
+val km: Keymap[Msg] = Keymap(
+  InputKey.CharKey('q')   -> Msg.Quit,
+  InputKey.CharKey('?')   -> Msg.ToggleHelp,
+  InputKey.Tab            -> Msg.NextFocus,
+  InputKey.BackTab        -> Msg.PrevFocus
+)
+
+km.lookup(InputKey.Tab)   // Some(NextFocus)
+km.lookup(InputKey.F1)    // None
+```
+
+`Keymap[Msg]` is just `Map[InputKey, Msg]` under the hood — equality,
+size, etc. work as you'd expect.
+
+## Composing keymaps
+
+Two keymaps merge with `++`. The right-hand side wins on conflict —
+so put global bindings first, mode-specific bindings last:
+
+```scala
+val global    = Keymap.quit(Msg.Quit) + (InputKey.CharKey('?') -> Msg.ToggleHelp)
+val editing   = Keymap(InputKey.Escape -> Msg.LeaveEditMode)
+
+// In edit mode: editing's Escape wins over a global Escape, if any.
+val active    = global ++ editing
+```
+
+The `+` operator adds or replaces a single binding:
+
+```scala
+val withSave  = global + (InputKey.Ctrl('S') -> Msg.Save)
+```
+
+## Builders for common patterns
+
+```scala
+Keymap.empty[Msg]                                  // {}
+Keymap(bindings: (InputKey, Msg)*)                 // arbitrary
+Keymap.quit(Msg.Quit)                              // Ctrl+C, Esc, q, Q
+Keymap.focus(next = Msg.NextFocus, previous = Msg.PrevFocus)
+                                                   // Tab + Shift+Tab
+Keymap.focusVertical(previous = Msg.Up, next = Msg.Down)
+                                                   // ArrowUp + ArrowDown
+Keymap.focusHorizontal(previous = Msg.Left, next = Msg.Right)
+                                                   // ArrowLeft + ArrowRight
+```
+
+These are the four most common shapes — quitting, tab focus, vertical
+focus, horizontal focus. Stack them with `++` to assemble an app's
+global keymap.
+
+## Wiring into `update`
+
+```scala
+case Msg.KeyPressed(key) =>
+  km.lookup(key) match
+    case Some(mapped) => Tui(m, Cmd.GCmd(mapped))
+    case None         =>
+      // Unmapped key — fall through to widget-specific handling.
+      m.tui
+```
+
+The `Cmd.GCmd(mapped)` re-enters `update` with the mapped message,
+which `update` handles like any other domain event. This decouples
+"which keys do what" from "what happens when something is done".
+
+For widgets that swallow keystrokes (TextField, MultiLineInput,
+Prompt), feed the key into the widget *first*, and only fall back to
+`Keymap.lookup` when the widget doesn't consume it. The
+[forms tutorial](../tut/04-forms-and-dialogs.md#6-focus-dispatch)
+walks through this pattern.
+
+## Mode stacks
+
+Apps with insert / normal / command modes can stack keymaps:
+
+```scala
+final case class Model(
+  mode: EditorMode,                 // Normal | Insert | Command
+  /* … */
+):
+  def keymap: Keymap[Msg] = mode match
+    case Normal  => globalKm ++ normalKm
+    case Insert  => globalKm ++ insertKm
+    case Command => globalKm ++ commandKm
+```
+
+`update` always calls `model.keymap.lookup(key)`. Mode transitions
+just change which keymap is active.
+
+## Help overlays
+
+Because `Keymap` is just a map, you can render a help screen straight
+from the bindings:
+
+```scala
+def renderHelp(km: Keymap[Msg], labelOf: Msg => String): List[VNode] =
+  km.bindings.toList.sortBy(_._2.toString).map { case (key, msg) =>
+    TextNode(2.x, 1.y, List(
+      describe(key).text(fg = Theme.dark.primary),
+      "  ".text,
+      labelOf(msg).text
+    ))
+  }
+```
+
+`describe(InputKey)` is whatever pretty-printer you want — the
+`Keymap.scala` source has a `renderChord` helper that returns
+human-readable strings (`"Tab"`, `"Ctrl+S"`, `"Esc"`).
+
+## Reference
+
+> File: `modules/termflow-app/src/main/scala/termflow/tui/Keymap.scala`.
+
+For a working example, see
+[`apps.forms.FormDemoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/forms/FormDemoApp.scala)
+— it builds a global keymap, layers a per-field keymap on top, and
+renders the active bindings as a help footer.

--- a/docs/guide/screen-layer.md
+++ b/docs/guide/screen-layer.md
@@ -1,21 +1,246 @@
 # Screen layer
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`termflow-screen` sits one layer above the TTY. It gives you:
 
-This guide covers `termflow-screen` — the buffered character grid,
-layout DSL, hit-test cache, and ANSI diff renderer.
+- a **virtual DOM** (`VNode` ADT — `TextNode`, `BoxNode`, `InputNode`,
+  `RootNode`),
+- a **layout DSL** for stacking, gaps, fills, and zones,
+- an **ANSI renderer** that diff-paints frames into minimal terminal
+  patches,
+- a **hit-test cache** for routing mouse events to logical zones,
+- a **theme** model with semantic colour slots and box-drawing chars.
 
-Topics planned for this page:
+```scala
+libraryDependencies += "org.llm4s" %% "termflow-screen" % "0.2.0"
+```
 
-- `RenderFrame` and `RenderCell` — the cell grid and its style fields.
-- `AnsiRenderer` — diff-painting, cursor placement, capability gates.
-- `Layout` — the `Row` / `Column` / `Elem` / `Spacer` / `Fill` / `Zone`
-  DSL and how `resolve` produces absolute coordinates.
-- `HitTest[Id]` and `Layout.resolveTracked[Id]` — the layout-pass
-  hit-test cache used by the showcase to map mouse clicks to logical
-  zones.
-- When to use `termflow-screen` directly without the app layer.
+You reach for the screen layer directly when you want a draw surface
+and rendering, but not the Elm-style runtime — for example, a one-shot
+report renderer that emits ANSI to stdout and exits.
 
-Until the page is filled in, the
-[render pipeline doc](../contrib/RENDER_PIPELINE.md) is the most thorough
-write-up.
+## VNode — the virtual DOM
+
+```scala
+enum VNode:
+  case TextNode(x: XCoord, y: YCoord, txt: List[Text])
+  case BoxNode(
+    x: XCoord, y: YCoord, width: Int, height: Int,
+    children: List[VNode], style: Style, chars: BorderChars
+  )
+  case InputNode(
+    x: XCoord, y: YCoord, prompt: String, style: Style,
+    cursor: Int = -1, lineWidth: Int = 0, prefixLength: Int = 0
+  )
+```
+
+Plus the wrapper:
+
+```scala
+final case class RootNode(
+  width:    Int,
+  height:   Int,
+  children: List[VNode],
+  input:    Option[InputNode],
+  overlays: List[Overlay] = Nil,
+  layout:   Option[Layout] = None
+)
+```
+
+Every render produces a `RootNode`. `AnsiRenderer.render(prev, next)`
+diffs the two and emits the ANSI patch.
+
+A few invariants:
+
+- **Coordinates are 1-based.** `XCoord` and `YCoord` are opaque types
+  over `Int` so you can't accidentally swap them. Use the `.x` / `.y`
+  extension methods in `ScreenPrelude` (`2.x`, `3.y`) to construct.
+- **`BoxNode` is visual-only.** It draws a border but does not
+  position its children. If you want layout, use `Layout.Column` or
+  `Layout.Row` instead and attach the box as a sibling.
+- **Only the topmost `InputNode` is live.** It carries the hardware
+  cursor position. Nested input nodes are drawn but inert.
+
+> File: `modules/termflow-screen/src/main/scala/termflow/tui/vdom.scala`.
+
+## Layout DSL
+
+`Layout` describes the stacking shape. Build a tree, then `resolve`
+it at an origin to flatten it into absolute-coordinate `VNode`s.
+
+```scala
+enum Layout:
+  case Elem(vnode: VNode)
+  case Row(gap: Int, children: List[Layout])
+  case Column(gap: Int, children: List[Layout])
+  case Spacer(width: Int, height: Int)
+  case Fill(content: Layout)
+  case Zone(id: Any, content: Layout)
+```
+
+Concrete usage:
+
+```scala
+import termflow.tui.{Layout, BoxNode, TextNode, Style}
+import termflow.tui.TuiPrelude.*
+
+val column = Layout.Column(gap = 1, children = List(
+  Layout.Elem(TextNode(1.x, 1.y, List("Counter".text(fg = Yellow)))),
+  Layout.Elem(TextNode(1.x, 1.y, List(s"value: $count".text))),
+  Layout.Spacer(1, 1),
+  Layout.Elem(TextNode(1.x, 1.y, List("press + / -".text)))
+))
+
+val children: List[VNode] = column.resolve(Coord(2.x, 2.y))
+```
+
+Inside the layout tree the inner `(1.x, 1.y)` are *layout-local* —
+`resolve` adds the origin to produce the right absolute coordinates.
+
+The fluent factories `Layout.row(gap)(vnode1, vnode2, …)` and
+`Layout.column(gap)(...)` skip the `Elem` wrappers when you have a
+flat list of vnodes.
+
+### `Fill` — eat remaining space
+
+`Fill(content)` consumes whatever's left on the major axis. Useful
+for splits and panels:
+
+```scala
+Layout.Row(gap = 1, children = List(
+  Layout.Elem(sidebar),    // natural width
+  Layout.Fill(mainPanel)   // takes the rest of the row
+))
+```
+
+Resolve `Fill` regions with `Layout.resolveTo(layout, at, w, h)` — the
+form that knows the available width / height.
+
+### `Zone` — tag for hit-test
+
+Wrap a sub-layout in `Zone(id, content)` and `Layout.resolveTracked`
+will register the resulting rectangle in a `HitTest[Id]` so you can
+route mouse clicks back to the same id:
+
+```scala
+val (vnodes, hits) = Layout.resolveTracked[String](
+  layout, at = Coord(1.x, 1.y), availableWidth = 80, availableHeight = 24
+)
+
+mouseEvent match
+  case Mouse(MouseEvent.Press(_, col, row, _)) =>
+    hits.hit(col, row).foreach(handleZone)
+```
+
+> File: `modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala`.
+
+## HitTest
+
+```scala
+final case class Rect(x: Int, y: Int, width: Int, height: Int):
+  def right:  Int
+  def bottom: Int
+  def contains(col: Int, row: Int): Boolean
+  def at: Coord
+
+final case class HitTest[Id](zones: Vector[(Id, Rect)]):
+  def add(id: Id, rect: Rect): HitTest[Id]
+  def ++(other: HitTest[Id]): HitTest[Id]
+  def hit(col: Int, row: Int): Option[Id]
+```
+
+`hit(col, row)` returns the *topmost* zone (last-inserted wins) at the
+given coordinate. The cache is built during the layout pass — you
+never have to maintain a parallel zone list by hand.
+
+> File: `modules/termflow-screen/src/main/scala/termflow/tui/HitTest.scala`.
+
+## Theme — semantic colour slots
+
+```scala
+final case class Theme(
+  primary:    Color,  secondary:  Color,
+  error:      Color,  warning:    Color,
+  success:    Color,  info:       Color,
+  border:     Color,  background: Color,  foreground: Color,
+  chars: BorderChars = BorderChars.sharp
+)
+
+object Theme:
+  val dark:    Theme
+  val light:   Theme
+  val mono:    Theme
+  val rounded: Theme
+```
+
+A widget that takes `(using Theme)` can draw against the active
+theme without knowing anything about the user's palette. Override by
+making your own `given Theme = …` in scope, or by passing a theme
+explicitly to dialog/widget builders.
+
+`BorderChars` controls box-drawing glyphs:
+
+```scala
+object BorderChars:
+  val sharp:   BorderChars  // ┌─┐│└┘
+  val rounded: BorderChars  // ╭─╮│╰╯
+  val double:  BorderChars  // ╔═╗║╚╝
+  val ascii:   BorderChars  // +-+|-+ — for terminals without unicode
+```
+
+Capability-aware: when `Capabilities.unicode` is false, the renderer
+substitutes `ascii` automatically.
+
+> Files: `Theme.scala`, `BorderChars.scala`.
+
+## RenderFrame and AnsiRenderer
+
+The renderer turns a `RootNode` into a `RenderFrame` (a
+`width × height` grid of `RenderCell(ch, style, width)`), then diffs
+against the previous frame and emits ANSI.
+
+```scala
+final case class RenderCell(ch: Char, style: Style, width: Int = 1)
+
+final case class RenderFrame(
+  width:  Int,
+  height: Int,
+  cells:  Array[Array[RenderCell]],
+  cursor: Option[Coord]
+)
+```
+
+You normally don't construct a `RenderFrame` by hand — the runtime
+does it for you. Where it shows up is in tests: `TuiTestDriver.frame`
+returns the `RenderFrame` produced by the last `view` call, and
+`GoldenSupport.assertGoldenFrame` compares it to a snapshot.
+
+The wide-cell handling is critical:
+`RenderCell.width = 2` means the next cell is consumed by the same
+glyph. This is what makes `好` render correctly.
+
+> File: `modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala`.
+
+## ScreenPrelude — sugar
+
+```scala
+import termflow.tui.TuiPrelude.*  // lifts ScreenPrelude transitively
+
+2.x                                  // XCoord
+3.y                                  // YCoord
+"hello".text                         // Text(value, Style.empty)
+"warning".text(fg = Color.Yellow)    // styled text
+"OK".text(fg, bg, bold = true)       // multiple style args
+```
+
+These are the conversions every example uses. Always import
+`TuiPrelude.*` at the top of view code; you'll thank yourself.
+
+## When to climb up
+
+The screen layer plus your own loop is enough for read-only tools
+(report renderers, status dashboards, pipe viewers). The moment you
+want input — keystrokes, timers, async work — you want the
+[Application layer](app-layer.md). Everything in this layer is reused
+verbatim by the app layer, so nothing is wasted.
+
+The full per-type API is in the [Scaladoc](../reference/api.md).

--- a/docs/guide/terminal-layer.md
+++ b/docs/guide/terminal-layer.md
@@ -1,25 +1,205 @@
 # Terminal layer
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`termflow-terminal` is the lowest layer — direct access to the TTY,
+key decoding, capability detection, Unicode width and grapheme math.
+Most apps never need to touch this module directly: the `app` layer
+takes care of opening the terminal, registering input subscriptions,
+and switching to the alternate buffer. You reach for the terminal
+layer when those abstractions are in the way.
 
-This guide covers the lowest layer of TermFlow, published as
-`termflow-terminal`. It is what you reach for when the higher-level
-abstractions are in the way: capability detection, raw key reads,
-direct ANSI emission.
+```scala
+libraryDependencies += "org.llm4s" %% "termflow-terminal" % "0.2.0"
+```
 
-Topics planned for this page:
+## When to use it directly
 
-- The `TerminalBackend` trait and `JLineTerminalBackend` default.
-- `Capabilities` detection — true colour, bracketed paste, mouse,
-  extended modifiers.
-- `KeyDecoder` — the single source of truth for reading keystrokes,
-  modifier handling, and the SGR-1006 mouse multiplex onto
-  `InputKey.Mouse`.
-- `WCWidth` — column-width arithmetic for CJK and emoji.
-- `Grapheme` — UAX #29 cluster boundaries used by `Prompt` and
-  `MultiLineInput`.
-- When to depend on this module alone, and when to climb up.
+- Building a CLI utility that needs raw key reads but no full-screen
+  rendering.
+- Detecting whether the user's terminal supports true colour, mouse,
+  bracketed paste before deciding which features to enable.
+- Implementing a custom backend (telnet server, browser bridge) that
+  feeds an upper-layer app.
+- Writing tests for grapheme- or width-sensitive code without spinning
+  up the runtime.
 
-Until the page is filled in, the
-[contributor design doc](../contrib/DESIGN.md) is the most thorough
-write-up.
+## TerminalBackend
+
+`TerminalBackend` is the trait every terminal implementation
+satisfies. It bundles a `Reader` / `Writer` pair, current size, ANSI
+emission, and capability detection.
+
+```scala
+trait TerminalBackend extends TerminalInfo:
+  def reader: Reader
+  def writer: Writer
+  def width: Int
+  def height: Int
+  def write(text: String): Unit
+  def flush(): Unit
+  def close(): Unit
+  def capabilities: Capabilities
+  def onResize(listener: () => Unit): Option[() => Unit]
+```
+
+The default implementation is `JLineTerminalBackend`, backed by
+[JLine](https://github.com/jline/jline3). It honours SIGWINCH, so
+`onResize` fires the moment the user resizes their window — no
+polling.
+
+> File: `modules/termflow-terminal/src/main/scala/termflow/tui/TerminalBackend.scala`.
+
+## KeyDecoder.InputKey
+
+The decoded keystroke ADT. Pattern-match on it to react to user
+input:
+
+```scala
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.KeyDecoder.InputKey.*
+
+key match
+  case CharKey(c)             => /* printable */
+  case Ctrl(c)                => /* control modifier */
+  case Enter | Tab | Escape   => /* named keys */
+  case ArrowUp | ArrowDown    => /* navigation */
+  case Modified(inner, mods)  => /* shift/alt/ctrl/meta combinations */
+  case Mouse(event)           => /* SGR-1006 mouse events */
+  case Paste(text)            => /* bracketed-paste payload */
+  case _                      => /* F1–F12, BackTab, Insert, Home, End, PageUp/Down, NoOp, EndOfInput, Unknown */
+```
+
+`Modifiers(shift, alt, ctrl, meta)` decodes xterm's modifier byte; use
+`Modifiers.fromXtermCode(code)` if you're decoding raw CSI parameters.
+
+> File: `modules/termflow-terminal/src/main/scala/termflow/tui/KeyDecoder.scala`.
+
+## Capabilities
+
+A small struct describing what the terminal can do, with conservative
+defaults so apps that ignore it still work:
+
+```scala
+final case class Capabilities(
+  colorDepth:    ColorDepth, // Mono | Ansi8 | Ansi16 | Indexed256 | Truecolor
+  unicode:       Boolean,
+  mouse:         Boolean,
+  extendedStyles: Boolean,   // italic / dim / strike / blink
+  bracketedPaste: Boolean
+)
+
+object Capabilities:
+  def detect(env: Map[String, String]): Capabilities
+```
+
+`Capabilities.detect(sys.env)` honours `NO_COLOR`, `COLORTERM`, `TERM`,
+and `LANG` / `LC_*`. The `AnsiRenderer` calls this for you and
+downgrades colour emission accordingly — true-colour `Rgb(...)` styles
+become indexed-256 or 16-colour ANSI as needed.
+
+`ColorDepth` is monotonic: `td.supports(other)` returns `true` when
+`td`'s depth is at least `other`'s. Use it to gate features:
+
+```scala
+if caps.colorDepth.supports(ColorDepth.Truecolor) then highColourTheme
+else                                                  ansi8FallbackTheme
+```
+
+> File: `modules/termflow-terminal/src/main/scala/termflow/tui/Capabilities.scala`.
+
+## Mouse events
+
+Mouse events are multiplexed onto the keystroke stream as
+`InputKey.Mouse(event)`, so you handle them in the same `Sub.InputKey`
+handler as everything else.
+
+```scala
+enum MouseEvent:
+  case Press(button: MouseButton, col: Int, row: Int, modifiers: Modifiers)
+  case Release(button: MouseButton, col: Int, row: Int, modifiers: Modifiers)
+  case Drag(button: MouseButton, col: Int, row: Int, modifiers: Modifiers)
+  case Move(col: Int, row: Int, modifiers: Modifiers)
+  case Scroll(direction: ScrollDirection, col: Int, row: Int, modifiers: Modifiers)
+```
+
+`MouseButton` is `Left | Middle | Right | Other(code)`.
+`ScrollDirection` is `Up | Down | Left | Right`.
+
+For the standard click-and-drag flow, see the `screen` layer's
+`HitTest` cache and `Layout.Zone` — together they map a coordinate to
+a logical zone id without you re-deriving rectangles.
+
+> File: `modules/termflow-terminal/src/main/scala/termflow/tui/Mouse.scala`.
+
+## WCWidth — column-width arithmetic
+
+Some characters take up two columns (CJK ideographs, most emoji),
+some take zero (combining marks), some are control codes. Naïve
+`String.length` lies about the visual width.
+
+```scala
+import termflow.tui.WCWidth
+
+WCWidth.codePointWidth('A'.toInt)  // 1
+WCWidth.codePointWidth('好'.toInt) // 2
+WCWidth.charWidth('́')        // 0 (combining acute)
+WCWidth.stringWidth("こんにちは")   // 10 (5 wide chars × 2)
+```
+
+The renderer uses these for layout, cursor placement, and diff
+emission. Prompt cursor math (`Prompt.cursorColumn`) is one place this
+shows up — typing `好` advances the cursor by two columns, not one.
+
+> File: `modules/termflow-terminal/src/main/scala/termflow/tui/WCWidth.scala`.
+
+## Grapheme — UAX #29 cluster boundaries
+
+Backspace shouldn't delete half of a character. `é` written as `e +
+U+0301` is two code points but one grapheme — pressing Backspace once
+should remove both. `Grapheme` wraps `java.text.BreakIterator` to give
+you the right boundaries:
+
+```scala
+import termflow.tui.Grapheme
+
+Grapheme.previousBoundary("café", 4)  // 3   — back across "é"
+Grapheme.nextBoundary("café", 0)      // 1
+Grapheme.count("👋🏽")                // 1   (skin-tone modifier)
+```
+
+Used by `Prompt.handleKey` (Backspace, Delete, Arrow-left/right) and
+`MultiLineInput`. If you're building your own text widget, route your
+navigation through these.
+
+> File: `modules/termflow-terminal/src/main/scala/termflow/tui/Grapheme.scala`.
+
+## A working example: capability sniffer
+
+A standalone CLI that prints what your terminal can do:
+
+```scala
+import termflow.tui.{Capabilities, JLineTerminalBackend}
+
+@main def termcaps(): Unit =
+  val backend = new JLineTerminalBackend()
+  val caps    = backend.capabilities
+  println(s"size:           ${backend.width} × ${backend.height}")
+  println(s"colour depth:   ${caps.colorDepth}")
+  println(s"unicode:        ${caps.unicode}")
+  println(s"mouse:          ${caps.mouse}")
+  println(s"extended styles:${caps.extendedStyles}")
+  println(s"bracketed paste:${caps.bracketedPaste}")
+  backend.close()
+```
+
+This is the kind of utility that doesn't need the runtime, doesn't
+need the alt buffer, just wants to look at the TTY for a moment. The
+terminal layer alone is enough.
+
+## Reaching higher
+
+When you need a draw surface and diff rendering, the
+[Screen layer guide](screen-layer.md) is next. When you need an event
+loop, model + update + view, focus management, dialogs — that's the
+[Application layer guide](app-layer.md).
+
+The full per-type API is in the [Scaladoc](../reference/api.md).

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,23 +1,243 @@
 # Testing
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`termflow-testkit` is the test-only companion to `termflow-app`. It
+gives you a synchronous driver that runs your `TuiApp` without a real
+terminal, captures rendered frames as cell matrices for snapshot
+testing, and provides `KeySim` / `MouseSim` constructors so you don't
+have to hand-build `KeyDecoder.InputKey` values in test code.
 
-This guide will cover `termflow-testkit`: deterministic harness for
-TermFlow apps without a real terminal.
+```scala
+libraryDependencies += "org.llm4s" %% "termflow-testkit" % "0.2.0" % Test
+```
 
-Topics planned:
+## TuiTestDriver
 
-- `TuiTestDriver` — synchronous `init` / `send` / `frame` /
-  `model` / `exited` driver.
-- Asserting on the rendered frame (cell-grid comparison vs. golden
-  snapshots via `GoldenSupport`).
-- `KeySim` and `MouseSim` — typed key and mouse event constructors,
-  including `Tab`, `Enter`, `CharKey`, and SGR-1006 mouse events that
-  flow through `InputKey.Mouse`.
-- `TestRuntimeCtx` — keeps subscriptions dormant so timer ticks don't
-  fire during tests.
+The single entry point for testing apps:
 
-Until the page is filled in, the existing test suites under
+```scala
+import termflow.testkit.{TuiTestDriver, KeySim}
+import termflow.tui.KeyDecoder.InputKey
+
+val driver = TuiTestDriver(MyApp.App, width = 80, height = 24)
+driver.init()
+
+driver.send(MyApp.Msg.Increment)
+assert(driver.model.count == 1)
+```
+
+The driver:
+
+- Runs `app.init(ctx)` synchronously, captures the `Tui[Model, Msg]`.
+- Drains the command bus on every `send`, processing `GCmd`s
+  recursively so chained transitions complete before `send` returns.
+- Renders the current model after every `send` — `driver.frame`
+  returns the latest `RenderFrame`.
+- Suppresses subscription start-up — `Sub.Every` timers never tick,
+  `Sub.InputKey` never reads stdin, so tests stay deterministic.
+
+Key methods:
+
+```scala
+class TuiTestDriver[Model, Msg]:
+  def init():    Unit
+  def send(msg:  Msg):  Unit
+  def model:     Model
+  def exited:    Boolean
+  def cmds:      List[Cmd[Msg]]
+  def observedErrors: List[TermFlowError]
+  def frame:     RenderFrame
+```
+
+## Asserting on the frame
+
+The simplest assertion is "did the rendered text contain X?":
+
+```scala
+val rendered = (0 until driver.frame.height)
+  .map(r => driver.frame.cells(r).map(_.ch).mkString)
+  .mkString("\n")
+
+assert(rendered.contains("count: 1"))
+```
+
+For style assertions, drop into `RenderCell`:
+
+```scala
+val cell = driver.frame.cells(2)(15)
+assert(cell.ch == '✓')
+assert(cell.style.fg == Color.Green)
+```
+
+## Golden snapshots
+
+For higher-fidelity tests, mix in `GoldenSupport`:
+
+```scala
+import termflow.testkit.GoldenSupport
+import org.scalatest.funsuite.AnyFunSuite
+
+class MyAppSpec extends AnyFunSuite with GoldenSupport:
+  override def goldenSuiteName = "MyApp"
+
+  test("initial frame matches golden") {
+    val d = TuiTestDriver(MyApp.App, width = 80, height = 24)
+    d.init()
+    assertGoldenFrame(d.frame, "initial")
+  }
+```
+
+First run: the golden file doesn't exist, the test fails. Run with
+`-Dtermflow.update-goldens=true` (or `UPDATE_GOLDENS=1`) and the
+driver writes it. Commit the golden, future runs assert against it.
+
+Goldens live under
+`src/test/resources/termflow/golden/<suite>/<name>.txt` by default.
+Override via `goldenDir` and `goldenPath(name)`.
+
+## KeySim — typed key constructors
+
+```scala
+import termflow.testkit.KeySim
+
+KeySim.Tab           // InputKey.Tab
+KeySim.Enter         // InputKey.Enter
+KeySim.Escape        // InputKey.Escape
+
+KeySim.char('q')     // InputKey.CharKey('q')
+KeySim.ctrl('S')     // InputKey.Ctrl('S')
+KeySim.f(2)          // InputKey.F2
+KeySim.paste("hi")   // InputKey.Paste("hi")
+```
+
+Modifier wrappers:
+
+```scala
+KeySim.shift(KeySim.Tab)              // BackTab equivalent (Shift+Tab)
+KeySim.ctrl(KeySim.char('c'))         // Ctrl+C
+KeySim.modified(InputKey.End, shift = true, ctrl = true)
+```
+
+Sequences:
+
+```scala
+KeySim.typeString("hello")
+// → List(CharKey('h'), CharKey('e'), CharKey('l'), CharKey('l'), CharKey('o'))
+
+KeySim.typeString("a\tb")
+// → List(CharKey('a'), Tab, CharKey('b'))   // \t becomes Tab
+
+KeySim.typeString("a\nb")
+// → List(CharKey('a'), Enter, CharKey('b')) // \n becomes Enter
+```
+
+This is what the showcase, wizard, and form-demo specs use to drive
+their drivers — typing a string and asserting on the resulting model
+is by far the most readable test shape.
+
+## MouseSim — typed mouse constructors
+
+Mouse events live inside `InputKey.Mouse(event)`. `MouseSim` wraps
+that for you:
+
+```scala
+import termflow.testkit.MouseSim
+
+MouseSim.click(col = 10, row = 5)               // Press at (10, 5)
+MouseSim.scrollOnce(ScrollDirection.Down, 10, 5) // Single wheel click
+
+MouseSim.clickPair(col = 10, row = 5)
+// → Vector(InputKey.Mouse(Press(...)), InputKey.Mouse(Release(...)))
+
+MouseSim.scroll(ScrollDirection.Down, 10, 5, ticks = 3)
+// → three Mouse(Scroll(Down, ...)) events
+```
+
+For drag-resize tests of `SplitPane`:
+
+```scala
+val events = Vector(
+  MouseSim.press(col = 40, row = 12),
+  MouseSim.drag(col = 50, row = 12),
+  MouseSim.release(col = 50, row = 12)
+)
+events.foreach(e => driver.send(MyApp.Msg.KeyPressed(e)))
+```
+
+## TestRuntimeCtx
+
+`TuiTestDriver` constructs a `TestRuntimeCtx[Msg]` for you, but if
+you want to drive a `TuiApp` lower-level, the ctx is exposed
+directly. Useful when you're testing a sub-component that takes a
+`RuntimeCtx[Msg]` parameter without going through the full app.
+
+```scala
+val ctx = TestRuntimeCtx[MyApp.Msg](width = 80, height = 24)
+
+// Register a sub manually if you need to assert on it:
+val keys = Sub.InputKey[MyApp.Msg](
+  msg     = k => MyApp.Msg.KeyPressed(k),
+  onError = _ => MyApp.Msg.Quit,
+  ctx     = ctx
+)
+assert(ctx.registeredSubs.contains(keys))
+```
+
+## A complete spec
+
+```scala
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.testkit.{TuiTestDriver, KeySim}
+
+class CounterSpec extends AnyFunSuite:
+
+  private def driver = {
+    val d = TuiTestDriver(SyncCounter.App, width = 80, height = 24)
+    d.init()
+    d
+  }
+
+  test("increment via keystroke") {
+    val d = driver
+    KeySim.typeString("increment").foreach(k =>
+      d.send(SyncCounter.Msg.ConsoleInputKey(k))
+    )
+    d.send(SyncCounter.Msg.ConsoleInputKey(KeySim.Enter))
+    assert(d.model.counter.count == 1)
+  }
+
+  test("exit on Ctrl+C") {
+    val d = driver
+    d.send(SyncCounter.Msg.ConsoleInputKey(KeySim.ctrl('C')))
+    assert(d.exited)
+  }
+```
+
+## Testing async work
+
+`Cmd.FCmd` futures don't run automatically inside the driver — that
+would make tests non-deterministic. Instead, the driver records the
+`FCmd` in `cmds` and you assert on it:
+
+```scala
+test("Increment dispatches an FCmd with onEnqueue = Busy") {
+  val d = driver
+  d.send(FutureCounter.Msg.Increment)
+  val fcmd = d.cmds.collectFirst {
+    case f: Cmd.FCmd[?, ?] => f
+  }.getOrElse(fail("expected an FCmd"))
+  assert(fcmd.onEnqueue.exists(_.isInstanceOf[FutureCounter.Msg.Busy]))
+}
+```
+
+For end-to-end async tests, use `Await.result` on the captured future
+and feed the resolved value back via `driver.send`. This is the
+pattern the `FutureCounter` spec uses.
+
+## Reference
+
+> Files: `modules/termflow-testkit/src/main/scala/termflow/testkit/{TuiTestDriver,TestRuntimeCtx,KeySim,MouseSim,GoldenSupport}.scala`.
+
+For working examples, every spec under
 [`modules/termflow-sample/src/test/scala`](https://github.com/llm4s/termflow/tree/main/modules/termflow-sample/src/test/scala)
-are good worked examples — the wizard, showcase, and form-demo specs
-all use `TuiTestDriver`, `KeySim`, and `MouseSim`.
+uses the testkit — the wizard, showcase, form-demo, and dashboard
+specs cover the full surface.

--- a/docs/guide/theming.md
+++ b/docs/guide/theming.md
@@ -1,14 +1,150 @@
 # Theming
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`Theme` is a small struct of named colour slots plus a `BorderChars`
+glyph set. Widgets and dialogs that take `(using Theme)` pick up the
+ambient theme without needing to know what your palette looks like.
 
-This guide will cover the `Theme` API: per-slot colour roles
-(primary / secondary / foreground / background / border / info),
-themable `BorderChars`, and the capability gates that decide which
-ANSI features actually emit (true colour, bracketed paste, extended
-modifiers).
+```scala
+import termflow.tui.Theme
+```
 
-Until the page is filled in, see
-[`termflow.apps.themes.ThemeDemoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/themes/ThemeDemoApp.scala)
-for a side-by-side preview of every shipped theme, and the
-[Scaladoc for `Theme`](../reference/api.md) for the full API.
+## The shape
+
+```scala
+final case class Theme(
+  primary:    Color,  secondary:  Color,
+  error:      Color,  warning:    Color,
+  success:    Color,  info:       Color,
+  border:     Color,  background: Color,  foreground: Color,
+  chars:      BorderChars = BorderChars.sharp
+)
+
+object Theme:
+  val dark:    Theme   // shipped — default
+  val light:   Theme   // shipped — light palette
+  val mono:    Theme   // shipped — single-colour terminal fallback
+  val rounded: Theme   // shipped — rounded box-drawing chars
+```
+
+Pick one as your `given` at the top of your view code:
+
+```scala
+import termflow.tui.{Theme, Color}
+import termflow.tui.Theme.themed
+
+given Theme = Theme.dark
+
+val tag = "PRIMARY".themed(_.primary)
+val ok  = "✓".themed(_.success)
+```
+
+The `.themed(slot)` extension takes a `Theme => Color` and returns a
+styled `Text`. This keeps view code free of hard-coded colours and
+gives you palette-swap-by-import.
+
+## Slot semantics
+
+The names are deliberately abstract — they mean roles, not literal
+colours:
+
+| Slot        | Used for |
+|-------------|----------|
+| `primary`   | Headings, focus chrome, active tab |
+| `secondary` | Subtle headings, placeholder text |
+| `error`     | Validation messages, exit codes |
+| `warning`   | Caution states |
+| `success`   | Confirmation messages, "✓ Submitted" |
+| `info`      | Neutral status (timestamps, counts) |
+| `border`    | Box outlines, separators |
+| `background`| Fills (rare — the terminal default usually wins) |
+| `foreground`| Default text colour |
+
+The four shipped themes pick concrete `Color` values for each slot
+that look good together. When you add your own theme, copy
+`Theme.dark` and override what you need:
+
+```scala
+val termflowBranded: Theme = Theme.dark.copy(
+  primary  = Color.Rgb(0xff, 0x6f, 0x3d),  // brand orange
+  border   = Color.Indexed(238)
+)
+```
+
+## Capability gating
+
+`Color.Rgb(...)` only emits true-colour ANSI when the terminal
+supports it. The `AnsiRenderer` reads `Capabilities.colorDepth` (from
+the `Capabilities.detect(env)` pass at startup) and downgrades:
+
+```text
+Truecolor → Indexed256 → Ansi16 → Ansi8 → Mono
+```
+
+So an `Rgb(0xff, 0x6f, 0x3d)` becomes the closest 256-colour
+approximation on terminals that don't speak true-colour, and a basic
+8-colour ANSI on really old terminals.
+
+`NO_COLOR` is honoured — set the env var and the renderer drops to
+`Mono`. For everything `colour-blind`-related, prefer the `mono`
+theme rather than rolling your own.
+
+## Box-drawing chars
+
+```scala
+object BorderChars:
+  val sharp:   BorderChars  // ┌─┐│└┘
+  val rounded: BorderChars  // ╭─╮│╰╯
+  val double:  BorderChars  // ╔═╗║╚╝
+  val ascii:   BorderChars  // +-+|-+
+```
+
+When `Capabilities.unicode` is `false`, the renderer auto-substitutes
+`ascii` regardless of which set the theme picked. This means you can
+ship `Theme.dark` (which uses `sharp`) and it still renders correctly
+on a vt100.
+
+To switch glyphs in code:
+
+```scala
+val rounded = Theme.dark.copy(chars = BorderChars.rounded)
+```
+
+## A theme-aware widget
+
+Most widgets in the catalogue already take `(using Theme)` — that's
+all you have to know to use them. If you're building your own
+widget, the same pattern applies:
+
+```scala
+def MyBadge(label: String)(using theme: Theme): VNode =
+  TextNode(1.x, 1.y, List(
+    " ".text,
+    label.text(fg = theme.background, bg = theme.primary, bold = true),
+    " ".text
+  ))
+```
+
+## Switching at runtime
+
+Because `Theme` is just a value, you can swap themes from `update`
+and pass it through to `view` via the model:
+
+```scala
+final case class Model(theme: Theme, /* … */)
+
+def view(m: Model): RootNode =
+  given Theme = m.theme
+  // … render against the active theme
+```
+
+The
+[`apps.themes.ThemeDemoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/themes/ThemeDemoApp.scala)
+sample shows side-by-side previews of every shipped theme — useful
+both as a smoke test for new themes and as a starting point if you're
+designing your own palette.
+
+## Reference
+
+> File: `modules/termflow-screen/src/main/scala/termflow/tui/Theme.scala`.
+
+For the full per-slot API, see the [Scaladoc](../reference/api.md).

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -1,41 +1,284 @@
 # Widgets
 
-> *Stub — full content lands in Phase C of the docs roll-out.*
+`termflow-widgets` ships a catalogue of reusable components. Every
+widget is built on top of `termflow-screen` and `termflow-app`,
+follows the same `(State, handleKey, view)` shape, and takes a
+`given Theme` so it picks up your colour scheme.
 
-This guide will catalogue every widget in `termflow-widgets` with one
-paragraph per widget, a screenshot, and a code snippet showing the
-common usage. Until then, the
-[showcase app](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala)
-exercises every widget and the
-[Scaladoc](../reference/api.md) has the full per-widget API.
+```scala
+libraryDependencies += "org.llm4s" %% "termflow-widgets" % "0.2.0"
+```
 
-The widgets, grouped:
+The umbrella `termflow` artefact already depends on this module —
+most apps don't need to depend on it directly.
 
-**Inputs**
+> Every widget is exercised by the
+> [showcase app](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala).
+> Run `sbt showcase` to see them rendered side-by-side.
 
-- `TextField` — single-line text input
-- `MultiLineInput` — multi-line editor with grapheme-aware navigation
-- `Button`
-- `CheckBox` / `RadioGroup`
-- `Select` / `Autocomplete`
-- `Prompt` (in `termflow-app`, not `widgets`)
+## The widget protocol
 
-**Data**
+Most widgets follow a three-piece pattern:
 
-- `ListView`
-- `Table`
-- `Tree`
+1. **`State`** — the widget's data (cursor positions, scroll offsets,
+   selected index). You store this on your model.
+2. **`handleKey(state, key)(...)`** — pure function from a key to the
+   next state, optionally producing a `Msg` (e.g. on Enter).
+3. **`view(state, …, focused: Boolean = true)`** — pure function from
+   state to `VNode` or `List[VNode]`. The `focused` flag controls
+   which highlight to use.
 
-**Layout**
+Stateless widgets (`Button`, `RadioGroup`, `ProgressBar`, `Spinner`,
+`StatusBar`, `Separator`) skip step 2 — they only render.
 
-- `Tabs`
-- `SplitPane` (with mouse-drag resize)
-- `Separator` (horizontal / vertical)
-- `ScrollBar`
+## Inputs
 
-**Feedback**
+### TextField
 
-- `ProgressBar`
-- `Spinner`
-- `StatusBar`
-- `LogView`
+Single-line text input. Handles cursor, paste, grapheme-aware
+backspace.
+
+```scala
+import termflow.tui.widgets.TextField
+
+val initial = TextField.State.withPlaceholder("alice@example.com")
+val (next, _) = TextField.handleKey[Msg](initial, key)(_ => None)
+val node = TextField.view(next, lineWidth = 28, focused = true)
+```
+
+Placeholder text renders dim+italic until the user types.
+
+### MultiLineInput
+
+Multi-line editor. Cursor row uses reverse-video (TextField-style) so
+it embeds cleanly in any layout. Tab inserts a literal `\t`.
+Grapheme-aware navigation across all four arrows, Backspace, Delete.
+
+```scala
+val state = MultiLineInput.State(lines = Vector("hello", "world"))
+val (next, _) = MultiLineInput.handleKey[Msg](state, key)(_ => None)
+val node = MultiLineInput.view(next, width = 60, height = 12, focused = true)
+```
+
+### Button
+
+Inline `[ Label ]`. Focus = primary background bar. Stateless —
+`Button(label, focused)` returns a `VNode` directly.
+
+```scala
+widgets.Button(label = "Submit", focused = focusManager.isFocused(SubmitId))
+```
+
+### CheckBox / RadioGroup
+
+```scala
+widgets.CheckBox(label = "Remember me", checked = true, focused = true)
+
+widgets.RadioGroup(
+  options       = Vector("Free", "Pro", "Enterprise"),
+  selectedIndex = 1,
+  focusedIndex  = 1,
+  at            = Coord(4.x, 8.y)
+)
+```
+
+`RadioGroup` returns `List[VNode]`, one per option. Use `Layout.Column`
+or absolute coordinates if you want different placement.
+
+Capability-aware glyphs: ☐/☒ and ◯/◉ on Unicode terminals,
+`[ ]/[x]` and `( )/(*)` on ASCII-only.
+
+### Select / Autocomplete
+
+`Select` is a closed-state dropdown — single click opens, click again
+or pick an item closes. `Autocomplete` is the open-state variant: a
+filterable list always visible underneath an input.
+
+```scala
+val acState = Autocomplete.State.of(Vector("apple", "banana", "cherry"))
+val r       = Autocomplete.handleKey(acState, key)
+val nodes   = Autocomplete.view(r.state, width = 16, maxVisible = 6, focused = true)
+```
+
+Both clamp `selectedIdx` into the visible filtered range. The
+viewport scrolls so the cursor row stays visible.
+
+### Prompt
+
+Strictly speaking `Prompt` is in `termflow-app`, not `widgets`, but
+it's the workhorse for REPL-style apps — see the
+[Counter tutorial](../tut/02-counter.md) for the full integration.
+
+## Data display
+
+### ListView
+
+Scrollable, selectable list. `▸ ` cursor when focused, just colour
+when blurred.
+
+```scala
+val state = ListView.State(items = Vector("apple", "banana", "cherry"))
+val (next, _) = ListView.handleKey[Msg](state, key)(_ => None)
+val node = ListView.view(next, width = 24, maxVisible = 8, focused = true)
+```
+
+### Table
+
+Selectable rows + columns with `Align.Left | Right | Center`.
+
+```scala
+val cols = Vector(
+  Table.Column("Name",  width = 20, align = Align.Left),
+  Table.Column("Score", width = 8,  align = Align.Right)
+)
+val state = Table.State(columns = cols, rows = Vector(Vector("alice","42")))
+```
+
+### Tree
+
+Recursive collapsible tree.
+
+- Expanded glyph: `[-] `
+- Collapsed glyph: `[+] `
+- Leaf glyph: `    ` (four spaces)
+
+```scala
+val tree = Tree.State(root = Tree.Node("root", children = …))
+val nodes = Tree.view(tree, width = 32, focused = true)
+
+// Mouse: distinguish chevron clicks from label clicks
+Tree.hitTest(rows, at = Rect(...), indentWidth = 2, col, row, labelLength) match
+  case Tree.HitResult.Chevron(idx) => /* toggle expansion */
+  case Tree.HitResult.Label(idx)   => /* select */
+  case _                           => /* miss */
+```
+
+### LogView
+
+Tail-following log buffer. Auto-scrolls until the user scrolls up,
+then pauses until they scroll back to the bottom.
+
+```scala
+val log = LogView.State.empty
+val updated = LogView.append(log, "build started", Style(fg = Yellow))
+val node = LogView.view(updated, width = 80, height = 16)
+```
+
+## Layout
+
+### Tabs
+
+```scala
+val state = Tabs.State(labels = Vector("Inputs", "Data", "Layout"), activeIdx = 0)
+val (next, _) = Tabs.handleKey[Msg](state, key)(_ => None)
+val node = Tabs.view(next, width = 80, focused = true)
+```
+
+### SplitPane
+
+Horizontal/vertical pane divider. Resize via mouse drag (Stage 3 §6.2)
+or via keyboard (`[` / `]`).
+
+```scala
+val ds = SplitPane.DragState(splitRatio = 0.5, dragging = false)
+val ds2 = SplitPane.handleMouse(
+  state = ds, event = mouseEvent,
+  direction = SplitPane.Vertical, width = 80, height = 24,
+  at = Coord(1.x, 1.y), gap = 1
+)
+```
+
+### Separator
+
+```scala
+widgets.Separator.horizontal(width = 60, at = Coord(1.x, 5.y), title = Some("Section"))
+widgets.Separator.vertical(height = 12, at = Coord(40.x, 1.y))
+```
+
+### ScrollBar
+
+Visual thumb track. Use alongside `ListView`, `Table`, or
+`MultiLineInput` when content exceeds the visible area.
+
+```scala
+val sb = ScrollBar.State(offset = 0, visible = 12, total = 60)
+if sb.needed then
+  val node = ScrollBar(sb, at = Coord(80.x, 2.y), height = 12)
+```
+
+## Feedback
+
+### ProgressBar
+
+```scala
+widgets.ProgressBar(at = Coord(2.x, 5.y), width = 40, fraction = 0.6)
+```
+
+`█` filled, `░` empty on Unicode terminals; `#` / `-` on ASCII.
+
+### Spinner
+
+```scala
+val frames = Spinner.Braille  // or .Line, .Dots
+val frame  = Spinner.frame(frames, tickIndex)
+```
+
+Stateless — you advance `tickIndex` on each `Sub.Every` tick. See the
+[async tutorial](../tut/03-async.md) for the full pattern.
+
+### StatusBar
+
+3-column header/footer in inverse video.
+
+```scala
+widgets.StatusBar(
+  width  = 80,
+  left   = " ▌ TermFlow ",
+  center = " connected ",
+  right  = "  q quit "
+)
+```
+
+### MenuBar
+
+Top-of-screen menu bar with dropdown items.
+
+```scala
+val menus = Vector(
+  MenuBar.Menu("File", items = Vector("Open…", "Save", "Quit")),
+  MenuBar.Menu("Edit", items = Vector("Undo", "Redo"))
+)
+val state = MenuBar.State(menus = menus, openIdx = None)
+val node  = MenuBar(state, width = 80)
+```
+
+## Form
+
+The composite `Form.column` helper renders multi-row forms with
+labels, focus-aware widgets, and inline validation. The
+[forms tutorial](../tut/04-forms-and-dialogs.md#8-building-forms-with-widgetsformcolumn)
+walks through it end-to-end.
+
+```scala
+widgets.Form.column(
+  rows         = Vector(
+    Form.Row(NameId,  "Name:",  focused => TextField.view(name,  lineWidth = 28, focused = focused)),
+    Form.Row(EmailId, "Email:", focused => TextField.view(email, lineWidth = 28, focused = focused))
+  ),
+  focusManager = fm,
+  at           = Coord(2.x, 4.y),
+  labelWidth   = 8,
+  gap          = 1,
+  errors       = Map("wiz-email" -> "Email must contain '@'")
+)
+```
+
+## Coverage
+
+The complete file list is checked by
+[`scripts/check_widget_docs.sh`](https://github.com/llm4s/termflow/blob/main/scripts/check_widget_docs.sh)
+in CI: any new file under
+`modules/termflow-widgets/src/main/scala/termflow/tui/widgets/` that
+isn't mentioned in this guide will fail the build.
+
+For full per-widget API, see the [Scaladoc](../reference/api.md).

--- a/scripts/check_widget_docs.sh
+++ b/scripts/check_widget_docs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Verify that every widget under termflow-widgets is mentioned in the
+# user-facing widgets guide. Prevents the catalogue page from rotting
+# silently when a new widget is added.
+#
+# Run from the repo root; exits non-zero with a clear diff if any
+# widget file isn't named in docs/guide/widgets.md.
+
+set -euo pipefail
+
+WIDGET_DIR="modules/termflow-widgets/src/main/scala/termflow/tui/widgets"
+GUIDE="docs/guide/widgets.md"
+
+if [[ ! -d "$WIDGET_DIR" ]]; then
+  echo "$0: widget directory not found at $WIDGET_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$GUIDE" ]]; then
+  echo "$0: widgets guide not found at $GUIDE" >&2
+  exit 1
+fi
+
+missing=()
+for src in "$WIDGET_DIR"/*.scala; do
+  name="$(basename "$src" .scala)"
+  if ! grep -qE "(^|[^A-Za-z])${name}([^A-Za-z]|$)" "$GUIDE"; then
+    missing+=("$name")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "ERROR: the following widgets are missing from $GUIDE:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  echo "" >&2
+  echo "Add a section for each new widget, then re-run this script." >&2
+  exit 1
+fi
+
+echo "OK: all $(ls -1 "$WIDGET_DIR"/*.scala | wc -l | tr -d ' ') widgets covered in $GUIDE"


### PR DESCRIPTION
## Summary

Phase C — replaces the seven guide stubs from Phase A with real
per-layer content, plus an automated widget-coverage gate.

### Guides

- **terminal-layer** — \`TerminalBackend\`, \`KeyDecoder.InputKey\`, \`Capabilities\` + \`ColorDepth\`, \`MouseEvent\` ADT, \`WCWidth\`, \`Grapheme\`.
- **screen-layer** — \`VNode\` tree, \`Layout\` DSL with \`Fill\` / \`Zone\`, \`HitTest[Id]\`, \`Theme\` + \`BorderChars\`, \`RenderFrame\`.
- **app-layer** — \`TuiApp\` contract, \`Cmd\` cases, \`Sub\` factories + auto-register, \`RuntimeCtx\`, \`FocusManager\`, \`Dialogs\`, \`Prompt\`.
- **widgets** — full catalogue (20 widgets) grouped Inputs / Data / Layout / Feedback / Form, with code snippets.
- **keymap** — composition, builders, mode stacks, help-overlay rendering.
- **theming** — slot semantics, capability gating, \`BorderChars\`, runtime switching.
- **testing** — \`TuiTestDriver\`, frame assertions, \`GoldenSupport\`, \`KeySim\` / \`MouseSim\`, async-\`FCmd\` patterns.

### Coverage gate

\`scripts/check_widget_docs.sh\` greps every file under \`modules/termflow-widgets/.../widgets/\` and fails if any aren't mentioned in \`docs/guide/widgets.md\`. Wired into \`.github/workflows/ci.yml\` next to the existing scala3 style gate — a new widget that nobody documents fails the build.

Currently passes for all 20 shipped widgets.

## Stacked on #183

This PR targets \`feat/docs-site-phase-b\`. Merge order: **#182 → #183 → #184**, or squash-merge in that order.

## Test plan

- [x] \`mdbook build\` — clean (linkcheck enabled, zero broken links)
- [x] \`scripts/check_widget_docs.sh\` — passes (20/20)
- [x] \`sbt ciCheck\` — green
- [ ] CI green on this PR