### PR TITLE
chore: fix two broken Scaladoc @link queries

### DIFF
--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/LogView.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/LogView.scala
@@ -14,7 +14,8 @@ import termflow.tui.*
  *
  * Long lines are wrapped to fit `width` when `wrap = true` (default),
  * or truncated with a trailing `…` when `wrap = false`. Wrapping is
- * computed by [[wrap]]; the visible window is sliced by [[viewport]].
+ * computed by [[expand]] (which delegates per line to [[wrapLine]]);
+ * the visible window is sliced by [[viewport]].
  * Both helpers are public so apps can pre-compute display lines once
  * per buffer change instead of every frame.
  *

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
@@ -127,15 +127,16 @@ object SplitPane:
    * Drag state for mouse-driven divider resize.
    *
    * Apps hold a single `DragState` per `SplitPane`, default
-   * [[DragState.idle]], and feed every [[InputKey.Mouse]] event into
-   * [[handleMouse]]. The `splitRatio` field is what the next frame
-   * should use; `dragging` is true while the user is mid-gesture so the
-   * app can render a focused divider style if it likes.
+   * [[DragState.idle]], and feed every `KeyDecoder.InputKey.Mouse`
+   * event into [[handleMouse]]. The `splitRatio` field is what the
+   * next frame should use; `dragging` is true while the user is
+   * mid-gesture so the app can render a focused divider style if
+   * it likes.
    *
    * @param splitRatio Current split ratio. Always clamped to
    *                   `[MinSizeRatio, 1 - MinSizeRatio]`.
-   * @param dragging   True between [[MouseEvent.Press]] on the divider
-   *                   and the next [[MouseEvent.Release]].
+   * @param dragging   True between a `MouseEvent.Press` on the divider
+   *                   and the next `MouseEvent.Release`.
    */
   final case class DragState(splitRatio: Double, dragging: Boolean):
     /** Reset back to the idle state at the supplied ratio. */


### PR DESCRIPTION
## Summary

Unidoc emitted three \"Couldn't resolve a member for the given link query\" warnings on our code:

- **\`LogView\`** header doc: \`[[wrap]]\` — there's no \`wrap\` method on the object; the public expansion entrypoint is \`expand\` (which delegates per line to \`wrapLine\`). Rewrote to \`[[expand]]\` + \`[[wrapLine]]\`.
- **\`SplitPane.DragState\`** header: \`[[InputKey.Mouse]]\` — the actual case lives at \`KeyDecoder.InputKey.Mouse\` and Scaladoc can't resolve a top-level \`InputKey\`. Rewrote as a literal reference; same fix for the \`@param dragging\` description's \`[[MouseEvent.Press]]\` / \`[[MouseEvent.Release]]\` references.

After this fix, \`sbt unidoc\` emits zero warnings on our code.

## What about the other warnings in that CI run?

For reference (not in scope of this PR):

- \`NullArgumentException\` / \`TestFailedException\` — from inside ScalaTest's own \`Assertions.scala\`. Out of our control.
- \`Flag -classpath set repeatedly\` — known sbt-unidoc cosmetic artefact.

So those can be ignored.

## Test plan

- [x] \`sbt unidoc\` — clean for our sources
- [ ] CI green on this PR