### PR TITLE
chore(ci): bump Node 20 actions to v5 for Node 24 readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
@@ -48,7 +48,7 @@ jobs:
         run: sbt --batch coverageLib
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: |
@@ -61,7 +61,7 @@ jobs:
           verbose: true
 
       - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: scoverage-report
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Needed for sbt-dynver
 
       - name: Setup JVM
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"


### PR DESCRIPTION
## Summary

GitHub flagged the following actions as still running on Node 20, with Node 24 becoming the default in June 2026 and Node 20 removed in September 2026. Bumped all four to v5 (Node 24-ready):

| Action | Before | After |
|---|---|---|
| \`actions/checkout\` | v4 | **v5** |
| \`actions/setup-java\` | v4 | **v5** |
| \`actions/upload-artifact\` | v4 | **v5** |
| \`codecov/codecov-action\` | v4 | **v5** |

All four are drop-in replacements with the same input surface for how this repo uses them — checkout has no \`submodules\` config, setup-java keeps \`distribution\` / \`java-version\` / \`cache\`, codecov keeps \`token\` / \`files\` / \`slug\` / \`fail_ci_if_error\` / \`verbose\`, and upload-artifact keeps \`name\` / \`path\` / \`retention-days\`.

\`actions/upload-pages-artifact@v3\` and \`actions/deploy-pages@v4\` in \`docs.yml\` weren't called out by the deprecation warning, so left as-is.

## Test plan

- [ ] CI green on this PR (it's the workflow change, so the run on this PR is the test)
- [ ] After merge, watch the next \`main\` run + \`docs\` run for any v5 surprises