### PR TITLE
docs: cookbook + widgets-guide accuracy fixes (Stage 4 §7.2 Phase D)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,14 @@
 # Cookbook
 
 - [Index](cookbook/index.md)
+- [Show a confirm dialog](cookbook/confirm-dialog.md)
+- [Stream output into a scrollback view](cookbook/streaming-output.md)
+- [Pause and resume a timer](cookbook/timer-pause-resume.md)
+- [Open a file picker](cookbook/file-picker.md)
+- [Draggable splitter](cookbook/split-pane-drag.md)
+- [Mouse on a custom widget](cookbook/mouse-on-custom-widget.md)
+- [Wide-character input](cookbook/wide-character-input.md)
+- [Clean shutdown](cookbook/clean-shutdown.md)
 
 # Reference
 

--- a/docs/cookbook/clean-shutdown.md
+++ b/docs/cookbook/clean-shutdown.md
@@ -1,0 +1,107 @@
+# Clean shutdown on `Ctrl-C` and on resize
+
+Two events that *should* always restore the terminal cleanly:
+
+1. **`Ctrl-C`** — user wants to quit, fast.
+2. **Window resize** — not a shutdown event itself, but a frequent
+   trigger for "my app crashed and now my terminal is broken".
+
+The runtime handles most of this for you. The remaining work is
+making sure your app dispatches `Cmd.Exit` from the right places.
+
+## What the runtime already does
+
+- `TuiRuntime.run` registers a JVM shutdown hook that restores the
+  terminal (alt-buffer off, cursor visible, raw mode off, mouse
+  tracking off) even on uncaught exceptions or `kill`.
+- All `Sub`s registered via `RuntimeCtx` (`Sub.Every`, `Sub.InputKey`,
+  `Sub.TerminalResize`) auto-cancel on `Cmd.Exit` *and* on shutdown.
+- The renderer watches for SIGWINCH (size change) and re-renders
+  without you doing anything.
+
+## What you have to wire
+
+- A `Quit` `Msg` and a `Cmd.Exit` follow-up for it.
+- A keystroke that produces `Quit` for `Ctrl-C` (and ideally `q`).
+- An optional re-read of `ctx.terminal.{width, height}` on every
+  `update` so the model knows the current size.
+
+## Code: the canonical wiring
+
+```scala
+import termflow.tui.{Cmd, KeyDecoder, RuntimeCtx, Sub, Tui, TuiApp, TuiRuntime, RootNode}
+import termflow.tui.KeyDecoder.InputKey.*
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+
+object MyApp:
+
+  final case class Model(
+    width:  Int,
+    height: Int,
+    input:  Sub[Msg]
+  )
+
+  enum Msg:
+    case KeyPressed(k: KeyDecoder.InputKey)
+    case Quit
+
+  object App extends TuiApp[Model, Msg]:
+
+    private def syncSize(m: Model, ctx: RuntimeCtx[Msg]): Model =
+      val w = ctx.terminal.width
+      val h = ctx.terminal.height
+      if w == m.width && h == m.height then m else m.copy(width = w, height = h)
+
+    def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val keys = Sub.InputKey[Msg](
+        msg     = Msg.KeyPressed.apply,
+        onError = _ => Msg.Quit,                  // hard-quit on input pump errors
+        ctx     = ctx
+      )
+      Model(ctx.terminal.width, ctx.terminal.height, keys).tui
+
+    def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val sized = syncSize(m, ctx)
+      msg match
+        case Msg.KeyPressed(Ctrl('C'))  => Tui(sized, Cmd.Exit)
+        case Msg.KeyPressed(CharKey('q')) => Tui(sized, Cmd.Exit)
+        case Msg.KeyPressed(_)          => sized.tui
+        case Msg.Quit                   => Tui(sized, Cmd.Exit)
+
+    def view(m: Model): RootNode =
+      RootNode(m.width, m.height, children = /* … */, input = None)
+
+    def toMsg(input: PromptLine): Result[Msg] = Right(Msg.Quit)
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)
+```
+
+## Notes
+
+- **`syncSize` on every update** is the cheapest way to stay correct
+  on resize. The cost is a single `==` comparison per message —
+  effectively free.
+- **`Ctrl-C` should always quit.** Don't be tempted to swallow it:
+  if your app hangs, the user will reach for `Ctrl-C` and expect a
+  graceful exit.
+- **Quit during a modal dialog.** If you have an open `Dialogs`
+  overlay, `Ctrl-C` can either close the dialog or quit the whole
+  app. Pick one and be consistent. Most apps treat `Ctrl-C` as
+  unconditional quit and `Esc` as "close the dialog".
+- **Quit during text input.** Inside a `Prompt` or `TextField`,
+  `q` is a literal letter — only quit on `q` *outside* text fields.
+  The wizard sample shows the
+  [quit-when-not-in-text-field](../tut/04-forms-and-dialogs.md#7-quit-semantics--quit-when-not-in-text-field)
+  idiom.
+- **Don't `System.exit`.** It bypasses the runtime's cleanup. Always
+  return `Cmd.Exit` from `update`; the runtime takes it from there.
+- **Crash recovery.** If your app crashes despite all of this,
+  `reset` in your shell will get the terminal back. The shutdown
+  hook makes this rare.
+
+For a working example, every demo app under
+[`modules/termflow-sample/.../apps`](https://github.com/llm4s/termflow/tree/main/modules/termflow-sample/src/main/scala/termflow/apps)
+follows this pattern.

--- a/docs/cookbook/confirm-dialog.md
+++ b/docs/cookbook/confirm-dialog.md
@@ -1,0 +1,91 @@
+# Show a confirm dialog and act on the answer
+
+`Dialogs.confirm` returns an `Overlay` value — it does *not* take
+callbacks. The app owns the dialog's open/closed state and the
+focused button; key events route to whichever side owns focus.
+
+## Pattern
+
+1. Add a flag (or sealed `case class`) to your model that says "the
+   confirm dialog is open and waiting for an answer".
+2. In `view`, when that flag is set, append the `Dialogs.confirm`
+   overlay to `RootNode.overlays`.
+3. In `update`, route key events to the dialog when it's open: arrow
+   keys flip the focused button, `Enter`/`Space` commits, `Escape`
+   cancels.
+
+## Code
+
+```scala
+import termflow.tui.{Dialogs, Theme}
+import termflow.tui.KeyDecoder.InputKey.*
+
+final case class Model(
+  /* … domain fields … */,
+  confirm: Option[ConfirmState]
+)
+
+enum ConfirmState:
+  case Open(yesFocused: Boolean)   // dialog visible, button focus tracked here
+
+enum Msg:
+  case AskDelete             // user requested the destructive action
+  case ConfirmYes
+  case ConfirmNo
+  case ConfirmKey(k: InputKey)
+
+def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.AskDelete =>
+      m.copy(confirm = Some(ConfirmState.Open(yesFocused = false))).tui
+
+    case Msg.ConfirmKey(k) =>
+      m.confirm match
+        case Some(ConfirmState.Open(yesFocused)) =>
+          k match
+            case ArrowLeft | ArrowRight | Tab | BackTab =>
+              m.copy(confirm = Some(ConfirmState.Open(!yesFocused))).tui
+            case Enter | CharKey(' ') =>
+              if yesFocused then m.copy(confirm = None).gCmd(Msg.ConfirmYes)
+              else              m.copy(confirm = None).gCmd(Msg.ConfirmNo)
+            case Escape =>
+              m.copy(confirm = None).gCmd(Msg.ConfirmNo)
+            case _ => m.tui
+        case None => m.tui
+
+    case Msg.ConfirmYes =>  /* perform the destructive action */
+    case Msg.ConfirmNo  =>  m.tui /* no-op */
+
+def view(m: Model): RootNode =
+  given Theme = Theme.dark
+  val baseChildren = /* … */
+  val overlays = m.confirm match
+    case Some(ConfirmState.Open(yesFocused)) =>
+      List(Dialogs.confirm(
+        prompt     = "Delete this file?",
+        yesFocused = yesFocused,
+        title      = "Confirm delete",
+        yesLabel   = "Yes",
+        noLabel    = "No"
+      ))
+    case None => Nil
+
+  RootNode(80, 24, children = baseChildren, input = None, overlays = overlays)
+```
+
+## Notes
+
+- **Why `Option[ConfirmState]` and not just `Boolean`?** It scales —
+  add `Open(yesFocused, prompt: String)` later and any caller of
+  `AskDelete` can pass its own prompt.
+- **Always re-route keys when a dialog is open.** Don't forget to
+  intercept the global keymap so `q` doesn't quit while the dialog is
+  modal. The simplest pattern is: if `m.confirm.isDefined`, route the
+  whole keystream into `ConfirmKey` and skip your normal handlers.
+- **Mouse clicks on overlays.** `Dialogs.confirm` is mouse-aware in
+  the renderer; if you want clicks on the buttons to flip focus,
+  pair the dialog with `Layout.resolveTracked` and dispatch
+  `ConfirmKey` from the hit-test result.
+
+For a working example, see the showcase's *Dialogs* tab —
+[`Stage1ShowcaseApp.scala`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala).

--- a/docs/cookbook/file-picker.md
+++ b/docs/cookbook/file-picker.md
@@ -1,0 +1,129 @@
+# Open a file picker and load the result
+
+`Dialogs.fileDialog` is a presentational overlay — like
+`Dialogs.confirm`, it returns an `Overlay` and doesn't take
+callbacks. The app owns the current path, the directory listing, the
+selected index, and rebuilds the listing when the user steps into a
+subdirectory.
+
+## Pattern
+
+1. Hold a `picker: Option[PickerState]` on the model with the path,
+   entries, and selected index.
+2. On `Open`, list the start directory and store it in the picker.
+3. Route keys to the picker while it's open — Enter dives into a
+   directory or returns the selected file; Esc cancels.
+4. On commit, close the picker and dispatch a domain `Msg` carrying
+   the chosen path.
+
+## Code
+
+```scala
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+
+import termflow.tui.{Dialogs, FileEntry, Theme}
+import termflow.tui.KeyDecoder.InputKey.*
+
+final case class PickerState(
+  path:          Path,
+  entries:       Seq[FileEntry],
+  selectedIndex: Int,
+  okFocused:     Boolean = true
+)
+
+final case class Model(
+  loadedFile: Option[Path],
+  picker:     Option[PickerState]
+)
+
+enum Msg:
+  case OpenPicker
+  case PickerKey(k: InputKey)
+  case FileChosen(p: Path)
+  case PickerCancelled
+
+def listDir(p: Path): Seq[FileEntry] =
+  // FileEntry has fields name, path, isDir, sizeBytes — see
+  // termflow.tui.FileEntry. Skipping sort/hidden filtering for brevity.
+  Files.list(p).iterator.asScala.toList.map(FileEntry.fromPath).sortBy(e => (!e.isDir, e.name))
+
+def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.OpenPicker =>
+      val cwd = Path.of(System.getProperty("user.dir"))
+      m.copy(picker = Some(PickerState(cwd, listDir(cwd), 0))).tui
+
+    case Msg.PickerKey(k) =>
+      m.picker match
+        case None => m.tui
+        case Some(p) =>
+          k match
+            case ArrowDown =>
+              val next = math.min(p.entries.size - 1, p.selectedIndex + 1)
+              m.copy(picker = Some(p.copy(selectedIndex = next))).tui
+
+            case ArrowUp =>
+              val next = math.max(0, p.selectedIndex - 1)
+              m.copy(picker = Some(p.copy(selectedIndex = next))).tui
+
+            case Enter | CharKey(' ') =>
+              p.entries.lift(p.selectedIndex) match
+                case Some(entry) if entry.isDir =>
+                  // Step in: rebuild listing
+                  m.copy(picker = Some(p.copy(
+                    path          = entry.path,
+                    entries       = listDir(entry.path),
+                    selectedIndex = 0
+                  ))).tui
+                case Some(entry) =>
+                  m.copy(picker = None).gCmd(Msg.FileChosen(entry.path))
+                case None => m.tui
+
+            case Escape =>
+              m.copy(picker = None).gCmd(Msg.PickerCancelled)
+
+            case _ => m.tui
+
+    case Msg.FileChosen(p) =>
+      m.copy(loadedFile = Some(p)).tui
+
+    case Msg.PickerCancelled =>
+      m.tui
+
+def view(m: Model): RootNode =
+  given Theme = Theme.dark
+  val baseChildren = /* … */
+  val overlays = m.picker.toList.map { p =>
+    Dialogs.fileDialog(
+      title         = "Open file",
+      currentPath   = p.path,
+      entries       = p.entries,
+      selectedIndex = p.selectedIndex,
+      okFocused     = p.okFocused,
+      maxVisible    = 12,
+      showSizes     = true
+    )
+  }
+  RootNode(80, 24, children = baseChildren, input = None, overlays = overlays)
+```
+
+## Notes
+
+- **`FileEntry`** is a small case class shipped in `termflow.tui`
+  with `name`, `path`, `isDir`, `sizeBytes`. Build your own list any
+  way you like — flat directory listing, recursive search,
+  pre-filtered globs. The dialog only renders.
+- **Hidden / dotfiles.** Filter at the `listDir` level so the dialog
+  never shows them. Adding a `showHidden: Boolean` to `PickerState`
+  is straightforward.
+- **Read the file inside `FileChosen`** if it's small. For larger
+  loads, return `Cmd.FCmd(Future { … }, Msg.LoadDone.apply)` and
+  treat it as async work — the
+  [Async tutorial](../tut/03-async.md) covers the pattern.
+- **Symlink loops** are not detected by `listDir` above — guard with
+  `Files.readAttributes(..., LinkOption.NOFOLLOW_LINKS)` if you walk
+  user-supplied trees.
+
+For a working example, see
+[`apps.dialog.FileDialogDemoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/dialog/FileDialogDemoApp.scala).

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -1,22 +1,35 @@
 # Cookbook
 
-> *Stub — recipes land in Phase D of the docs roll-out.*
+Short "how do I…" recipes. Each one is one or two screens of
+explanation plus a self-contained snippet, grounded in actual
+TermFlow APIs and (where possible) a sample app you can run.
 
-The cookbook will be a flat list of short "how do I…" entries. Each one
-has a one-paragraph problem statement, a self-contained snippet, and a
-link to a working sample app or test.
+## Recipes
 
-Recipes planned for the first cut:
+- **[Show a confirm dialog and act on the answer](confirm-dialog.md)**
+  — `Dialogs.confirm`, model-owned dialog state, key routing while
+  modal.
+- **[Stream output into a scrollback view](streaming-output.md)** —
+  `widgets.LogView`, append-and-tail buffering, auto-tail vs. paused
+  scroll.
+- **[Pause and resume a `Sub.Every` timer](timer-pause-resume.md)** —
+  cancel + recreate, `Sub.NoSub` placeholder, interval changes.
+- **[Open a file picker and load the result](file-picker.md)** —
+  `Dialogs.fileDialog` integration pattern, directory navigation,
+  Esc-to-cancel.
+- **[Two-pane layout with a draggable splitter](split-pane-drag.md)**
+  — `SplitPane.handleMouse`, `DragState`, keyboard-equivalent
+  shortcuts.
+- **[Capture mouse clicks on a custom widget](mouse-on-custom-widget.md)**
+  — `Layout.Zone` + `Layout.resolveTracked` + `HitTest[Id]`.
+- **[Wide-character (CJK / emoji) input handling](wide-character-input.md)**
+  — `WCWidth`, `Grapheme`, `RenderCell.width = 2`.
+- **[Clean shutdown on `Ctrl-C` and on resize](clean-shutdown.md)** —
+  what the runtime does for you, where you still have to wire `Cmd.Exit`.
 
-- **Show a confirm dialog and wait for the answer.**
-- **Stream LLM tokens into a scrollback view.**
-- **Pause and resume a `Sub.Every` timer.**
-- **Open a file picker and load the result.**
-- **Two-pane layout with a draggable splitter.**
-- **Capture mouse clicks on a custom widget.**
-- **Wide-character (CJK / emoji) input handling.**
-- **Clean shutdown on `Ctrl-C` and on resize.**
-- **Per-step `FocusManager` for multi-screen flows.**
-- **Custom theme with `Theme.copy`.**
+## Want more?
 
-Have a recipe you'd like to see written up? [Open an issue](https://github.com/llm4s/termflow/issues).
+Recipe gaps are tracked as GitHub issues. If you've got a "how do I
+do X" that isn't covered, please
+[open an issue](https://github.com/llm4s/termflow/issues) — most
+recipes start as a question that came up twice.

--- a/docs/cookbook/mouse-on-custom-widget.md
+++ b/docs/cookbook/mouse-on-custom-widget.md
@@ -1,0 +1,103 @@
+# Capture mouse clicks on a custom widget
+
+The screen layer ships a hit-test cache built into the layout pass.
+Wrap any subtree in `Layout.Zone(id, content)` and call
+`Layout.resolveTracked[Id]` instead of `resolve` — you get a
+`HitTest[Id]` mapping click coordinates back to your zone IDs.
+
+This is how the showcase routes clicks on its action-list dialog,
+its tree, and its tab headers.
+
+## Pattern
+
+1. Tag every interactive sub-layout with `Layout.Zone(id, content)`.
+   IDs can be any type — `String`, an `enum`, a generic `Int`.
+2. Use `Layout.resolveTracked[Id](layout, at, w, h)` when rendering;
+   keep the returned `HitTest[Id]` on the model (or rebuild it
+   every frame).
+3. On a `MouseEvent.Press`, ask the cache `hits.hit(col, row)` and
+   dispatch the matching `Msg`.
+
+## Code
+
+```scala
+import termflow.tui.{HitTest, Layout, Coord, MouseEvent, KeyDecoder}
+import termflow.tui.KeyDecoder.InputKey.*
+
+enum WidgetZone:
+  case ButtonA, ButtonB, ListRow(idx: Int)
+
+final case class Model(
+  hits:        HitTest[WidgetZone],
+  selected:    Option[Int],
+  /* … */
+)
+
+enum Msg:
+  case Mouse(e: MouseEvent)
+  case ClickedA
+  case ClickedB
+  case ClickedRow(idx: Int)
+
+def buildLayout(rowCount: Int): Layout =
+  Layout.column(gap = 1)(
+    Layout.zone(WidgetZone.ButtonA,
+      Layout.Elem(TextNode(1.x, 1.y, List("[ A ]".text(fg = Color.Green))))
+    ),
+    Layout.zone(WidgetZone.ButtonB,
+      Layout.Elem(TextNode(1.x, 1.y, List("[ B ]".text(fg = Color.Cyan))))
+    ),
+    Layout.column(gap = 0)(
+      (0 until rowCount).toList.map(i =>
+        Layout.zone(WidgetZone.ListRow(i),
+          Layout.Elem(TextNode(1.x, 1.y, List(s"row $i".text)))
+        )
+      )*
+    )
+  )
+
+def view(m: Model): RootNode =
+  given Theme = Theme.dark
+  val (nodes, hits) = Layout.resolveTracked[WidgetZone](
+    buildLayout(rowCount = 10),
+    at              = Coord(2.x, 2.y),
+    availableWidth  = 78,
+    availableHeight = 22
+  )
+  // Stash the hit-test cache on the next render — store it in the model
+  // via a Cmd.GCmd or accept the rebuild cost (which is tiny).
+  RootNode(80, 24, children = nodes, input = None)
+
+def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.Mouse(MouseEvent.Press(_, col, row, _)) =>
+      m.hits.hit(col, row) match
+        case Some(WidgetZone.ButtonA)        => m.gCmd(Msg.ClickedA)
+        case Some(WidgetZone.ButtonB)        => m.gCmd(Msg.ClickedB)
+        case Some(WidgetZone.ListRow(idx))   => m.gCmd(Msg.ClickedRow(idx))
+        case None                            => m.tui
+    case Msg.Mouse(_)                        => m.tui
+    case Msg.ClickedA                        => /* ... */
+    case Msg.ClickedB                        => /* ... */
+    case Msg.ClickedRow(i)                   => m.copy(selected = Some(i)).tui
+```
+
+## Notes
+
+- **The cache is per-frame.** Rebuild it inside `view` (or via a
+  helper called from `view`) and either pass it through to a
+  click-handler in the same closure, or stash it in the model so
+  `update` can look it up next time. The showcase uses the second
+  approach — see `actionListHitTest` in
+  [`Stage1ShowcaseApp.scala`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala).
+- **Topmost wins.** When zones nest, `hits.hit(col, row)` returns the
+  *last-inserted* match — overlays naturally win over the background.
+- **`Layout.zone(id, vnode)`** is shorthand for
+  `Layout.Zone(id, Layout.Elem(vnode))` when you want to tag a single
+  vnode without wrapping it in a layout.
+- **No `Zone` for keyboard.** Hit-test is mouse-only. Focus
+  navigation routes through `FocusManager`, which uses `FocusId`.
+  The two are deliberately separate concerns.
+
+The full hit-test surface lives in
+`modules/termflow-screen/src/main/scala/termflow/tui/HitTest.scala`.

--- a/docs/cookbook/split-pane-drag.md
+++ b/docs/cookbook/split-pane-drag.md
@@ -1,0 +1,97 @@
+# Two-pane layout with a draggable splitter
+
+`SplitPane` ships with a `DragState` and a pure `handleMouse` that
+turns a `MouseEvent` stream into a new `splitRatio`. Pair it with
+keyboard shortcuts (`[` / `]`) and you get a fully interactive
+divider in ~20 lines.
+
+## Pattern
+
+1. Hold a `SplitPane.DragState` on the model — `splitRatio: Double`
+   in `[0.0, 1.0]`, `dragging: Boolean` for "we're mid-gesture".
+2. Route mouse events into `SplitPane.handleMouse` to update drag
+   state.
+3. Map `[` / `]` (or whatever keys you like) to `splitRatio - 0.05`
+   and `+0.05` for keyboard control.
+4. Use `m.split.splitRatio` when laying out the two panes.
+
+## Code
+
+```scala
+import termflow.tui.widgets.SplitPane
+import termflow.tui.{Coord, KeyDecoder, MouseEvent}
+import termflow.tui.KeyDecoder.InputKey.*
+
+final case class Model(
+  split:    SplitPane.DragState,
+  /* … */
+)
+
+enum Msg:
+  case Mouse(e: MouseEvent)
+  case Wider, Narrower, ResetSplit
+
+def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.Mouse(e) =>
+      val next = SplitPane.handleMouse(
+        state     = m.split,
+        event     = e,
+        direction = SplitPane.Direction.Vertical,  // pane divider runs vertically
+        width     = ctx.terminal.width,
+        height    = ctx.terminal.height,
+        at        = Coord(1.x, 1.y),
+        gap       = 1
+      )
+      m.copy(split = next).tui
+
+    case Msg.Wider =>
+      m.copy(split = m.split.copy(splitRatio = math.min(0.9, m.split.splitRatio + 0.05))).tui
+
+    case Msg.Narrower =>
+      m.copy(split = m.split.copy(splitRatio = math.max(0.1, m.split.splitRatio - 0.05))).tui
+
+    case Msg.ResetSplit =>
+      m.copy(split = SplitPane.DragState(splitRatio = 0.5, dragging = false)).tui
+
+def view(m: Model): RootNode =
+  given Theme = Theme.dark
+  val w        = 80
+  val h        = 24
+  val leftCols = math.max(1, (w * m.split.splitRatio).toInt)
+
+  val left  = Layout.column(gap = 0)(
+    /* left-pane vnodes */
+  )
+  val right = Layout.column(gap = 0)(
+    /* right-pane vnodes */
+  )
+
+  val divider = TextNode((leftCols + 1).x, 1.y, List(
+    "│".text(fg = if m.split.dragging then Color.Yellow else Color.White)
+  ))
+
+  val nodes = left.resolve(Coord(1.x, 1.y)) ++
+              right.resolve(Coord((leftCols + 2).x, 1.y)) ++
+              List(divider)
+
+  RootNode(w, h, children = nodes, input = None)
+```
+
+## Notes
+
+- **`Direction.Vertical` means a vertical divider** that splits the
+  width — left pane / right pane. `Direction.Horizontal` is a
+  horizontal divider (top / bottom split).
+- **Recolouring during drag** — `m.split.dragging` is `true` between
+  Press and Release; rendering the divider in `theme.warning` gives
+  immediate feedback that the gesture is live.
+- **Clamp the ratio** to `[0.05, 0.95]` if you want to keep both
+  panes visible. `SplitPane.handleMouse` doesn't clamp — it lets you
+  drag the divider all the way to the edge.
+- **Keystroke vs mouse** — pick reasonable shortcuts for users who
+  don't have a mouse or are working over an SSH session that
+  doesn't pass mouse events. The showcase uses `[` / `]` / `=`.
+
+For a working example, see the showcase's *Layout* tab —
+[`Stage1ShowcaseApp.scala`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala).

--- a/docs/cookbook/streaming-output.md
+++ b/docs/cookbook/streaming-output.md
@@ -1,0 +1,90 @@
+# Stream output into a scrollback view
+
+`LogView` is a stateless renderer that takes a `Seq[String]` and a
+`scrollOffset`. The app owns the buffer and decides whether to
+auto-tail (stay pinned to the latest line) or pause (when the user
+has scrolled up).
+
+This pattern fits any streaming source: LLM tokens, build output,
+log tails, network frames.
+
+## Pattern
+
+1. Hold the buffer (`Vector[String]`) plus a `scrollOffset` and an
+   `autoTail: Boolean` flag on the model.
+2. As new lines arrive (via `Cmd.GCmd(NewLine(...))` or
+   `Sub.Every` polling), append to the buffer; if `autoTail` is set,
+   bump `scrollOffset` to keep the bottom in view.
+3. ArrowUp / ArrowDown adjust `scrollOffset` and toggle `autoTail`.
+
+## Code
+
+```scala
+import termflow.tui.widgets
+
+final case class Model(
+  buffer:       Vector[String],
+  scrollOffset: Int,
+  autoTail:     Boolean
+):
+  def append(line: String, viewW: Int, viewH: Int): Model =
+    val nextBuf  = (buffer :+ line).takeRight(2000)   // bound the history
+    val maxScr   = widgets.LogView.maxScroll(nextBuf, viewW, viewH, wrap = true)
+    val nextScr  = if autoTail then maxScr else math.min(scrollOffset, maxScr)
+    copy(buffer = nextBuf, scrollOffset = nextScr)
+
+enum Msg:
+  case TokenArrived(text: String)
+  case Up
+  case Down
+
+def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.TokenArrived(t) =>
+      m.append(t, viewW = ctx.terminal.width - 4, viewH = 16).tui
+
+    case Msg.Up =>
+      val maxScr = widgets.LogView.maxScroll(m.buffer, ctx.terminal.width - 4, 16, true)
+      m.copy(
+        scrollOffset = math.max(0, m.scrollOffset - 1),
+        autoTail     = false
+      ).tui
+
+    case Msg.Down =>
+      val maxScr = widgets.LogView.maxScroll(m.buffer, ctx.terminal.width - 4, 16, true)
+      val next   = math.min(maxScr, m.scrollOffset + 1)
+      m.copy(scrollOffset = next, autoTail = next == maxScr).tui
+
+def view(m: Model): RootNode =
+  given Theme = Theme.dark
+  val viewW = 80 - 4
+  val nodes = widgets.LogView(
+    lines        = m.buffer,
+    width        = viewW,
+    height       = 16,
+    scrollOffset = m.scrollOffset,
+    at           = Coord(2.x, 2.y),
+    wrap         = true
+  )
+  RootNode(80, 24, children = nodes, input = None)
+```
+
+## Notes
+
+- **Bound the buffer.** `takeRight(2000)` keeps the history finite —
+  important when streams can run for hours. The actual cap depends on
+  your domain.
+- **Token vs line.** If your source emits tokens (LLM-style), keep a
+  *partial-line* string on the side and only append to `buffer` when
+  you see a `\n`. Otherwise every token becomes its own row.
+- **Auto-tail toggles automatically.** When the user scrolls back to
+  the bottom (offset == maxScroll), `Down` flips `autoTail = true`
+  again — the convention every chat client uses.
+- **Dropping `wrap = true`** truncates rather than wrapping; the
+  `maxScroll` math still works either way.
+
+For an end-to-end example, see
+[`apps.echo.EchoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/echo/EchoApp.scala),
+which uses a hand-rolled line column instead of `LogView` but
+implements the same scrollback semantics — you can swap to `LogView`
+in 20 lines.

--- a/docs/cookbook/timer-pause-resume.md
+++ b/docs/cookbook/timer-pause-resume.md
@@ -1,0 +1,78 @@
+# Pause and resume a `Sub.Every` timer
+
+`Sub.Every` has no native pause/resume — `cancel()` is final. To
+"resume" you create a new subscription. This is fine because
+subscription construction is cheap and `Sub.NoSub` is a safe
+placeholder.
+
+## Pattern
+
+1. Store the timer `Sub[Msg]` on your model — `Sub.NoSub` when
+   inactive.
+2. To start: replace the field with `Sub.Every(...)`.
+3. To pause: `cancel()` the existing sub and write `Sub.NoSub` back.
+4. To resume: build a fresh `Sub.Every` and store it.
+
+## Code
+
+```scala
+import termflow.tui.{Cmd, Sub, Tui}
+import termflow.tui.Tui.*
+
+final case class Model(
+  ticks:     Int,
+  ticker:    Sub[Msg],    // Sub.NoSub when paused
+  intervalMs: Long
+)
+
+enum Msg:
+  case Tick
+  case Pause
+  case Resume
+  case SetInterval(ms: Long)
+  case Quit
+
+def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.Tick =>
+      m.copy(ticks = m.ticks + 1).tui
+
+    case Msg.Pause =>
+      if m.ticker.isActive then m.ticker.cancel()
+      m.copy(ticker = Sub.NoSub).tui
+
+    case Msg.Resume =>
+      if m.ticker.isActive then m.tui   // already running
+      else m.copy(ticker = Sub.Every(m.intervalMs, () => Msg.Tick, ctx)).tui
+
+    case Msg.SetInterval(ms) =>
+      // Changing interval = cancel + restart with the new rate.
+      if m.ticker.isActive then m.ticker.cancel()
+      m.copy(
+        intervalMs = ms,
+        ticker     = Sub.Every(ms, () => Msg.Tick, ctx)
+      ).tui
+
+    case Msg.Quit =>
+      if m.ticker.isActive then m.ticker.cancel()
+      Tui(m, Cmd.Exit)
+```
+
+## Notes
+
+- **`isActive` check before `cancel()`** is paranoia — `cancel()` is
+  idempotent, but the guard makes the intent explicit.
+- **`Sub.Every` auto-registers via `ctx`** so the runtime cancels it
+  on `Cmd.Exit` regardless of whether you remembered to. The explicit
+  cancel above is defensive.
+- **Don't capture `m.intervalMs` at sub construction** — pass it
+  through. The thunk `() => Msg.Tick` re-evaluates per tick, but the
+  `millis` argument is fixed for the sub's lifetime.
+- **Multiple timers** don't share a thread — each `Sub.Every` spins up
+  its own `ScheduledExecutorService`. Cheap, but worth knowing if
+  you're building a thousand-timer app.
+
+For a working example, see the *Async work* tutorial — the
+`FutureCounter` spinner uses exactly this pattern, except the start /
+stop boundary is "async work in flight" rather than user-driven
+pause.

--- a/docs/cookbook/wide-character-input.md
+++ b/docs/cookbook/wide-character-input.md
@@ -1,0 +1,107 @@
+# Wide-character (CJK / emoji) input handling
+
+CJK ideographs and most emoji take **two terminal cells**. Combining
+marks like the acute accent in `é = e + ́` take **zero**. Naïve
+`String.length` is wrong about both. Render and edit code that
+ignores this clips characters, miscounts cursor positions, and
+leaves stray cells when text shrinks.
+
+TermFlow's prompt and multi-line widgets handle this for you out of
+the box. If you're building your own text widget, the rules are
+straightforward.
+
+## Pattern
+
+Three primitives:
+
+| Need | Use |
+|---|---|
+| How wide is this char/string? | `WCWidth.charWidth(c)` / `stringWidth(s)` |
+| Where's the previous grapheme boundary? | `Grapheme.previousBoundary(s, idx)` |
+| Where's the next? | `Grapheme.nextBoundary(s, idx)` |
+
+Apply them in two places:
+
+1. **Cursor column math.** When rendering a text input, the cursor's
+   *visual* column is `WCWidth.stringWidth(text.take(charIndex))`,
+   not `charIndex` itself.
+2. **Backspace / Delete.** Move by graphemes, not by chars or code
+   points.
+
+## Code: cursor column
+
+```scala
+import termflow.tui.WCWidth
+
+def cursorColumn(buffer: String, charIndex: Int): Int =
+  WCWidth.stringWidth(buffer.take(charIndex))
+
+cursorColumn("hello", 3)        // 3
+cursorColumn("こんにちは", 3)   // 6  (3 wide chars × 2)
+cursorColumn("👋🏽 hi", 3)      // 4  (👋🏽 = 2 cells, space = 1)
+```
+
+`Prompt.cursorColumn(state)` does exactly this — see
+`modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala`.
+
+## Code: grapheme-aware Backspace
+
+```scala
+import termflow.tui.Grapheme
+
+def backspace(buffer: String, cursor: Int): (String, Int) =
+  if cursor == 0 then (buffer, 0)
+  else
+    val prev    = Grapheme.previousBoundary(buffer, cursor)
+    val without = buffer.substring(0, prev) + buffer.substring(cursor)
+    (without, prev)
+
+backspace("café", 4)   // ("caf", 3) — drops "é" cleanly even though it's 2 chars
+backspace("👋🏽hi", 4)  // ("hi", 0)  — drops the whole emoji+modifier
+```
+
+`Prompt.handleKey` already does this internally for `Backspace`,
+`Delete`, `ArrowLeft`, `ArrowRight`. If you reach for it, you don't
+have to.
+
+## Code: rendering wide cells in a custom widget
+
+```scala
+import termflow.tui.WCWidth
+
+// When laying out one row of text into cells, advance by width(c):
+def stringToCells(text: String, style: Style): List[RenderCell] =
+  val out = List.newBuilder[RenderCell]
+  text.foreach { ch =>
+    WCWidth.charWidth(ch) match
+      case 1 => out += RenderCell(ch, style, width = 1)
+      case 2 => out += RenderCell(ch, style, width = 2)  // takes two cells
+      case 0 => /* combining; skip — should fold into prior cell */
+      case _ => /* control; skip */
+  }
+  out.result()
+```
+
+The `RenderCell.width = 2` flag is what tells `AnsiRenderer` to
+*skip* the next cell — it knows the wide glyph already covers it.
+
+## Notes
+
+- **Don't mix `String.length` with cell math.** They aren't the
+  same. If you find yourself comparing one to the other, you almost
+  certainly have a bug.
+- **`Grapheme.count(s)`** returns the number of user-visible
+  characters, not cells. It's the right thing for "how many
+  characters has the user typed?", which is rarely what you actually
+  want for layout.
+- **`NO_COLOR` and `LANG=C`.** Some terminals are configured to
+  refuse Unicode. The `Capabilities.unicode` flag tells you whether
+  to use ASCII fallbacks (`Theme` already does this for box-drawing
+  glyphs).
+- **Combining sequences.** `Grapheme.previousBoundary` walks across
+  full graphemes including ZWJ sequences (👨‍👩‍👧‍👦), skin-tone
+  modifiers (👋🏽), and regional indicators (🇯🇵🇺🇸).
+
+For a working example, see the showcase's *Inputs* tab — type CJK
+and emoji into the `MultiLineInput` and watch the cursor track
+correctly.

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -136,42 +136,70 @@ val state = Table.State(columns = cols, rows = Vector(Vector("alice","42")))
 
 ### Tree
 
-Recursive collapsible tree.
+Recursive collapsible tree. Stateless — the app owns `expanded:
+Set[Id]` and `selectedIndex: Int`; the renderer takes a typeclass
+`Children[A, Id]` describing how to traverse your data structure.
 
 - Expanded glyph: `[-] `
 - Collapsed glyph: `[+] `
 - Leaf glyph: `    ` (four spaces)
 
 ```scala
-val tree = Tree.State(root = Tree.Node("root", children = …))
-val nodes = Tree.view(tree, width = 32, focused = true)
+case class Node(name: String, kids: Vector[Node])
+given widgets.Tree.Children[Node, String] with
+  def id(n: Node):   String        = n.name
+  def kids(n: Node): Vector[Node]  = n.kids
+
+val nodes = widgets.Tree(
+  roots         = Vector(Node("src", Vector(Node("Main.scala", Vector.empty)))),
+  expanded      = Set("src"),
+  selectedIndex = 0,
+  render        = _.name,
+  at            = Coord(2.x, 2.y)
+)
 
 // Mouse: distinguish chevron clicks from label clicks
-Tree.hitTest(rows, at = Rect(...), indentWidth = 2, col, row, labelLength) match
-  case Tree.HitResult.Chevron(idx) => /* toggle expansion */
-  case Tree.HitResult.Label(idx)   => /* select */
-  case _                           => /* miss */
+val rows = widgets.Tree.visibleRows(roots, expanded)
+widgets.Tree.hitTest(rows, at = Coord(2.x, 2.y), indentWidth = 2, col, row) match
+  case Some(widgets.Tree.HitResult.Chevron(idx)) => /* toggle expansion */
+  case Some(widgets.Tree.HitResult.Label(idx))   => /* select */
+  case None                                      => /* miss */
 ```
 
 ### LogView
 
-Tail-following log buffer. Auto-scrolls until the user scrolls up,
-then pauses until they scroll back to the bottom.
+Stateless line-buffer viewer. The app owns the `Vector[String]`
+buffer and the current `scrollOffset`; `LogView` wraps and clips
+into the requested viewport.
 
 ```scala
-val log = LogView.State.empty
-val updated = LogView.append(log, "build started", Style(fg = Yellow))
-val node = LogView.view(updated, width = 80, height = 16)
+val node = widgets.LogView(
+  lines        = m.logBuffer,            // Seq[String]
+  width        = 80,
+  height       = 16,
+  scrollOffset = m.scrollOffset,
+  wrap         = true
+)
 ```
+
+Use `LogView.maxScroll(lines, width, height, wrap)` when the user
+scrolls so you clamp the offset correctly.
 
 ## Layout
 
 ### Tabs
 
+Stateless tab-header renderer — the app owns the active and focused
+indices and handles tab-switching keys itself.
+
 ```scala
-val state = Tabs.State(labels = Vector("Inputs", "Data", "Layout"), activeIdx = 0)
-val (next, _) = Tabs.handleKey[Msg](state, key)(_ => None)
-val node = Tabs.view(next, width = 80, focused = true)
+val node = widgets.Tabs(
+  labels       = Seq("Inputs", "Data", "Layout"),
+  activeIndex  = m.activeTab,
+  focusedIndex = if m.headerFocused then m.activeTab else -1,
+  at           = Coord(2.x, 1.y),
+  separator    = " │ "
+)
 ```
 
 ### SplitPane
@@ -244,13 +272,19 @@ widgets.StatusBar(
 Top-of-screen menu bar with dropdown items.
 
 ```scala
-val menus = Vector(
-  MenuBar.Menu("File", items = Vector("Open…", "Save", "Quit")),
-  MenuBar.Menu("Edit", items = Vector("Undo", "Redo"))
+val state = widgets.MenuBar.State(
+  menus = Vector(
+    widgets.MenuBar.Menu("File", items = Vector("Open…", "Save", "Quit")),
+    widgets.MenuBar.Menu("Edit", items = Vector("Undo", "Redo"))
+  )
 )
-val state = MenuBar.State(menus = menus, openIdx = None)
-val node  = MenuBar(state, width = 80)
+val widgets.MenuBar.KeyResult(next, picked) = widgets.MenuBar.handleKey(state, key)
+val node = widgets.MenuBar(next, at = Coord(1.x, 1.y), focused = true)
 ```
+
+`KeyResult.picked: Option[(menuIdx, itemIdx)]` is `Some(...)` only on
+the keystroke that committed a selection — fold it into your domain
+`Msg` and dispatch.
 
 ## Form
 


### PR DESCRIPTION
## Summary

Phase D — fills in the cookbook with eight working recipes, plus
correctness fixes to the widgets guide where Phase C had API drift.

### Recipes (\`docs/cookbook/\`)

| File | Topic |
|---|---|
| \`confirm-dialog\` | \`Dialogs.confirm\` — model-owned state, key routing while modal, no callbacks |
| \`streaming-output\` | \`widgets.LogView\` — append-and-tail, auto-tail vs paused scroll |
| \`timer-pause-resume\` | \`Sub.Every\` cancel + recreate, \`Sub.NoSub\` placeholder |
| \`file-picker\` | \`Dialogs.fileDialog\` integration, directory navigation |
| \`split-pane-drag\` | \`SplitPane.handleMouse\` + \`DragState\` + keyboard fallback |
| \`mouse-on-custom-widget\` | \`Layout.Zone\` + \`resolveTracked\` + \`HitTest[Id]\` |
| \`wide-character-input\` | \`WCWidth\`, \`Grapheme\`, \`RenderCell.width = 2\` |
| \`clean-shutdown\` | What the runtime does for you, ctrl-C semantics |

The cookbook index lists all eight; \`SUMMARY.md\` links each as its
own nav entry so search hits land on the right recipe.

### Widgets-guide accuracy

While auditing API shapes for the recipes I caught four examples in
\`docs/guide/widgets.md\` that didn't match the actual surface — they
would have failed to compile if anyone copy-pasted them:

- **LogView** — claimed \`LogView.State.empty\` / \`LogView.append\`. Reality: \`LogView.apply(lines, width, height, ...)\` is purely presentational.
- **Tree** — claimed \`Tree.State(root = ...)\`. Reality: \`Tree.apply(roots, expanded, selectedIndex, render)\` plus a \`Children[A, Id]\` typeclass.
- **Tabs** — claimed \`Tabs.State\` + \`handleKey\`. Reality: stateless renderer.
- **MenuBar** — example signature was wrong; real \`handleKey\` returns \`KeyResult(state, picked: Option[(menuIdx, itemIdx)])\`.

All four examples now match the real APIs. \`scripts/check_widget_docs.sh\` still passes (all 20 widgets named).

## Stacked on #184

This PR targets \`feat/docs-site-phase-c\`. Merge order:
**#182 → #183 → #184 → #185**, or squash in that order.

## Test plan

- [x] \`mdbook build\` — clean (linkcheck enabled, zero broken links)
- [x] \`scripts/check_widget_docs.sh\` — passes (20/20)
- [x] \`sbt ciCheck\` — green
- [ ] CI green on this PR
- [ ] After all four phases merge: full site live at \`https://llm4s.github.io/termflow/\` with \`/api/\` Scaladoc, four tutorials, seven layer guides, eight cookbook recipes