### PR TITLE
feat: tree/ sample app — file-tree explorer (Stage 4 §3.2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -296,3 +296,4 @@ addCommandAlias("showcase",     "termflowSample/runMain termflow.apps.showcase.S
 addCommandAlias("unicodeDemo",  "termflowSample/runMain termflow.apps.unicode.UnicodeDemoApp")
 addCommandAlias("dashboardDemo","termflowSample/runMain termflow.apps.dashboard.DashboardApp")
 addCommandAlias("wizardDemo",   "termflowSample/runMain termflow.apps.wizard.WizardApp")
+addCommandAlias("treeDemo",     "termflowSample/runMain termflow.apps.tree.FileTreeApp")

--- a/docs/contrib/RUN_EXAMPLES.md
+++ b/docs/contrib/RUN_EXAMPLES.md
@@ -27,6 +27,7 @@ sbt taskDemo          # Task manager
 sbt stressDemo        # High-frequency renders for repaint stress testing
 sbt sineDemo          # Animated sine wave
 sbt inputDemo         # Prompt / cursor regression repro (#73 / #74)
+sbt treeDemo          # File-tree explorer (Tree widget + Layout.Border)
 ```
 
 Inside an `sbt` session you can chain them: `sbt> widgetsDemo`.

--- a/modules/termflow-sample/src/main/scala/termflow/apps/tree/FileTreeApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/tree/FileTreeApp.scala
@@ -1,0 +1,385 @@
+package termflow.apps.tree
+
+import termflow.tui.*
+import termflow.tui.Theme.themed
+import termflow.tui.Tui.*
+import termflow.tui.TuiPrelude.*
+import termflow.tui.widgets.Tree
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import scala.jdk.CollectionConverters.*
+import scala.util.Try
+import scala.util.Using
+
+/**
+ * Two-pane file-tree explorer (Stage 4 §3.2 sample).
+ *
+ * Left pane: a [[widgets.Tree]] of the working directory. Directories
+ * expand on demand; their listings are cached on the model so re-expanding
+ * is free. Right pane: details about the selected entry — absolute path,
+ * size, kind (file / dir / symlink), and (for files under 2 KiB) a small
+ * preview of the first few lines.
+ *
+ * Demonstrates: lazy directory traversal under the [[Tree.Children]]
+ * typeclass, [[Layout.Border]] for the four-pane shell (header + left
+ * tree + center details + bottom status), [[Layout.Zone]] + hit-test
+ * passthrough for chevron-vs-label mouse clicks, and `Sub.InputKey`
+ * auto-registration via `RuntimeCtx`.
+ *
+ * ## Keys
+ *
+ *   - `↑` / `↓`     — move selection
+ *   - `Enter` / `Space` / `→` — toggle expand on a directory; on a file,
+ *                              this is a no-op (the details pane already
+ *                              shows the preview).
+ *   - `←`            — collapse the directory under the cursor, or jump
+ *                       to its parent if it's already collapsed.
+ *   - `q` / `Esc` / `Ctrl+C`  quit.
+ *
+ * ## Mouse
+ *
+ *   - Click chevron — toggle expand.
+ *   - Click label — select.
+ *
+ * Run with `sbt treeDemo`.
+ */
+object FileTreeApp:
+
+  // ---- Domain --------------------------------------------------------------
+
+  /** A node in the visible tree (only nodes inside expanded dirs appear). */
+  final case class FsNode(path: Path, isDir: Boolean, children: Vector[FsNode])
+
+  given Tree.Children[FsNode, String] with
+    def id(n: FsNode): String           = n.path.toAbsolutePath.toString
+    def kids(n: FsNode): Vector[FsNode] = n.children
+
+  // ---- Model + Msg ---------------------------------------------------------
+
+  enum DetailsPreview:
+    case None
+    case Lines(lines: Vector[String])
+    case Truncated(reason: String)
+
+  final case class Details(
+    path: Path,
+    isDir: Boolean,
+    sizeBytes: Long,
+    preview: DetailsPreview
+  )
+
+  final case class Model(
+    root: Path,
+    expanded: Set[String],
+    childrenCache: Map[String, Vector[FsNode]],
+    selectedIndex: Int,
+    width: Int,
+    height: Int,
+    input: Sub[Msg]
+  ):
+    /** The visible tree built from the current expanded set + cache. */
+    def visibleTree: FsNode = buildVisibleTree(root, expanded, childrenCache)
+
+    def visibleRows: Vector[Tree.Row[FsNode]] =
+      Tree.visibleRows(Vector(visibleTree), expanded)
+
+    def selectedNode: Option[FsNode] =
+      visibleRows.lift(selectedIndex).map(_.node)
+
+  enum Msg:
+    case KeyPressed(k: KeyDecoder.InputKey)
+    case Quit
+    case KeyError(t: Throwable)
+
+  // ---- Tree construction ---------------------------------------------------
+
+  private def listDir(p: Path): Vector[FsNode] =
+    val attempt = Using(Files.list(p))(stream => stream.iterator.asScala.toVector)
+    attempt.toOption
+      .getOrElse(Vector.empty)
+      .map(child => FsNode(child, Files.isDirectory(child), Vector.empty))
+      .sortBy(n => (!n.isDir, n.path.getFileName.toString.toLowerCase))
+
+  private def buildVisibleTree(
+    p: Path,
+    expanded: Set[String],
+    cache: Map[String, Vector[FsNode]]
+  ): FsNode =
+    val isDir = Files.isDirectory(p)
+    val key   = p.toAbsolutePath.toString
+    val kids =
+      if isDir && expanded.contains(key) then
+        cache
+          .getOrElse(key, Vector.empty)
+          .map(child => buildVisibleTree(child.path, expanded, cache))
+      else Vector.empty
+    FsNode(p, isDir, kids)
+
+  /** Ensure `model.childrenCache` has an entry for `path`, listing if not. */
+  private def withListing(model: Model, path: Path): Model =
+    val key = path.toAbsolutePath.toString
+    if model.childrenCache.contains(key) then model
+    else model.copy(childrenCache = model.childrenCache.updated(key, listDir(path)))
+
+  // ---- Update --------------------------------------------------------------
+
+  private def toggleExpand(m: Model): Model =
+    m.selectedNode match
+      case Some(node) if node.isDir =>
+        val key       = node.path.toAbsolutePath.toString
+        val withCache = withListing(m, node.path)
+        if m.expanded.contains(key) then withCache.copy(expanded = m.expanded - key)
+        else withCache.copy(expanded = m.expanded + key)
+      case _ => m
+
+  private def collapseOrAscend(m: Model): Model =
+    val rows = m.visibleRows
+    if rows.isEmpty then m
+    else
+      val row = rows(m.selectedIndex)
+      val key = row.id
+      if row.expanded then m.copy(expanded = m.expanded - key)
+      else
+        // Move selection to the parent row, if any.
+        val parent = parentRowIndex(rows, m.selectedIndex)
+        m.copy(selectedIndex = parent.getOrElse(m.selectedIndex))
+
+  private def parentRowIndex(rows: Vector[Tree.Row[FsNode]], idx: Int): Option[Int] =
+    if idx <= 0 then None
+    else
+      val depth = rows(idx).depth
+      if depth == 0 then None
+      else (idx - 1 to 0 by -1).find(i => rows(i).depth < depth)
+
+  private def moveCursor(m: Model, delta: Int): Model =
+    val n = m.visibleRows.size
+    if n == 0 then m
+    else
+      val next = math.max(0, math.min(n - 1, m.selectedIndex + delta))
+      m.copy(selectedIndex = next)
+
+  // ---- Mouse helpers -------------------------------------------------------
+
+  /**
+   * Origin of the tree column inside the rendered frame. Mirrors the
+   * Layout.Border / Row positions used in `view`.
+   */
+  private[tree] val treeOrigin: Coord = Coord(2.x, 4.y)
+  private[tree] val indentWidth: Int  = 2
+
+  private def routeMouse(m: Model, e: MouseEvent): Model = e match
+    case MouseEvent.Press(_, col, row, _) =>
+      val rows = m.visibleRows
+      Tree.hitTest(rows, treeOrigin, indentWidth, col, row, labelLength = 64) match
+        case Some(Tree.HitResult.Chevron(idx)) =>
+          val target = rows(idx).node
+          val key    = target.path.toAbsolutePath.toString
+          val sel    = m.copy(selectedIndex = idx)
+          if target.isDir then toggleExpand(sel) else sel
+        case Some(Tree.HitResult.Label(idx)) =>
+          m.copy(selectedIndex = idx)
+        case None => m
+    case _ => m
+
+  // ---- Pure step (testable without the runtime) ----------------------------
+
+  def step(m: Model, msg: Msg): Model =
+    import KeyDecoder.InputKey.*
+    msg match
+      case Msg.Quit        => m
+      case Msg.KeyError(_) => m
+      case Msg.KeyPressed(k) =>
+        k match
+          case ArrowDown                         => moveCursor(m, +1)
+          case ArrowUp                           => moveCursor(m, -1)
+          case Enter | CharKey(' ') | ArrowRight => toggleExpand(m)
+          case ArrowLeft                         => collapseOrAscend(m)
+          case Mouse(e)                          => routeMouse(m, e)
+          case _                                 => m
+
+  // ---- View ---------------------------------------------------------------
+
+  private def details(m: Model): Option[Details] =
+    m.selectedNode.map { node =>
+      val isDir = node.isDir
+      val size  = if isDir then 0L else Try(Files.size(node.path)).getOrElse(0L)
+      val preview =
+        if isDir then DetailsPreview.None
+        else if size > 2 * 1024 then DetailsPreview.Truncated(s"${size} bytes — preview skipped")
+        else
+          val attempt = Try {
+            val all = Files.readAllLines(node.path).asScala.toVector
+            all.take(20)
+          }
+          attempt.toEither match
+            case Right(lines) => DetailsPreview.Lines(lines)
+            case Left(err)    => DetailsPreview.Truncated(s"unreadable: ${err.getClass.getSimpleName}")
+      Details(node.path, isDir, size, preview)
+    }
+
+  private def viewRender(m: Model): RootNode =
+    given Theme = Theme.dark
+    val w       = math.max(40, m.width)
+    val h       = math.max(10, m.height)
+
+    val title = TextNode(
+      2.x,
+      1.y,
+      List(
+        Text("File tree explorer", Style(fg = Theme.dark.primary, bold = true))
+      )
+    )
+    val help = TextNode(
+      2.x,
+      2.y,
+      List(
+        " ↑/↓ ".themed(_.primary),
+        "move  ".text,
+        " Enter ".themed(_.primary),
+        "expand  ".text,
+        " ← ".themed(_.primary),
+        "collapse  ".text,
+        " q ".themed(_.primary),
+        "quit".text
+      )
+    )
+
+    val rows = m.visibleRows
+    val treeNodes: List[VNode] = Tree(
+      roots = Vector(m.visibleTree),
+      expanded = m.expanded,
+      selectedIndex = m.selectedIndex,
+      render = (n: FsNode) => labelFor(n, m.root),
+      at = treeOrigin,
+      indentWidth = indentWidth,
+      unicode = true
+    )
+
+    val detailsLines: List[VNode] = details(m) match
+      case None =>
+        List(
+          TextNode(1.x, 1.y, List("(empty)".text(fg = Theme.dark.secondary)))
+        )
+      case Some(d) =>
+        val header = TextNode(
+          1.x,
+          1.y,
+          List(
+            (if d.isDir then "📁 " else "📄 ").text,
+            Text(d.path.toAbsolutePath.toString, Style(bold = true, fg = Theme.dark.primary))
+          )
+        )
+        val sizeLine =
+          if d.isDir then TextNode(1.x, 2.y, List(s"directory".text(fg = Theme.dark.info)))
+          else TextNode(1.x, 2.y, List(s"size: ${d.sizeBytes} bytes".text(fg = Theme.dark.info)))
+        val previewLines: List[VNode] = d.preview match
+          case DetailsPreview.None => Nil
+          case DetailsPreview.Truncated(why) =>
+            List(TextNode(1.x, 4.y, List(why.text(fg = Theme.dark.secondary))))
+          case DetailsPreview.Lines(lines) =>
+            lines.zipWithIndex.toList.map { case (line, i) =>
+              TextNode(1.x, (4 + i).y, List(line.take(120).text))
+            }
+        header :: sizeLine :: previewLines
+
+    // Flatten the tree column and the details column into Layout.Elem stacks
+    // wrapped in a Border. The header lives outside the border so it's not
+    // clipped by the band sizing.
+    val tw      = math.max(20, w * 2 / 5)
+    val treeCol = Layout.Column(gap = 0, children = treeNodes.map(Layout.Elem.apply))
+    val detsCol = Layout.Column(gap = 0, children = detailsLines.map(Layout.Elem.apply))
+    val statusLine = TextNode(
+      1.x,
+      1.y,
+      List(
+        s"${rows.size} rows · ${m.expanded.size} expanded"
+          .text(fg = Theme.dark.secondary)
+      )
+    )
+
+    val body = Layout.border(
+      left = treeCol,
+      center = detsCol,
+      bottom = Layout.Elem(statusLine),
+      gap = 1
+    )
+    // Reserve the top two rows for title + help; body fills the rest.
+    val resolvedBody = Layout.resolveTo(
+      body,
+      at = Coord(2.x, 4.y),
+      availableWidth = w - 2,
+      availableHeight = h - 4
+    )
+
+    RootNode(
+      width = w,
+      height = h,
+      children = title :: help :: resolvedBody,
+      input = None
+    )
+
+  private def labelFor(n: FsNode, root: Path): String =
+    val name = Option(n.path.getFileName).map(_.toString).getOrElse(n.path.toString)
+    val displayName =
+      if n.path == root then
+        // Root node: show absolute root path so the user knows where they are.
+        n.path.toAbsolutePath.toString
+      else name
+    if n.isDir then s"$displayName/" else displayName
+
+  // ---- Initial model -------------------------------------------------------
+
+  /**
+   * Pure factory used both by the runtime and by tests. Tests can override
+   * the start path; runtime starts at the user's CWD.
+   */
+  def initialModel(start: Path, width: Int, height: Int, input: Sub[Msg]): Model =
+    val rootKey     = start.toAbsolutePath.toString
+    val rootListing = listDir(start)
+    Model(
+      root = start,
+      expanded = Set(rootKey),
+      childrenCache = Map(rootKey -> rootListing),
+      selectedIndex = 0,
+      width = width,
+      height = height,
+      input = input
+    )
+
+  // ---- App -----------------------------------------------------------------
+
+  object App extends TuiApp[Model, Msg]:
+
+    override def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val keys = Sub.InputKey[Msg](
+        msg = Msg.KeyPressed.apply,
+        onError = Msg.KeyError.apply,
+        ctx = ctx
+      )
+      val cwd = Paths.get(System.getProperty("user.dir"))
+      initialModel(cwd, ctx.terminal.width, ctx.terminal.height, keys).tui
+
+    override def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+      val sized = m.copy(width = ctx.terminal.width, height = ctx.terminal.height)
+      msg match
+        case Msg.Quit        => Tui(sized, Cmd.Exit)
+        case Msg.KeyError(_) => sized.tui
+        case Msg.KeyPressed(k) =>
+          import KeyDecoder.InputKey.*
+          val isQuit = k match
+            case CharKey('q') | CharKey('Q') | Escape | Ctrl('C') => true
+            case _                                                => false
+          if isQuit then Tui(sized, Cmd.Exit)
+          else step(sized, msg).tui
+
+    override def view(m: Model): RootNode = viewRender(m)
+
+    override def toMsg(input: PromptLine): Result[Msg] =
+      val _ = input
+      Left(TermFlowError.Validation("FileTreeApp has no prompt"))
+
+  def main(args: Array[String]): Unit =
+    val _ = args
+    TuiRuntime.run(App)

--- a/modules/termflow-sample/src/test/scala/termflow/apps/tree/FileTreeAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/tree/FileTreeAppSpec.scala
@@ -1,0 +1,133 @@
+package termflow.apps.tree
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import termflow.testkit.KeySim
+import termflow.testkit.TuiTestDriver
+import termflow.tui.KeyDecoder.InputKey
+import termflow.tui.Sub
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class FileTreeAppSpec extends AnyFunSuite with BeforeAndAfterAll:
+
+  // Build a temp tree:
+  //   root/
+  //     a.txt
+  //     b.txt
+  //     sub/
+  //       c.txt
+  private var root: Path = _
+
+  override def beforeAll(): Unit =
+    root = Files.createTempDirectory("termflow-tree-spec-")
+    Files.writeString(root.resolve("a.txt"), "alpha\n")
+    Files.writeString(root.resolve("b.txt"), "beta\n")
+    val sub = Files.createDirectory(root.resolve("sub"))
+    Files.writeString(sub.resolve("c.txt"), "gamma\n")
+
+  override def afterAll(): Unit =
+    deleteRecursively(root)
+
+  private def deleteRecursively(p: Path): Unit =
+    if Files.isDirectory(p) then
+      val ds = Files.list(p)
+      try ds.iterator.nn.asInstanceOf[java.util.Iterator[Path]].forEachRemaining(deleteRecursively(_))
+      finally ds.close()
+    Files.deleteIfExists(p)
+    ()
+
+  // ---- helpers ------------------------------------------------------------
+
+  private def freshModel: FileTreeApp.Model =
+    FileTreeApp.initialModel(root, width = 80, height = 24, input = Sub.NoSub)
+
+  private def step(m: FileTreeApp.Model, key: InputKey): FileTreeApp.Model =
+    FileTreeApp.step(m, FileTreeApp.Msg.KeyPressed(key))
+
+  // ---- tests --------------------------------------------------------------
+
+  test("initial model lists the root with the root entry expanded"):
+    val m = freshModel
+    assert(m.expanded.contains(root.toAbsolutePath.toString))
+    val rows = m.visibleRows
+    // Root + 3 children (sub/, a.txt, b.txt) — directories sort first.
+    assert(rows.size == 4, s"expected 4 rows; got ${rows.size}")
+    assert(rows.head.depth == 0)
+    assert(rows(1).node.isDir, "first child should be a directory")
+
+  test("ArrowDown / ArrowUp move the selection inside the visible rows"):
+    val m  = freshModel
+    val m1 = step(m, KeySim.ArrowDown)
+    assert(m1.selectedIndex == 1)
+    val m2 = step(m1, KeySim.ArrowDown)
+    assert(m2.selectedIndex == 2)
+    val m3 = step(m2, KeySim.ArrowUp)
+    assert(m3.selectedIndex == 1)
+
+  test("ArrowDown clamps at the last visible row"):
+    val m    = freshModel
+    val rows = m.visibleRows.size
+    val m1   = (1 to rows + 5).foldLeft(m)((acc, _) => step(acc, KeySim.ArrowDown))
+    assert(m1.selectedIndex == rows - 1)
+
+  test("Enter on a directory expands it and the cache is populated"):
+    val m   = freshModel
+    val m1  = step(m, KeySim.ArrowDown) // select sub/
+    val m2  = step(m1, KeySim.Enter)
+    val key = root.resolve("sub").toAbsolutePath.toString
+    assert(m2.expanded.contains(key))
+    assert(m2.childrenCache.contains(key))
+    // sub/ is now visible-expanded → c.txt appears underneath.
+    val labels = m2.visibleRows.map(row => Option(row.node.path.getFileName).map(_.toString).getOrElse(""))
+    assert(labels.contains("c.txt"))
+
+  test("Enter on a directory toggles back when invoked twice"):
+    val m   = freshModel
+    val m1  = step(m, KeySim.ArrowDown)
+    val m2  = step(m1, KeySim.Enter)
+    val m3  = step(m2, KeySim.Enter)
+    val key = root.resolve("sub").toAbsolutePath.toString
+    assert(!m3.expanded.contains(key))
+
+  test("ArrowLeft on an expanded directory collapses it"):
+    val m   = freshModel
+    val m1  = step(m, KeySim.ArrowDown)   // sub/
+    val m2  = step(m1, KeySim.ArrowRight) // expand
+    val key = root.resolve("sub").toAbsolutePath.toString
+    assert(m2.expanded.contains(key))
+    val m3 = step(m2, KeySim.ArrowLeft)
+    assert(!m3.expanded.contains(key))
+
+  test("ArrowLeft on a child jumps focus to its parent"):
+    val m  = freshModel
+    val m1 = step(m, KeySim.ArrowDown)   // sub/
+    val m2 = step(m1, KeySim.ArrowRight) // expand sub
+    val m3 = step(m2, KeySim.ArrowDown)  // step into c.txt
+    assert(m3.selectedIndex == 2)
+    val m4 = step(m3, KeySim.ArrowLeft)
+    // After collapse-or-ascend on a leaf, focus returns to its parent.
+    assert(m4.selectedIndex == 1, s"expected to land on sub/ (idx 1); got ${m4.selectedIndex}")
+
+  test("'q' triggers Cmd.Exit when driven through the App"):
+    val d = TuiTestDriver(FileTreeApp.App, width = 80, height = 24)
+    d.init()
+    d.send(FileTreeApp.Msg.KeyPressed(KeySim.char('q')))
+    assert(d.exited)
+
+  test("Mouse press on the root chevron toggles expand on the root"):
+    val m = freshModel
+    // Root is rendered at row 4, indented 0 cells, glyph occupies cols 2..5
+    // ([+]/[-] is 4 chars but treeOrigin starts at col 2 so chevron is col 2..5).
+    val click   = MouseSimRecreate.press(col = 3, row = 4)
+    val m1      = step(m, click)
+    val rootKey = root.toAbsolutePath.toString
+    // Root started expanded; chevron click collapses it.
+    assert(!m1.expanded.contains(rootKey))
+
+  // tiny re-export so the test file doesn't depend on MouseSim's package
+  private object MouseSimRecreate:
+    import termflow.testkit.MouseSim
+    def press(col: Int, row: Int): InputKey =
+      MouseSim.press(col, row)


### PR DESCRIPTION
## Summary

Two-pane file-tree explorer demonstrating \`widgets.Tree\` on top of a
lazy directory traversal. Closes one of the §3.2 sample-app gaps from
the pruned roadmap.

### Layout

- \`Layout.border\` with title + help row at the top, tree column on the left, details panel in the center, status line on the bottom — exercises the §3.4 layout primitives that just merged.

### Tree integration

- \`Tree.Children[FsNode, String]\` typeclass instance walks a model-owned tree of \`FsNode\` values.
- Directory listings are cached in the model (\`childrenCache\`) so re-expanding is free.
- The visible tree is rebuilt purely from the \`expanded\` set + cache on each render — no mutable I/O during \`view\`.

### Interaction

- **Keyboard:** \`↑\` / \`↓\` move, \`Enter\` / \`Space\` / \`→\` toggle expand on directories, \`←\` collapses or jumps to parent, \`q\` / \`Esc\` / \`Ctrl+C\` quits.
- **Mouse:** chevron clicks toggle expand via \`Tree.hitTest\` + \`HitResult.Chevron\`; label clicks select.

### Details panel

For files under 2 KiB, shows the absolute path, byte size, and the first 20 lines. Larger files / unreadable files render a truncation note. Directories show a kind label.

### Tests

9 specs in \`FileTreeAppSpec\`:

- initial model has the root pre-expanded
- Arrow nav (up/down with clamping)
- Enter expands and populates the cache
- Enter on an expanded directory collapses
- ArrowLeft on an expanded dir collapses; on a leaf it ascends to the parent
- \`q\` triggers \`Cmd.Exit\` via \`TuiTestDriver\`
- Mouse press on the root chevron toggles expansion via \`MouseSim.press\`

## Test plan

- [x] \`sbt termflowSample/testOnly termflow.apps.tree.FileTreeAppSpec\` — 9/9 pass
- [x] \`sbt ciCheck\` — green
- [x] \`mdbook build\` — clean
- [x] \`./scripts/check_widget_docs.sh\` — passes
- [ ] CI green on this PR
- [ ] Manual smoke: \`sbt treeDemo\` in a real terminal