### PR TITLE
Pre-1.0 hardening: notifications, error overlay, layout, mouse-wheel scrollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,128 +5,77 @@
 
 📖 **[User guide & tutorials → llm4s.github.io/termflow](https://llm4s.github.io/termflow)**
 
-`termflow` is a small, functional terminal UI (TUI) framework for Scala.
+`termflow` is a small, functional terminal UI (TUI) framework for Scala 3.
+It uses an Elm-style architecture: a pure `update`, a declarative `view`,
+async via `Cmd`, and event streams via `Sub`.
 
-It’s designed for building interactive CLIs with a simple architecture:
+The [docs site](https://llm4s.github.io/termflow) is the primary reference —
+elevator pitch, install, tutorials, layer guides, cookbook, and Scaladoc.
+This README focuses on building, releasing, and contributing to the repo
+itself.
 
-- a pure-ish `update` function (state transitions)
-- a `view` function (render a small virtual DOM)
-- `Cmd` for async work and `Sub` for event streams (keys, timers, etc.)
-
-The project started as the TUI layer for LLM4s sample applications, but it is
-usable on its own.
-
-## What You Can Build
-
-- prompt-driven apps (REPL-style, command palettes)
-- streaming output (e.g., LLM token streaming)
-- progress spinners and long-running tasks
-- simple dashboards (lists, panes, status bars)
-
-## Notes On Rendering
-
-Rendering is intentionally simple today. Virtual-DOM diffing and throttling to
-minimize flicker are work-in-progress topics we plan to iterate on (especially
-for high-frequency updates like spinners and streaming text).
-
-## Scala Versions
-
-This branch (`main`) is the Scala 3 line.
-The `legacy-213-track` branch is the Scala 2.13 maintenance line.
-We intend to regularly port applicable fixes and critical updates from `main` to `legacy-213-track`.
-
-## Modules
-
-- `modules/termflow`: the library (`org.llm4s:termflow_3`)
-- `modules/termflow-testkit`: deterministic test harness — `TuiTestDriver`,
-  golden-snapshot support, `TestRuntimeCtx` (`org.llm4s:termflow-testkit_3`,
-  depend on as `% Test`)
-- `modules/termflow-sample`: demo apps (not published)
-
-## Quick Start
-
-Add to your build (Scala 3):
+## Quick start
 
 ```scala
 libraryDependencies += "org.llm4s" %% "termflow" % "0.2.0"
 ```
 
-Run a sample app:
+Then follow [What is TermFlow?](https://llm4s.github.io/termflow/intro/what-is-termflow.html)
+and the [Hello, World tutorial](https://llm4s.github.io/termflow/tut/01-hello-world.html).
 
-- `sbt "termflowSample/runMain termflow.run.TermFlowMain"`
+To poke at the bundled samples:
 
-## Sample Apps
+```bash
+sbt hubDemo            # menu launcher for ~22 sample apps
+```
 
-The `termflow-sample` module contains a few small demo apps you can run with `runMain`.
+The full demo list lives in
+[Running sample apps](https://llm4s.github.io/termflow/contrib/RUN_EXAMPLES.html).
 
-- Echo: `sbt "termflowSample/runMain termflow.apps.echo.EchoApp"`
-- Counter (sync): `sbt "termflowSample/runMain termflow.apps.counter.SyncCounter"`
-- Counter (async + spinner): `sbt "termflowSample/runMain termflow.apps.counter.FutureCounter"`
-- Clock: `sbt "termflowSample/runMain termflow.apps.clock.DigitalClock"`
+## Repository layout
 
-Note: there are also small “inspector” utilities under `termflow.run.jline.*` to
-debug key sequences and line editing behaviour.
+Five published modules plus testkit and samples:
 
-## Build
+- `modules/termflow-terminal` — TTY backend, key decoding, capability detection.
+- `modules/termflow-screen` — character grid, layout, ANSI diff renderer.
+- `modules/termflow-app` — Elm-style runtime (`TuiApp`, `Cmd`, `Sub`, `Dialogs`).
+- `modules/termflow-widgets` — reusable components (`Button`, `Table`, `Tree`, …).
+- `modules/termflow` — umbrella artefact pulling in all four.
+- `modules/termflow-testkit` — `TuiTestDriver`, `KeySim`, `MouseSim`, golden-snapshot support (depend on as `% Test`).
+- `modules/termflow-sample` — demo apps (not published).
+- `modules/termflow-scalafix-rules` — internal scalafix rules for the build.
 
-- Compile: `sbt compile`
-- Format: `sbt scalafmtAll`
-- CI-equivalent local check: `sbt ciCheck`
-- Scalafix rewrite: `sbt scalafixAll`
-- Tests: `sbt test`
-- Library coverage report: `sbt coverageLib`
-- Pre-PR gate (format, scalafix, tests, coverage, sample smoke): `sbt prePR`
-- Publish locally (for integration testing): `sbt publishLocal`
+See [Architecture](https://llm4s.github.io/termflow/intro/architecture.html)
+for what each layer does and when to depend on a single one.
 
-## Scala 3 Conventions
+## Building
+
+```bash
+sbt compile           # Compile (Scala 3)
+sbt test              # Run tests
+sbt scalafmtAll       # Format
+sbt scalafixAll       # Scalafix rewrite
+sbt ciCheck           # CI-equivalent local check
+sbt prePR             # Format + scalafix + tests + coverage + sample smoke
+sbt coverageLib       # Library coverage report
+sbt publishLocal      # Publish to local Ivy cache
+```
+
+## Scala 3 conventions
 
 - Prefer `enum` for closed ADTs.
 - Prefer `given` / `using` over implicit parameters and values.
 - Prefer `extension` methods over implicit classes.
-- Avoid implicit conversions; return explicit `Tui` values (for example, `model.tui`).
-- Keep migration changes behavior-preserving unless a PR states otherwise.
+- Avoid implicit conversions; return explicit `Tui` values (e.g. `model.tui`).
+- Keep migration changes behaviour-preserving unless a PR states otherwise.
 
-## Async Work
+## Scala versions
 
-`termflow` stays effect-system-agnostic. Async commands use `scala.concurrent.Future`
-combined with the framework's `Result[A] = Either[TermFlowError, A]`, exposed as a
-type alias that mirrors the [llm4s](https://github.com/llm4s/llm4s) core 1:1 so values
-flow between the two libraries without an adapter:
+The `main` branch is **Scala 3 only**. The `legacy-213-track` branch is the
+Scala 2.13 maintenance line; applicable fixes and critical updates are ported
+from `main`.
 
-```scala
-type AsyncResult[+A] = Future[Result[A]]
-```
-
-Lift one onto the command bus with `Cmd.asyncResult`:
-
-```scala
-import termflow.tui.*
-import termflow.tui.TuiPrelude.*
-
-enum Msg:
-  case Loaded(value: User)
-  case Failed(err: TermFlowError)
-
-def fetch(id: UserId): AsyncResult[User] = ...
-
-Cmd.asyncResult(
-  task      = fetch(id),
-  onSuccess = Msg.Loaded.apply,
-  onError   = Msg.Failed.apply,
-  onEnqueue = Some(Msg.LoadingFlash)   // optional
-)
-```
-
-`Future` failures (network drops, JVM exceptions) surface through the runtime's
-standard `Cmd.TermFlowErrorCmd` path automatically; only domain errors need an
-explicit `onError`. `AsyncResult` ships a small companion with `success`,
-`failure`, `fromResult`, and `fromFuture` for lifting at the boundary.
-
-We do **not** ship cats-effect or ZIO adapter modules — apps that use `IO` /
-`ZIO` can bridge to a `Future` at the `Cmd` boundary in a couple of characters
-of glue.
-
-## Versioning
+## Releasing
 
 Versioning is fully driven by git tags via `sbt-dynver`; nothing is hand-edited
 in `build.sbt` or a `version.sbt` file.
@@ -153,9 +102,10 @@ The workflow runs `sbt ci-release`, which:
 
 1. Re-runs CI checks.
 2. Imports the GPG key from `PGP_SECRET` and signs all artifacts.
-3. Stages to the Sonatype Central Portal using `SONATYPE_USERNAME` / `SONATYPE_PASSWORD`
-   (these are the **portal user token** values, not your Sonatype account login).
-4. Releases the staged bundle automatically — no manual “close & release” step.
+3. Stages to the Sonatype Central Portal using `SONATYPE_USERNAME` /
+   `SONATYPE_PASSWORD` (these are the **portal user token** values, not your
+   Sonatype account login).
+4. Releases the staged bundle automatically — no manual "close & release" step.
 
 Artifacts land at `https://repo1.maven.org/maven2/org/llm4s/termflow_3/`
 within a few minutes of the workflow finishing.
@@ -170,3 +120,10 @@ depend on the locally-installed coordinate.
 > publishing through the new Sonatype Central Portal. Use
 > [central.sonatype.com](https://central.sonatype.com/artifact/org.llm4s/termflow_3)
 > or the raw repo URL above to verify a release.
+
+## Contributing
+
+- [Design](docs/contrib/DESIGN.md) — architectural rationale.
+- [Render pipeline](docs/contrib/RENDER_PIPELINE.md) — how a frame becomes ANSI.
+- [Roadmap](docs/contrib/ROADMAP.md) — what's left for 1.0 and beyond.
+- [Running sample apps](docs/contrib/RUN_EXAMPLES.md) — every demo and its `sbt` alias.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,6 +37,7 @@
 - [Wide-character input](cookbook/wide-character-input.md)
 - [Clean shutdown](cookbook/clean-shutdown.md)
 - [Flag a session as needing attention](cookbook/notifications.md)
+- [Full-screen layouts that reflow on resize](cookbook/full-screen-layout.md)
 
 # Reference
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,6 +36,7 @@
 - [Mouse on a custom widget](cookbook/mouse-on-custom-widget.md)
 - [Wide-character input](cookbook/wide-character-input.md)
 - [Clean shutdown](cookbook/clean-shutdown.md)
+- [Flag a session as needing attention](cookbook/notifications.md)
 
 # Reference
 

--- a/docs/contrib/ROADMAP.md
+++ b/docs/contrib/ROADMAP.md
@@ -1,8 +1,12 @@
 # TermFlow Roadmap
 
-> Status: 2026-04-29 · Current release: **0.2.0** · Working towards **1.0**.
+> Status: 2026-04-30 · Current release: **0.2.0** · Working towards **1.0**.
 >
-> Stages 1–3 are complete. Stage 4 (1.0 stabilisation) is in progress.
+> Stages 1–3 are complete. Stage 4 (1.0 stabilisation) is in progress —
+> §3.2 (sample apps) and §3.4 (Grid + Border layouts) have landed; the
+> killer demo, the migration guide, and the pre-1.0 release-hardening
+> checklist (§4) remain. MiMa (§3.1) was deferred to the post-1.0 cycle
+> (baseline = 1.0.0).
 > This document is forward-looking: it describes the work *left*, not the
 > history of the work *done*.
 
@@ -42,7 +46,8 @@ What ships today:
   downgrade.
 - **Capability detection** — true-colour / 256-colour / 16-colour /
   8-colour / mono, bracketed paste, mouse (SGR-1006), extended modifier
-  parsing, SIGWINCH-driven resize.
+  parsing, SIGWINCH-driven resize, terminal-attention notifications
+  (iTerm2 OSC 9 / 1337, kitty OSC 99, VTE OSC 777, BEL fallback).
 - **20+ widgets** — `TextField`, `MultiLineInput`, `Button`,
   `CheckBox`, `RadioGroup`, `Select`, `Autocomplete`, `ListView`,
   `Table`, `Tree`, `Tabs`, `SplitPane` (drag-resize), `Separator`,
@@ -56,14 +61,16 @@ What ships today:
   `BreakIterator`, wide-cell math via `WCWidth`.
 - **Testkit** — `TuiTestDriver`, `KeySim`, `MouseSim`,
   `GoldenSupport`. Published as `termflow-testkit`.
-- **~20 sample apps** — counter, async counter, clock, dashboard,
+- **~22 sample apps** — counter, async counter, clock, dashboard,
   echo, hello, forms, wizard, dialog, file-dialog, themes, unicode,
-  stress, sine, hub, input, tabs, task, catalog, widgets, showcase.
+  stress, sine, hub, input, tabs, task, catalog, widgets, showcase,
+  tree, editor, chat.
 - **Docs site** — live at `https://llm4s.github.io/termflow` with
-  Introduction, four tutorials, seven layer guides, eight cookbook
+  Introduction, four tutorials, seven layer guides, nine cookbook
   recipes, and aggregated Scaladoc.
 
-No outstanding architectural debts for 1.0. Remaining work is in §3.
+No outstanding architectural debts for 1.0. Remaining work is in §3
+and the pre-1.0 release-hardening checklist in §4.
 
 ---
 
@@ -72,28 +79,40 @@ No outstanding architectural debts for 1.0. Remaining work is in §3.
 The lock-in stage. Goal: produce an API stable enough to keep
 unchanged for years.
 
-### 3.1 MiMa for binary compatibility
+### 3.1 MiMa for binary compatibility — deferred to post-1.0
 
-Add `sbt-mima-plugin`. Configure each of `termflow-terminal`,
-`termflow-screen`, `termflow-app`, `termflow-widgets`, and
-`termflow-testkit` to check against the previous release. Fail CI on
-incompatible changes; require explicit `mimaBinaryIssueFilters` for
-accepted breaks.
+Originally planned as a 1.0 gate, but moved out of the critical path
+(decision: 2026-04-30). The simpler workflow is to ship 1.0 first, then
+wire `sbt-mima-plugin` against `1.0.0` as the baseline so every
+subsequent release (`1.0.x`, `1.1.0`, …) is checked.
 
-The decisions made via filters drive content for the migration guide
-(§3.5).
+Why the change:
 
-### 3.2 Sample app catalogue gaps
+- 0.2.0 is already API-stable, so the 0.2.0 → 1.0 filter list would
+  mostly be noise.
+- Avoids the bookkeeping cost of maintaining
+  `mimaBinaryIssueFilters` during the 0.2.x → 1.0 window.
+- Removes the chicken-and-egg between §3.1 and §3.5 — see §3.5 for
+  the simplified migration-guide stance.
 
-Target: 25 apps; close to 20 today. Specific gaps remaining:
+Plan once 1.0 ships:
 
-- **`tree/`** — file-tree explorer, natural fit on top of
-  `fileDialog` and the `Tree` widget.
-- **`editor/`** — minimal multi-file text editor, exercises
-  `MultiLineInput` + `SplitPane` + `MenuBar` together.
-- **`chat/` expansion** — extend the existing `chat` sample to use
-  streaming + scrollback (see the
-  [streaming-output cookbook recipe](../cookbook/streaming-output.md)).
+1. Add `sbt-mima-plugin` to `project/plugins.sbt`.
+2. Set `mimaPreviousArtifacts := Set("org.llm4s" %% name % "1.0.0")`
+   on each of `termflow-terminal`, `termflow-screen`, `termflow-app`,
+   `termflow-widgets`, `termflow`, and `termflow-testkit`.
+3. Append `mimaReportBinaryIssues` to the `ciCheck` alias.
+
+This becomes part of the 1.0.1 / 1.1.0 release prep, not 1.0.
+
+### 3.2 Sample app catalogue gaps — ☑ landed
+
+All three planned samples shipped (#188 / #189 / #190): `tree/`
+(file-tree explorer over the `Tree` widget), `editor/` (multi-buffer
+text editor exercising `MultiLineInput` + `SplitPane` + `MenuBar`),
+and `chat/` (streaming chat with scrollback per the
+[streaming-output cookbook recipe](../cookbook/streaming-output.md)).
+Catalogue now stands at 22 apps.
 
 ### 3.3 Killer demo
 
@@ -101,48 +120,184 @@ A working `llm4s` chat client in <200 lines of TermFlow, used as the
 README headline screenshot. Demonstrates streaming, dialogs, theming,
 mouse, async tool calls — every Stage 1–3 capability in one app.
 
-### 3.4 GridLayout + BorderLayout
+### 3.4 GridLayout + BorderLayout — ☑ landed
 
-Listed as Stage 1 work but never shipped — only `Row` / `Column` /
-`Fill` / `Zone` exist today. Add:
-
-- **`Layout.Grid(rows, cols, gap, children)`** — fixed-grid layout
-  with span support. Lanterna's `GridLayout` is the template.
-- **`Layout.Border(top, left, center, right, bottom)`** — five-zone
-  border layout. Useful for "header / sidebar / main / footer"
-  apps without manually computing heights.
-
-Both should fit cleanly behind `Layout.resolveTo` (the size-aware
-resolution) so existing `resolve` callers don't need changes.
+Shipped in #187. `Layout.Grid(columns, rowGap, colGap, cells)` with
+`GridCell` row/column spans, and `Layout.Border(top, left, center,
+right, bottom)` with five-zone resolution. Both flow through
+`Layout.resolveTo` so existing `resolve` callers are unchanged.
+`LayoutGridSpec` and `LayoutBorderSpec` cover sizing, gaps, spans,
+and zone omission.
 
 ### 3.5 Migration guide
 
-Currently a placeholder. Populate as MiMa filters accumulate:
+With MiMa deferred (§3.1), there is no automated source of breakage
+data for 0.2.0 → 1.0. The guide page stays useful as a hand-written
+record of any deliberate API changes during the run-up to 1.0.
 
-- One section per accepted incompatible change between 0.2.0 and 1.0.
-- Before / after code recipes for each.
-- A rationale paragraph for any non-obvious change.
+For 1.0:
 
-If we don't break anything between now and 1.0, the page becomes a
-one-liner ("no migration needed; 1.0 is binary-compatible with
-0.2.0"). That's a fine outcome.
+- Walk the public API by hand, note any intentional breaks, and write
+  before/after recipes for each.
+- If nothing broke, collapse the page to "no migration needed; 1.0 is
+  source-compatible with 0.2.0."
+- Once §3.1 is wired post-1.0, future entries are driven by MiMa
+  filters as originally intended.
 
 ### 3.6 Definition of done for 1.0
 
-- ☐ MiMa passes; published artefacts are stable.
 - ☑ Docs site live at `https://llm4s.github.io/termflow`.
 - ☑ Tutorial ladder complete (Hello World, Counter, Async, Forms).
-- ☐ Sample app count ≥ 20 (need ~5 more after §3.2).
-- ☐ README headline screenshot is the chat client.
-- ☐ Migration guide populated (or "no migration needed" confirmed).
+- ☑ Sample app count ≥ 20 (22 today, including `tree`, `editor`, `chat`).
+- ☑ `Layout.Grid` + `Layout.Border` shipped (§3.4).
+- ☐ README headline screenshot is the chat client (§3.3).
+- ☐ Migration guide populated (or "no migration needed" confirmed) (§3.5).
+- ☐ Pre-1.0 release-hardening checklist complete (§4).
+
+MiMa (§3.1) was originally on this list; it is now scheduled for the
+1.0.1 / 1.1.0 cycle with `1.0.0` as the baseline.
 
 ---
 
-## 4. Stage 5 — Alternative backends (post-1.0, speculative)
+## 4. Stage 5 — Pre-1.0 release requirements
+
+Final hardening before tagging `v1.0.0`. These are not new feature
+tracks; they are release-quality gates for the current library surface.
+
+### 4.1 User-visible error path
+
+`Cmd.TermFlowErrorCmd` must be visible in the default runtime/renderer
+path. Validation failures, rejected prompt input, and async failures
+should render a deterministic transient error view (or documented
+equivalent) instead of disappearing.
+
+Acceptance:
+
+- Default `TuiRuntime.run(..., SimpleANSIRenderer())` surfaces
+  `TermFlowError` to the user.
+- Testkit can assert the same error path without a real terminal.
+- Docs describing validation/error behaviour match the implementation.
+
+### 4.2 Version and release-doc sweep
+
+Before the final release branch/tag, every copy-pasteable coordinate
+and release statement should reflect the intended 1.0 release story.
+
+Acceptance:
+
+- README, install guide, API reference, migration notes, and roadmap
+  agree on the current released baseline and the next target.
+- Release instructions describe the exact tag/workflow path for
+  `v1.0.0`.
+- Any stale `0.2.0` / `0.3.0` examples are intentional and explained.
+
+### 4.3 Public API and docs example audit
+
+Do a final pass over the public-facing APIs and every tutorial/guide
+snippet. The goal is not to freeze internals forever; it is to remove
+surprise from the surface users will copy into their apps.
+
+Acceptance:
+
+- Public names, signatures, and examples line up (`Cmd.asyncResult`,
+  widget constructors, `Sub.TerminalResize`, layout helpers, etc.).
+- Any deliberately sharp/advanced APIs are marked as SPI or documented
+  with constraints.
+- Migration notes list every known user-visible API adjustment, or
+  explicitly say no migration is required.
+
+### 4.4 Layout ergonomics audit
+
+Review the final layout API for common misuse before 1.0 locks it in.
+In particular, make the distinction between eager `Layout.resolve` /
+`toRootNode` and budget-aware `RootNode(layout = Some(...))` obvious
+enough that users do not accidentally disable `Fill`/resize behaviour.
+
+Acceptance:
+
+- Either `Layout.toRootNode` preserves budget-aware layout semantics,
+  or docs/examples make the eager-vs-deferred distinction explicit.
+- At least one tutorial or cookbook recipe demonstrates the preferred
+  full-screen/resizable layout pattern.
+- Golden or unit tests cover the intended public pattern.
+
+### 4.5 Rolling console / agent UI recipe
+
+TermFlow should make the Claude Code / Cursor-style transcript pattern
+obvious: execution history scrolls upward, new output auto-tails while
+the user is at the bottom, and the prompt remains fixed at the bottom
+of the viewport.
+
+Acceptance:
+
+- Add a cookbook recipe for a rolling console / agent UI built from
+  `widgets.LogView`, `Prompt`, and a bottom-row `InputNode`.
+- Document the supported model clearly: TermFlow owns an in-app
+  scrollback viewport in the alternate buffer; native terminal
+  scrollback is not the default runtime behaviour.
+- The recipe covers auto-tail, pausing auto-tail when the user scrolls
+  up, resuming with `End`, and bounding retained history.
+- Link the recipe from the install/intro path or widgets guide so LLM
+  and command-runner app authors can find it quickly.
+
+### 4.6 Mouse-wheel scrolling for LogView-style views
+
+Mouse wheel input is already decoded as `InputKey.Mouse(MouseEvent.Scroll(...))`.
+The rolling-console path should demonstrate and, where useful, smooth
+over the app wiring needed to turn that into `scrollOffset` changes.
+
+Acceptance:
+
+- `chatDemo` handles mouse-wheel up/down over the transcript pane.
+- Add a small helper or documented pattern for mapping
+  `MouseEvent.Scroll` to `LogView` scroll deltas while ignoring scrolls
+  outside the target viewport.
+- Add deterministic test coverage using `MouseSim.scrollUp` /
+  `MouseSim.scrollDown`.
+- The docs mention keyboard equivalents for environments where mouse
+  reporting is unavailable.
+
+### 4.7 Test coverage review and quick wins
+
+Because TermFlow is mostly deterministic UI logic, coverage should be
+higher than a typical terminal integration project. Run `sbt --batch
+coverageLib`, inspect the lowest-covered files/branches, and take the
+low-risk wins before 1.0.
+
+Current local coverage snapshot (2026-04-30):
+
+- `termflow-terminal`: 66.04% statements / 63.32% branches.
+- `termflow-screen`: 71.81% statements / 65.22% branches.
+- `termflow-app`: 80.29% statements / 68.61% branches.
+- `termflow-widgets`: 92.63% statements / 85.00% branches.
+
+Acceptance:
+
+- Add focused tests for pure/render/update logic with obvious gaps.
+- Prefer deterministic tests over brittle real-terminal integration.
+- Record any accepted low-coverage areas with rationale (JLine/raw TTY
+  integration, shutdown-hook paths, genuinely platform-specific code).
+- Keep `coverageLib` green and ensure the combined trend moves up, with
+  particular attention to `termflow-terminal` and `termflow-screen`.
+
+### 4.8 Zero-warning build and Scaladoc polish
+
+The 1.0 branch should build cleanly enough that new warnings stand out.
+
+Acceptance:
+
+- `sbt --batch ciCheck` emits no Scala compiler warnings.
+- `sbt --batch unidoc` completes without unresolved-link warnings where
+  a simple Scaladoc link fix is available.
+- mdBook/linkcheck remain green.
+
+---
+
+## 5. Stage 6 — Alternative backends (post-1.0, speculative)
 
 Each backend is an opt-in module. None are on the 1.0 critical path.
 
-### 4.1 Telnet backend
+### 5.1 Telnet backend
 
 `termflow-backend-telnet`. Bind a port, accept connections, each
 connection becomes a `TerminalBackend`. Telnet option negotiation
@@ -153,7 +308,7 @@ effort.
 debug shells. **Not encrypted** — operators wrap it in stunnel /
 WireGuard / SSH-jumphost for production.
 
-### 4.2 Web backend (xterm.js over WebSocket)
+### 5.2 Web backend (xterm.js over WebSocket)
 
 `termflow-backend-web`. Serve `xterm.js` plus a WebSocket; the WS
 frames become the terminal stream. Run a TUI in a browser tab.
@@ -161,14 +316,14 @@ frames become the terminal stream. Run a TUI in a browser tab.
 **Effort.** Large but cleanly bounded. Probably the most
 "wow factor" of the bunch — a Scala TUI in the browser is unique.
 
-### 4.3 Explicitly *not* planned (third-party PRs welcome)
+### 5.3 Explicitly *not* planned (third-party PRs welcome)
 
 - **Swing / AWT emulator backend** — desktop window with a TUI
-  emulator inside. Skipped because §4.2 covers most of the same use
+  emulator inside. Skipped because §5.2 covers most of the same use
   cases at similar effort and reaches more users.
 - **SSH backend** — wrap Apache MINA SSHD or sshj. Skipped because
   key management, auth, and connection state are a perpetually-supported
-  surface area we don't want to own. Compose §4.1 Telnet behind an
+  surface area we don't want to own. Compose §5.1 Telnet behind an
   external SSH jump host instead.
 
 The `TerminalBackend` trait stays public so external contributors
@@ -176,7 +331,7 @@ can ship either as a separate artefact.
 
 ---
 
-## 5. Open questions
+## 6. Open questions
 
 1. **Native image.** `sbt-native-image` build for
    `graalvm-native-image`? The shutdown hook + JLine reflection make
@@ -197,7 +352,7 @@ can ship either as a separate artefact.
 
 ---
 
-## 6. Lanterna comparison reference
+## 7. Lanterna comparison reference
 
 The original 0.1.x roadmap was structured around a comparison with
 [Lanterna](https://github.com/mabe02/lanterna). That comparison drove
@@ -219,8 +374,25 @@ Two TermFlow-only wins worth preserving through 1.0:
 
 ---
 
-## 7. Recent decisions (rolling, last ~3 months)
+## 8. Recent decisions (rolling, last ~3 months)
 
+- *2026-04-30* — Terminal-attention notifications shipped:
+  `Cmd.RequestAttention` and `Cmd.Notify(title, body)` with detection for
+  iTerm2 (OSC 9 / 1337), kitty (OSC 99), VTE (OSC 777), and a BEL
+  fallback. Override via `TERMFLOW_NOTIFICATIONS=off|bell|auto`. Wired
+  through the showcase Help tab and a new `notifications` cookbook recipe.
+- *2026-04-30* — Added Stage 5 (§4) as the pre-1.0 release-hardening
+  checklist: user-visible errors, release-doc accuracy, API/docs audit,
+  layout ergonomics, rolling-console UX, mouse-wheel scrollback, coverage
+  quick wins, and zero-warning builds.
+- *2026-04-30* — MiMa (§3.1) deferred to post-1.0; baseline becomes
+  `1.0.0`. Reason: 0.2.0 is already API-stable, so the 0.2.0 → 1.0
+  filter list would be mostly noise, and decoupling §3.1 from §3.5
+  removes a chicken-and-egg dependency.
+- *2026-04-30* — Stage 4 §3.2 closed: `tree/` (#188), `editor/` (#189),
+  and streaming `chat/` (#190) sample apps landed. Catalogue at 22.
+- *2026-04-30* — Stage 4 §3.4 closed: `Layout.Grid` + `Layout.Border`
+  shipped in #187 with `LayoutGridSpec` / `LayoutBorderSpec` coverage.
 - *2026-04-29* — Docs site launched (Stage 4 §3 complete except for
   migration guide). mdBook + sbt-unidoc on GitHub Pages.
 - *2026-04-28* — Stage 3 final components landed: `actionList`
@@ -233,4 +405,4 @@ Two TermFlow-only wins worth preserving through 1.0:
 - *2026-04-27* — Stages 1 and 2 closed. Module split shipped early
   as Stage 4 prep so MiMa filters can be wired per-module on day one.
 - *2026-04-26* — Decision to deprioritise Swing/AWT and SSH backends
-  (now §4.3); Telnet (§4.1) and Web (§4.2) remain.
+  (now §5.3); Telnet (§5.1) and Web (§5.2) remain.

--- a/docs/contrib/ROADMAP.md
+++ b/docs/contrib/ROADMAP.md
@@ -293,9 +293,9 @@ Acceptance:
 
 ---
 
-## 5. Stage 6 — Alternative backends (post-1.0, speculative)
+## 5. Stage 6 — Alternative backends and renderers (post-1.0, speculative)
 
-Each backend is an opt-in module. None are on the 1.0 critical path.
+Each backend or renderer is opt-in. None are on the 1.0 critical path.
 
 ### 5.1 Telnet backend
 
@@ -316,7 +316,35 @@ frames become the terminal stream. Run a TUI in a browser tab.
 **Effort.** Large but cleanly bounded. Probably the most
 "wow factor" of the bunch — a Scala TUI in the browser is unique.
 
-### 5.3 Explicitly *not* planned (third-party PRs welcome)
+### 5.3 Rolling console renderer
+
+A constrained normal-buffer renderer/runtime mode for agent and command
+runner apps that want native terminal scrollback: output appends to the
+terminal's real history while a live prompt/status area remains pinned
+near the bottom.
+
+This should not try to support arbitrary full-screen TermFlow VDOM. The
+current default runtime enters the alternate buffer and the default
+renderer diffs fixed frames by absolute coordinates; native scrollback
+needs a different contract built around append-only transcript events,
+prompt repainting, cursor save/restore, and possibly terminal scroll
+regions.
+
+**Use case.** Claude Code / Cursor-style agents, build runners, REPLs,
+and long-running command logs where users expect their terminal
+emulator's own scrollbar, copy/search behaviour, and shell history
+context to keep working.
+
+**Shape.** Likely a dedicated `RollingConsoleApp` or renderer API, not
+a flag on `SimpleANSIRenderer`. It should support bounded app-side
+history for replay/testing, normal-buffer append, fixed bottom prompt,
+keyboard input, resize handling, and a graceful fallback when terminals
+handle scroll regions poorly.
+
+**Effort.** Medium-large and compatibility-sensitive. Worth prototyping
+after 1.0, but too risky to make part of the 1.0 contract.
+
+### 5.4 Explicitly *not* planned (third-party PRs welcome)
 
 - **Swing / AWT emulator backend** — desktop window with a TUI
   emulator inside. Skipped because §5.2 covers most of the same use
@@ -381,6 +409,9 @@ Two TermFlow-only wins worth preserving through 1.0:
   iTerm2 (OSC 9 / 1337), kitty (OSC 99), VTE (OSC 777), and a BEL
   fallback. Override via `TERMFLOW_NOTIFICATIONS=off|bell|auto`. Wired
   through the showcase Help tab and a new `notifications` cookbook recipe.
+- *2026-04-30* — Added rolling console renderer (§5.3) as a post-1.0
+  idea: native terminal scrollback for agent / command-runner UIs via a
+  constrained normal-buffer runtime, not the default full-screen renderer.
 - *2026-04-30* — Added Stage 5 (§4) as the pre-1.0 release-hardening
   checklist: user-visible errors, release-doc accuracy, API/docs audit,
   layout ergonomics, rolling-console UX, mouse-wheel scrollback, coverage
@@ -405,4 +436,4 @@ Two TermFlow-only wins worth preserving through 1.0:
 - *2026-04-27* — Stages 1 and 2 closed. Module split shipped early
   as Stage 4 prep so MiMa filters can be wired per-module on day one.
 - *2026-04-26* — Decision to deprioritise Swing/AWT and SSH backends
-  (now §5.3); Telnet (§5.1) and Web (§5.2) remain.
+  (now §5.4); Telnet (§5.1) and Web (§5.2) remain.

--- a/docs/contrib/ROADMAP.md
+++ b/docs/contrib/ROADMAP.md
@@ -164,19 +164,16 @@ MiMa (§3.1) was originally on this list; it is now scheduled for the
 Final hardening before tagging `v1.0.0`. These are not new feature
 tracks; they are release-quality gates for the current library surface.
 
-### 4.1 User-visible error path
+### 4.1 User-visible error path — ☑ landed
 
-`Cmd.TermFlowErrorCmd` must be visible in the default runtime/renderer
-path. Validation failures, rejected prompt input, and async failures
-should render a deterministic transient error view (or documented
-equivalent) instead of disappearing.
-
-Acceptance:
-
-- Default `TuiRuntime.run(..., SimpleANSIRenderer())` surfaces
-  `TermFlowError` to the user.
-- Testkit can assert the same error path without a real terminal.
-- Docs describing validation/error behaviour match the implementation.
+`Cmd.TermFlowErrorCmd` now reaches the user. `SimpleANSIRenderer`
+overlays a red, bold banner across the top row of the next frame and
+clears it on the following render — long messages truncate with an
+ellipsis. `SimpleANSIRendererSpec` covers banner content, styling,
+truncation, and frame immutability. `TuiTestDriver.observedErrors`
+gives tests the same assertion path without a real terminal. The
+app-layer guide has a new "How errors reach the user" section that
+shows the rendered banner and the testkit hook.
 
 ### 4.2 Version and release-doc sweep
 
@@ -206,20 +203,17 @@ Acceptance:
 - Migration notes list every known user-visible API adjustment, or
   explicitly say no migration is required.
 
-### 4.4 Layout ergonomics audit
+### 4.4 Layout ergonomics audit — ☑ landed
 
-Review the final layout API for common misuse before 1.0 locks it in.
-In particular, make the distinction between eager `Layout.resolve` /
-`toRootNode` and budget-aware `RootNode(layout = Some(...))` obvious
-enough that users do not accidentally disable `Fill`/resize behaviour.
-
-Acceptance:
-
-- Either `Layout.toRootNode` preserves budget-aware layout semantics,
-  or docs/examples make the eager-vs-deferred distinction explicit.
-- At least one tutorial or cookbook recipe demonstrates the preferred
-  full-screen/resizable layout pattern.
-- Golden or unit tests cover the intended public pattern.
+`Layout.toBudgetedRootNode(width, height, input)` now expresses the
+deferred form alongside the existing eager `toRootNode`, putting the
+layout into `RootNode.layout` so the renderer resolves it against the
+frame's full budget at render time. `toRootNode` keeps its eager
+semantics; its Scaladoc flags the trap and points at the budgeted form.
+A new cookbook recipe (`full-screen-layout.md`) walks the header / fill
+/ footer pattern, the eager-vs-deferred trade-off, and the both-fields
+composition seam. `LayoutSpec` covers both forms with a Fill-collapses
+vs Fill-expands comparison.
 
 ### 4.5 Rolling console / agent UI recipe
 
@@ -240,22 +234,17 @@ Acceptance:
 - Link the recipe from the install/intro path or widgets guide so LLM
   and command-runner app authors can find it quickly.
 
-### 4.6 Mouse-wheel scrolling for LogView-style views
+### 4.6 Mouse-wheel scrolling for LogView-style views — ☑ landed
 
-Mouse wheel input is already decoded as `InputKey.Mouse(MouseEvent.Scroll(...))`.
-The rolling-console path should demonstrate and, where useful, smooth
-over the app wiring needed to turn that into `scrollOffset` changes.
-
-Acceptance:
-
-- `chatDemo` handles mouse-wheel up/down over the transcript pane.
-- Add a small helper or documented pattern for mapping
-  `MouseEvent.Scroll` to `LogView` scroll deltas while ignoring scrolls
-  outside the target viewport.
-- Add deterministic test coverage using `MouseSim.scrollUp` /
-  `MouseSim.scrollDown`.
-- The docs mention keyboard equivalents for environments where mouse
-  reporting is unavailable.
+`LogView.scrollDelta(event, viewport, ticksPerDetent)` plus
+`LogView.Viewport(at, width, height)` map a `MouseEvent.Scroll` onto a
+clamp-friendly scroll delta when the wheel lands inside the viewport,
+returning `None` for outside-the-rect or non-scroll events. `chatDemo`
+wires it in (3 lines per detent, ignored over prompt / status row).
+`LogViewSpec` exercises every helper branch; `ChatStreamAppSpec` adds
+two `MouseSim.scrollUp` tests for the in-pane and out-of-pane paths.
+The streaming-output cookbook recipe documents the pattern next to the
+keyboard fallbacks.
 
 ### 4.7 Test coverage review and quick wins
 
@@ -404,6 +393,15 @@ Two TermFlow-only wins worth preserving through 1.0:
 
 ## 8. Recent decisions (rolling, last ~3 months)
 
+- *2026-04-30* — Stage 4 §4.1 closed: `SimpleANSIRenderer` now overlays
+  a red, bold banner for `Cmd.TermFlowErrorCmd` and clears it on the
+  next frame; testkit captures the same path via `observedErrors`.
+- *2026-04-30* — Stage 4 §4.4 closed: `Layout.toBudgetedRootNode` is the
+  deferred sibling to the eager `toRootNode`; new full-screen-layout
+  cookbook recipe explains when each form is appropriate.
+- *2026-04-30* — Stage 4 §4.6 closed: `LogView.scrollDelta` +
+  `LogView.Viewport` give apps a one-call hook for mouse-wheel
+  scrollback; wired into `chatDemo` and covered with `MouseSim`.
 - *2026-04-30* — Terminal-attention notifications shipped:
   `Cmd.RequestAttention` and `Cmd.Notify(title, body)` with detection for
   iTerm2 (OSC 9 / 1337), kitty (OSC 99), VTE (OSC 777), and a BEL

--- a/docs/contrib/RUN_EXAMPLES.md
+++ b/docs/contrib/RUN_EXAMPLES.md
@@ -70,6 +70,9 @@ sbt "termflowSample/runMain termflow.apps.chat.ProviderChatRenderReproMain"
 | `stressDemo` | `RenderStressApp` | High-frequency updates — useful for spotting flicker |
 | `sineDemo` | `SineWaveApp` | Animated sine wave; same purpose as `stressDemo` with smoother motion |
 | `inputDemo` | `InputLineReproApp` | Pinned reproduction of the prompt/cursor regressions behind #73 and #74 |
+| `treeDemo` | `FileTreeApp` | File-tree explorer over the `Tree` widget on a `Layout.Border` shell |
+| `editorDemo` | `EditorApp` | Multi-buffer text editor combining `MultiLineInput` + `SplitPane` + `MenuBar` |
+| `chatDemo` | `ChatStreamApp` | Streaming chat with `LogView` scrollback and `Sub.Every` token streaming |
 
 ## Widgets demo keys
 
@@ -124,10 +127,10 @@ If you'd rather have shell-level shortcuts, drop this in `~/.zshrc` /
 termflow-run() {
   local app="$1"
   case "$app" in
-    hub|widgets|form|catalog|echo|counter|future|clock|tabs|task|stress|sine|input)
+    hub|widgets|form|catalog|echo|counter|future|clock|tabs|task|stress|sine|input|tree|editor|chat)
       sbt "${app}Demo" ;;
     *)
-      echo "Usage: termflow-run {hub|widgets|form|catalog|echo|counter|future|clock|tabs|task|stress|sine|input}"
+      echo "Usage: termflow-run {hub|widgets|form|catalog|echo|counter|future|clock|tabs|task|stress|sine|input|tree|editor|chat}"
       return 1
       ;;
   esac

--- a/docs/cookbook/full-screen-layout.md
+++ b/docs/cookbook/full-screen-layout.md
@@ -1,0 +1,123 @@
+# Full-screen layouts that reflow on resize
+
+If you build your view with `Layout.row` / `Layout.column` / `Layout.Fill`
+and want the result to fill the terminal — and *keep* filling it when the
+user resizes — you need TermFlow to resolve the layout against the actual
+frame size at render time, not when `view` runs.
+
+## The two `RootNode` shapes
+
+| Shape | When the layout resolves | `Layout.Fill` behaviour |
+|---|---|---|
+| `RootNode(width, height, children, input)` | At `view` time, eagerly | Collapses to natural (zero) size |
+| `RootNode(width, height, Nil, input, layout = Some(l))` | At render time, against the frame's `(width, height)` | Expands to fill the available space |
+
+Two helpers on `Layout` produce each shape:
+
+```scala
+val eager     = layout.toRootNode(width = w, height = h)              // children = resolve(...)
+val budgeted  = layout.toBudgetedRootNode(width = w, height = h)      // layout = Some(layout), children = Nil
+```
+
+`toRootNode` is the right tool for fixed-size sub-regions, dialogs, and
+golden-snapshot tests where you want deterministic positions. **For
+full-screen apps containing `Fill` / `Grid` / `Border`, use
+`toBudgetedRootNode`** — that's the only form where the renderer knows
+the budget the layout should reflow into.
+
+## Recipe — header / fill / footer
+
+Take the canonical "header on top, scrolling middle, status bar pinned
+to the bottom" layout. The middle section uses `Layout.Fill` so it grows
+and shrinks with the terminal.
+
+```scala
+import termflow.tui.*
+import termflow.tui.ScreenPrelude.*
+import termflow.tui.Tui.*
+
+case class Model(width: Int, height: Int, log: List[String])
+
+enum Msg:
+  case Resize(w: Int, h: Int)
+  case Quit
+
+object App extends TuiApp[Model, Msg]:
+
+  def init(ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+    Model(ctx.terminal.width, ctx.terminal.height, log = Nil).tui
+
+  def update(m: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+    msg match
+      case Msg.Resize(w, h) => m.copy(width = w, height = h).tui
+      case Msg.Quit         => Tui(m, Cmd.Exit)
+
+  def view(m: Model): RootNode =
+    val header = TextNode(1.x, 1.y, List(" TermFlow demo ".text(bold = true)))
+    val body   = TextNode(1.x, 1.y, List(m.log.lastOption.getOrElse("(idle)").text))
+    val footer = TextNode(1.x, 1.y, List(s" ${m.width}×${m.height}  q: quit ".text))
+
+    Layout.column(gap = 0)(
+      header,
+      // Fill takes the rest of the column once header / footer are sized.
+      // Outside toBudgetedRootNode this would collapse to zero rows.
+    )
+    val layout = Layout.Column(
+      gap = 0,
+      children = List(
+        header.asLayout,
+        Layout.Fill(body.asLayout),
+        footer.asLayout
+      )
+    )
+    layout.toBudgetedRootNode(width = m.width, height = m.height)
+
+  def toMsg(input: PromptLine): Result[Msg] = Right(Msg.Quit)
+```
+
+Wire `Sub.TerminalResize` so `Msg.Resize` keeps `(width, height)` current
+and the renderer's frame budget tracks the live terminal — `Fill` then
+absorbs the extra rows automatically. No bespoke "what's the available
+height after the header" arithmetic in `view`.
+
+## Why both forms exist
+
+Eager resolution is genuinely useful:
+
+- **Fixed-size widgets and dialogs.** A 40×10 confirm dialog drawn at a
+  computed offset doesn't need to know the frame width.
+- **Golden-snapshot tests.** Asserting on `RootNode.children` is much
+  easier when the children list is populated.
+- **Composition.** You can resolve a sub-layout to a list of vnodes, mix
+  with hand-positioned nodes, and pass the lot to `RootNode(children =
+  ...)`.
+
+The deferred `toBudgetedRootNode` form trades that ergonomics for the
+guarantee that `Fill` actually fills and the layout reflows on resize.
+For most "the whole TUI is one layout" apps, that's the right trade.
+
+## Mixing both
+
+Both fields on `RootNode` may be set at once. `children` paints first,
+then the resolved `layout` is composited on top:
+
+```scala
+RootNode(
+  width = m.width,
+  height = m.height,
+  children = staticBackground,         // eager — fixed positions
+  input = focusedInput,
+  layout = Some(reflowableForeground)  // budget-aware — reflows on resize
+)
+```
+
+This is the seam most non-trivial apps end up using: a static decor
+behind a layout-driven main panel.
+
+## See also
+
+- [Screen layer guide](../guide/screen-layer.md#fill--eat-remaining-space)
+  for the full `Layout` DSL.
+- [`Layout.Grid` / `Layout.Border`](../guide/screen-layer.md#grid--fixed-column-grid-with-optional-span)
+  — both produce real reflow only under `toBudgetedRootNode` (or an
+  explicit `RootNode(layout = Some(...))`).

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -26,6 +26,9 @@ TermFlow APIs and (where possible) a sample app you can run.
   — `WCWidth`, `Grapheme`, `RenderCell.width = 2`.
 - **[Clean shutdown on `Ctrl-C` and on resize](clean-shutdown.md)** —
   what the runtime does for you, where you still have to wire `Cmd.Exit`.
+- **[Flag a session as needing attention](notifications.md)** —
+  `Cmd.RequestAttention`, `Cmd.Notify`, terminal detection
+  (iTerm2 / kitty / VTE), tmux caveats.
 
 ## Want more?
 

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -29,6 +29,9 @@ TermFlow APIs and (where possible) a sample app you can run.
 - **[Flag a session as needing attention](notifications.md)** —
   `Cmd.RequestAttention`, `Cmd.Notify`, terminal detection
   (iTerm2 / kitty / VTE), tmux caveats.
+- **[Full-screen layouts that reflow on resize](full-screen-layout.md)** —
+  `Layout.toBudgetedRootNode` vs. `toRootNode`, `Fill` semantics,
+  header/fill/footer pattern.
 
 ## Want more?
 

--- a/docs/cookbook/notifications.md
+++ b/docs/cookbook/notifications.md
@@ -1,0 +1,119 @@
+# Flag a session as needing attention
+
+Long-running TUIs often want to ping the user when something interesting
+happens — a build finished, a streaming reply landed, an alert fired. The
+classic UX is the **terminal bell** (which most modern terminals translate
+into a tab-bar activity indicator) plus, where supported, a real **desktop
+notification** with a title and body.
+
+TermFlow exposes two `Cmd` variants for this:
+
+- **`Cmd.RequestAttention`** — minimum signal. Emits BEL on every backend
+  except `Disabled`; iTerm2 also bounces the dock icon via
+  `OSC 1337 RequestAttention`.
+- **`Cmd.Notify(title, body)`** — desktop notification when the terminal
+  has a protocol for it; falls back to BEL otherwise.
+
+## Quick example
+
+```scala
+import termflow.tui.*
+import termflow.tui.Tui.*
+
+enum Msg:
+  case StreamFinished(reply: String)
+  case BackgroundJobFailed(err: String)
+  case Quit
+
+def update(model: Model, msg: Msg, ctx: RuntimeCtx[Msg]): Tui[Model, Msg] =
+  msg match
+    case Msg.StreamFinished(reply) =>
+      Tui(
+        model.copy(reply = Some(reply)),
+        Cmd.Notify("Reply ready", reply.take(60))
+      )
+
+    case Msg.BackgroundJobFailed(err) =>
+      // BEL + iTerm2 RequestAttention. Cheaper than a full notification —
+      // useful when the user is more likely to be watching the tab bar
+      // than a notification centre.
+      Tui(model.copy(error = Some(err)), Cmd.RequestAttention)
+
+    case Msg.Quit => Tui(model, Cmd.Exit)
+```
+
+That's it. The runtime delegates to `TerminalBackend.notify` /
+`TerminalBackend.requestAttention`, which select the right escape sequence
+from the detected `Capabilities.notifications`.
+
+## What gets emitted
+
+| Terminal | Detection | Sequence |
+|---|---|---|
+| iTerm2 | `TERM_PROGRAM=iTerm.app` | `OSC 9 ; <message> BEL` and `OSC 1337 ; RequestAttention=yes BEL` |
+| kitty | `KITTY_WINDOW_ID` set or `TERM=xterm-kitty` | `OSC 99 ; <metadata> ; <body> ST` |
+| GNOME Terminal / Tilix / xfce4-terminal | `VTE_VERSION` set | `OSC 777 ; notify ; <title> ; <body> BEL` |
+| Anything else (xterm, Alacritty, WezTerm, …) | TERM looks like a real terminal | `BEL` (`\x07`) |
+| `dumb` / unset `TERM` | — | nothing (`Disabled`) |
+
+The current detection lives in
+[`Capabilities.detect`](https://github.com/llm4s/termflow/blob/main/modules/termflow-terminal/src/main/scala/termflow/tui/Capabilities.scala);
+override the result by constructing `Capabilities` directly, or set
+`TERMFLOW_NOTIFICATIONS=off|bell|auto` to force a kind:
+
+- `off` — never emit anything.
+- `bell` — always emit just BEL, even on iTerm2 / kitty / VTE.
+- `auto` (default) — sniff the environment, pick the richest available kind.
+
+## Inside tmux / screen
+
+`tmux` and `screen` translate BEL into an in-status-bar window-bell or
+activity flag (subject to `set -g monitor-bell on`). That covers the
+"flag this pane needs attention" use case directly — no extra wiring
+required.
+
+The richer OSC sequences (`OSC 9`, `OSC 99`, `OSC 777`) **do not** reach the
+outer terminal by default. tmux can be configured to forward them via DCS
+passthrough (`set -g allow-passthrough on`) but this is off by default and
+TermFlow does not currently auto-wrap. If you need desktop notifications
+from inside tmux, either enable passthrough on the target session or rely
+on the BEL fallback.
+
+## Testing notifications
+
+`termflow-testkit`'s `TuiTestDriver` records every `Cmd.RequestAttention`
+and `Cmd.Notify` so apps can assert on them without a real terminal:
+
+```scala
+val driver = TuiTestDriver(MyApp, width = 80, height = 24)
+driver.init()
+driver.send(Msg.StreamFinished("hello"))
+
+assert(driver.observedNotifications == List("Reply ready" -> "hello"))
+assert(driver.attentionCount == 0)
+```
+
+No real escape bytes leave the harness — the driver intercepts the
+commands at dispatch time.
+
+## When to use which
+
+- **Reach for `Cmd.RequestAttention`** for cheap, frequent signals: a job
+  failed, an alert fired, an error came back from a streaming call. Most
+  terminals will silently fold a flurry of BELs into one activity flag.
+- **Reach for `Cmd.Notify`** for events the user genuinely wants to read
+  in a notification centre: a build finished after several minutes, an
+  agent finished a long task, a pull request is ready for review. Most OSes
+  rate-limit notifications, so aggressive use will get the user to silence
+  the app.
+
+## Caveats
+
+- **Headless / SSH.** BEL still works (it is just a byte). Desktop
+  notifications reach whichever terminal the user is sitting at — the
+  remote host has no idea whether the local terminal renders them.
+- **No newlines / control bytes in titles or bodies.** TermFlow strips
+  C0 controls before emitting, so unsanitised user input will not break
+  the OSC envelope.
+- **Always opt in.** Don't fire on every keystroke or every frame. Tie
+  notifications to model transitions the user actually cares about.

--- a/docs/cookbook/streaming-output.md
+++ b/docs/cookbook/streaming-output.md
@@ -82,6 +82,18 @@ def view(m: Model): RootNode =
   again — the convention every chat client uses.
 - **Dropping `wrap = true`** truncates rather than wrapping; the
   `maxScroll` math still works either way.
+- **Mouse-wheel scrollback.** Wire mouse events through
+  `LogView.scrollDelta(event, viewport, ticksPerDetent)` — it returns
+  `Some(delta)` only when the scroll lands inside the viewport rectangle
+  you describe with `LogView.Viewport(at, width, height)`. Reuse the
+  same `at` / `width` / `height` you passed to `LogView.apply`, and feed
+  the returned delta into the same scroll-update path the keyboard uses.
+  Outside-the-viewport events return `None` so a wheel hovering over the
+  prompt or the status row won't accidentally page through history.
+  Default `ticksPerDetent = 3` matches the speed terminal users expect;
+  pass `1` for one-line-per-detent. Keyboard equivalents (↑/↓, PageUp /
+  PageDown, End) keep working when mouse reporting is unavailable —
+  always wire both.
 
 For an end-to-end example, see
 [`apps.echo.EchoApp`](https://github.com/llm4s/termflow/blob/main/modules/termflow-sample/src/main/scala/termflow/apps/echo/EchoApp.scala),

--- a/docs/guide/app-layer.md
+++ b/docs/guide/app-layer.md
@@ -256,6 +256,33 @@ Plus the screen-prelude conversions (`.x`, `.y`, `.text`).
 
 > File: `TuiPrelude.scala`.
 
+### How errors reach the user
+
+A `Cmd.TermFlowErrorCmd(err)` does not crash the app or block the runtime
+loop. The runtime captures `err` as the *pending error* for the next
+frame; `SimpleANSIRenderer` then overlays a single-line, red, bold banner
+across the top row of the rendered frame and clears it on the following
+render. Long messages are truncated with an ellipsis to fit the terminal
+width.
+
+```text
+┌──────────────────────────────────┐
+│ Invalid input: name must be set… │  ← banner, single frame, then gone
+│ Name: alice___                   │
+│ ...                              │
+```
+
+Apps don't need to do anything to opt in — return `Cmd.TermFlowErrorCmd`
+from `update` (or use `Cmd.asyncResult` and let the runtime fold a
+`Left(err)` for you), and the banner appears.
+
+For tests, `TuiTestDriver.observedErrors: List[TermFlowError]` records
+every error raised through this path without a real terminal.
+
+The wording used by the banner is exposed as
+`SimpleANSIRenderer.formatErrorBanner(err)` so custom renderers can stay
+consistent with the default.
+
 ## Where to next
 
 - **Widgets.** The component catalogue: [Widgets guide](widgets.md).

--- a/docs/guide/screen-layer.md
+++ b/docs/guide/screen-layer.md
@@ -117,7 +117,14 @@ Layout.Row(gap = 1, children = List(
 ```
 
 Resolve `Fill` regions with `Layout.resolveTo(layout, at, w, h)` — the
-form that knows the available width / height.
+form that knows the available width / height. For full-screen apps, the
+idiomatic shape is `layout.toBudgetedRootNode(width, height)`, which
+puts the layout into `RootNode.layout` so the renderer applies the
+budget at render time and the layout reflows on resize. The eager
+`layout.toRootNode(width, height)` form intentionally does *not* apply
+a budget — see the
+[full-screen layout cookbook](../cookbook/full-screen-layout.md) for
+when each form is appropriate.
 
 ### `Grid` — fixed-column grid with optional span
 

--- a/modules/termflow-app/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Devtools.scala
@@ -655,6 +655,8 @@ object Devtools:
       case Cmd.Exit                      => Cmd.Exit
       case Cmd.GCmd(innerMsg)            => Cmd.GCmd(WrapMsg.Inner(innerMsg))
       case Cmd.TermFlowErrorCmd(err)     => Cmd.TermFlowErrorCmd(err)
+      case Cmd.RequestAttention          => Cmd.RequestAttention
+      case n: Cmd.Notify                 => n
       case fc: Cmd.FCmd[a, ?] @unchecked =>
         // Erasure-safe: Cmd.FCmd's second type parameter is always the
         // enclosing Cmd[Ms]'s Msg type. The @unchecked suppresses the

--- a/modules/termflow-app/src/main/scala/termflow/tui/SimpleANSIRenderer.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/SimpleANSIRenderer.scala
@@ -92,7 +92,7 @@ object SimpleANSIRenderer:
         else if budget <= 1 then text.take(budget)
         else text.take(budget - 1) + "…"
       val padded = (" " + body).padTo(frame.width, ' ').take(frame.width)
-      val style = Style(fg = Color.White, bg = Color.Red, bold = true)
+      val style  = Style(fg = Color.White, bg = Color.Red, bold = true)
       val newRow = Array.tabulate(frame.width) { col =>
         val ch = if col < padded.length then padded.charAt(col) else ' '
         AnsiRenderer.RenderCell(ch, style, 1)

--- a/modules/termflow-app/src/main/scala/termflow/tui/SimpleANSIRenderer.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/SimpleANSIRenderer.scala
@@ -8,6 +8,11 @@ package termflow.tui
  * decides per call whether to emit a diff or a full repaint, threading
  * the result through the supplied [[RenderMetrics]].
  *
+ * When the runtime supplies a non-empty `err`, the renderer overlays a
+ * red, bold banner across the top row of the frame *before* diffing, so
+ * the banner participates in the normal diff/repaint pipeline. The next
+ * frame without `err` paints over the banner with the app's own view.
+ *
  * Lives in `termflow-app` because it depends on the app-layer types
  * `TuiRenderer`, `TermFlowError`, and `RenderMetrics`. The pure
  * `AnsiRenderer.{buildFrame, diff}` primitives stay in
@@ -24,10 +29,13 @@ final case class SimpleANSIRenderer() extends TuiRenderer:
     terminal: TerminalBackend,
     renderMetrics: RenderMetrics
   ): Unit =
-    val currentFrame = AnsiRenderer.buildFrame(textNode)
-    val resized      = lastFrame.exists(prev => prev.width != currentFrame.width || prev.height != currentFrame.height)
-    val depth        = terminal.capabilities.colorDepth
-    val ext          = terminal.capabilities.extendedStyles
+    val baseFrame = AnsiRenderer.buildFrame(textNode)
+    val currentFrame = err match
+      case Some(e) => SimpleANSIRenderer.overlayErrorBanner(baseFrame, e)
+      case None    => baseFrame
+    val resized = lastFrame.exists(prev => prev.width != currentFrame.width || prev.height != currentFrame.height)
+    val depth   = terminal.capabilities.colorDepth
+    val ext     = terminal.capabilities.extendedStyles
     val initialDiff =
       if resized then AnsiRenderer.diff(None, currentFrame, depth, ext)
       else AnsiRenderer.diff(lastFrame, currentFrame, depth, ext)
@@ -46,4 +54,49 @@ final case class SimpleANSIRenderer() extends TuiRenderer:
       val bytes = ansi.getBytes("UTF-8").length
       renderMetrics.recordRender(diffResult.changedCells, bytes)
     lastFrame = Some(currentFrame)
-    val _ = err
+
+object SimpleANSIRenderer:
+
+  /**
+   * Format a [[TermFlowError]] as the short, single-line text shown in the
+   * runtime's error banner. Public so apps that ship a custom
+   * [[TuiRenderer]] can match the default's wording.
+   */
+  def formatErrorBanner(err: TermFlowError): String = err match
+    case TermFlowError.ConfigError(msg)    => s"Config error: $msg"
+    case TermFlowError.ModelNotFound       => "Model not found"
+    case TermFlowError.Unexpected(msg, _)  => s"Error: $msg"
+    case TermFlowError.Validation(msg)     => s"Invalid input: $msg"
+    case TermFlowError.CommandError(input) => s"Unrecognised command: $input"
+    case TermFlowError.UnknownApp(name)    => s"Unknown app: $name"
+
+  /**
+   * Return a copy of `frame` with the top row replaced by a red, bold
+   * banner that surfaces `err`. Wide-cell-safe: writes single-width cells
+   * across the row and truncates long messages with an ellipsis. If the
+   * frame has no rows or zero width the original frame is returned
+   * unchanged.
+   */
+  def overlayErrorBanner(
+    frame: AnsiRenderer.RenderFrame,
+    err: TermFlowError
+  ): AnsiRenderer.RenderFrame =
+    if frame.height <= 0 || frame.width <= 0 then frame
+    else
+      val text = formatErrorBanner(err)
+      // Reserve one leading space; truncate with an ellipsis when the
+      // message is wider than the remaining banner width.
+      val budget = math.max(0, frame.width - 1)
+      val body =
+        if text.length <= budget then text
+        else if budget <= 1 then text.take(budget)
+        else text.take(budget - 1) + "…"
+      val padded = (" " + body).padTo(frame.width, ' ').take(frame.width)
+      val style = Style(fg = Color.White, bg = Color.Red, bold = true)
+      val newRow = Array.tabulate(frame.width) { col =>
+        val ch = if col < padded.length then padded.charAt(col) else ' '
+        AnsiRenderer.RenderCell(ch, style, 1)
+      }
+      val newCells = frame.cells.clone()
+      newCells(0) = newRow
+      frame.copy(cells = newCells)

--- a/modules/termflow-app/src/main/scala/termflow/tui/Tui.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Tui.scala
@@ -143,6 +143,32 @@ enum Cmd[+Msg]:
    */
   case TermFlowErrorCmd(msg: TermFlowError) extends Cmd[Msg]
 
+  /**
+   * Ring the terminal bell or pop the iTerm2 "request attention" indicator.
+   *
+   * The runtime delegates to `TerminalBackend.requestAttention()`, which
+   * picks the right sequence based on `Capabilities.notifications` (BEL,
+   * `OSC 1337 RequestAttention=yes`, …). Apps typically fire this when an
+   * async result is ready while the user is likely focused elsewhere.
+   *
+   * No-op when notifications are disabled (`TERMFLOW_NOTIFICATIONS=off` or
+   * `TERM=dumb`).
+   */
+  case RequestAttention extends Cmd[Nothing]
+
+  /**
+   * Show a desktop notification (iTerm2, kitty, GNOME Terminal / VTE) or
+   * fall back to BEL on terminals without a notification protocol.
+   *
+   * The runtime delegates to `TerminalBackend.notify`, which selects the
+   * right OSC sequence from `Capabilities.notifications`. The `body` is
+   * sanitised to remove control bytes that would terminate the OSC envelope.
+   *
+   * Apps should use this sparingly — most terminals rate-limit notifications
+   * and aggressive use will get the user to silence the app.
+   */
+  case Notify(title: String, body: String) extends Cmd[Nothing]
+
 object Cmd:
 
   /**

--- a/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -256,6 +256,12 @@ object TuiRuntime:
               case Some(msg) => bus.publish(Cmd.GCmd(msg))
               case None      => bus.publish(Cmd.NoCmd)
 
+          case Cmd.RequestAttention =>
+            terminalBackend.requestAttention()
+
+          case Cmd.Notify(title, body) =>
+            terminalBackend.notify(title, body)
+
       while !shouldExit do
         val cmd = bus.take()
         processCommand(cmd)

--- a/modules/termflow-app/src/test/scala/termflow/tui/SimpleANSIRendererSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/SimpleANSIRendererSpec.scala
@@ -1,0 +1,55 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class SimpleANSIRendererSpec extends AnyFunSuite:
+
+  private def buildFrame(): AnsiRenderer.RenderFrame =
+    AnsiRenderer.buildFrame(
+      RootNode(
+        width = 20,
+        height = 5,
+        children = List(TextNode(XCoord(1), YCoord(1), List(Text("hello", Style())))),
+        input = None
+      )
+    )
+
+  test("formatErrorBanner formats every TermFlowError variant"):
+    assert(SimpleANSIRenderer.formatErrorBanner(TermFlowError.Validation("bad")) == "Invalid input: bad")
+    assert(SimpleANSIRenderer.formatErrorBanner(TermFlowError.ConfigError("nope")) == "Config error: nope")
+    assert(SimpleANSIRenderer.formatErrorBanner(TermFlowError.Unexpected("boom", None)) == "Error: boom")
+    assert(SimpleANSIRenderer.formatErrorBanner(TermFlowError.CommandError(":foo")) == "Unrecognised command: :foo")
+    assert(SimpleANSIRenderer.formatErrorBanner(TermFlowError.UnknownApp("counter")) == "Unknown app: counter")
+    assert(SimpleANSIRenderer.formatErrorBanner(TermFlowError.ModelNotFound) == "Model not found")
+
+  test("overlayErrorBanner stamps a red bold banner across the top row"):
+    val frame   = buildFrame()
+    val overlay = SimpleANSIRenderer.overlayErrorBanner(frame, TermFlowError.Validation("oops"))
+
+    val rowText = overlay.cells(0).map(_.ch).mkString
+    assert(rowText.startsWith(" Invalid input: oops"))
+    assert(rowText.length == frame.width)
+
+    val first = overlay.cells(0)(1)
+    assert(first.style.bold)
+    assert(first.style.fg == Color.White)
+    assert(first.style.bg == Color.Red)
+
+  test("overlayErrorBanner truncates messages that overflow the width"):
+    val frame   = buildFrame() // width = 20, banner budget = 18
+    val long    = "x" * 50
+    val overlay = SimpleANSIRenderer.overlayErrorBanner(frame, TermFlowError.Unexpected(long, None))
+    val rowText = overlay.cells(0).map(_.ch).mkString
+    assert(rowText.length == 20)
+    assert(rowText.endsWith("…"))
+
+  test("overlayErrorBanner is a no-op for zero-sized frames"):
+    val empty = AnsiRenderer.RenderFrame(width = 0, height = 0, cells = Array.empty, cursor = None)
+    val out   = SimpleANSIRenderer.overlayErrorBanner(empty, TermFlowError.Validation("x"))
+    assert(out eq empty)
+
+  test("overlayErrorBanner does not mutate the input frame"):
+    val frame  = buildFrame()
+    val before = frame.cells(0).map(_.ch).mkString
+    val _      = SimpleANSIRenderer.overlayErrorBanner(frame, TermFlowError.Validation("x"))
+    assert(frame.cells(0).map(_.ch).mkString == before)

--- a/modules/termflow-sample/src/main/scala/termflow/apps/chat/ChatStreamApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/chat/ChatStreamApp.scala
@@ -34,6 +34,8 @@ import termflow.tui.widgets
  *     streams in.
  *   - `↑` / `↓`             — scroll the transcript by one line
  *   - `PageUp` / `PageDown` — scroll by a page
+ *   - mouse wheel           — scroll when the cursor is over the transcript
+ *                              (3 lines per detent; ignored elsewhere)
  *   - `End`                 — jump to the bottom and re-enable auto-tail
  *   - `Ctrl+L`              — clear the transcript
  *   - `Ctrl+C` / `Esc`      — quit
@@ -158,6 +160,13 @@ object ChatStreamApp:
 
   private def transcriptWidth(m: Model): Int = math.max(20, m.width - 2)
 
+  /** Origin (top-left) of the transcript pane in absolute terminal cells. */
+  private val transcriptOrigin: Coord = Coord(XCoord(2), YCoord(4))
+
+  /** Mouse-wheel viewport for the transcript pane — see `LogView.scrollDelta`. */
+  private def transcriptViewport(m: Model): widgets.LogView.Viewport =
+    widgets.LogView.Viewport(transcriptOrigin, transcriptWidth(m), transcriptCapacity(m))
+
   /** Flatten the entries to display lines. Wrapping is delegated to LogView. */
   def transcriptLines(m: Model): Vector[String] =
     m.entries
@@ -252,6 +261,14 @@ object ChatStreamApp:
           case End                => StepResult.StayInModel(m.copy(scrollOffset = maxScroll(m), autoTail = true))
           case Ctrl('L')          => step(m, Msg.Clear)
           case Ctrl('C') | Escape => StepResult.ExitNow(m)
+          case Mouse(ev)          =>
+            // Mouse-wheel inside the transcript drives scrollback; scrolls
+            // outside (over the prompt or status row) are dropped so the
+            // user's wheel doesn't accidentally page through history while
+            // hovering somewhere unrelated.
+            widgets.LogView.scrollDelta(ev, transcriptViewport(m)) match
+              case Some(d) => StepResult.StayInModel(scrollBy(m, d))
+              case None    => StepResult.StayInModel(m)
           case _ =>
             val (nextPrompt, maybeCmd) = Prompt.handleKey[Msg](m.prompt, k)(toMsgFromPrompt)
             val withPrompt             = m.copy(prompt = nextPrompt)
@@ -290,7 +307,7 @@ object ChatStreamApp:
       2.x,
       2.y,
       List(
-        " ↑/↓ ".text(fg = Theme.dark.primary),
+        " ↑/↓/wheel ".text(fg = Theme.dark.primary),
         "scroll  ".text,
         " End ".text(fg = Theme.dark.primary),
         "tail  ".text,
@@ -301,9 +318,8 @@ object ChatStreamApp:
       )
     )
 
-    val transcriptOrigin = Coord(2.x, 4.y)
-    val tCap             = transcriptCapacity(m)
-    val tWidth           = transcriptWidth(m)
+    val tCap   = transcriptCapacity(m)
+    val tWidth = transcriptWidth(m)
     val transcript = widgets.LogView(
       lines = transcriptLines(m),
       width = tWidth,

--- a/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
+++ b/modules/termflow-sample/src/main/scala/termflow/apps/showcase/Stage1ShowcaseApp.scala
@@ -415,6 +415,10 @@ object Stage1ShowcaseApp:
     // ---- Embedded sub-apps ----
     wizardModel: WizardApp.Model,
     dashboardModel: DashboardApp.Model,
+    /** Number of `Cmd.Notify` test fires from the Help tab. */
+    notifyCount: Int,
+    /** Number of `Cmd.RequestAttention` test fires from the Help tab. */
+    attentionCount: Int,
     input: Sub[Msg],
     resize: Sub[Msg],
     tickSub: Sub[Msg]
@@ -460,6 +464,8 @@ object Stage1ShowcaseApp:
     case LayoutMouse(ev: MouseEvent)
     case EditorKey(k: KeyDecoder.InputKey)
     case TreeMouse(ev: MouseEvent)
+    case TestNotification
+    case TestAttention
     case Quit
     case Key(k: KeyDecoder.InputKey)
     case KeyError(t: Throwable)
@@ -515,6 +521,8 @@ object Stage1ShowcaseApp:
         ),
         wizardModel = WizardApp.initialModel,
         dashboardModel = DashboardApp.initialModel,
+        notifyCount = 0,
+        attentionCount = 0,
         input = Sub.InputKey(k => Key(k), e => KeyError(e), ctx),
         resize = Sub.TerminalResize[Msg](200, (w, h) => Resize(w, h), ctx),
         tickSub = Sub.Every(tickPeriodMs, () => Tick, ctx)
@@ -658,6 +666,13 @@ object Stage1ShowcaseApp:
         case TreeDown =>
           val rows = widgets.Tree.visibleRows(demoTree, m.treeExpanded)
           m.copy(treeSelected = math.min(math.max(0, rows.size - 1), m.treeSelected + 1)).tui
+        case TestNotification =>
+          Tui(
+            m.copy(notifyCount = m.notifyCount + 1),
+            Cmd.Notify("TermFlow showcase", s"Test notification #${m.notifyCount + 1}")
+          )
+        case TestAttention =>
+          Tui(m.copy(attentionCount = m.attentionCount + 1), Cmd.RequestAttention)
         case Quit        => Tui(m, Cmd.Exit)
         case KeyError(_) => m.tui
         case Key(k)      =>
@@ -915,6 +930,9 @@ object Stage1ShowcaseApp:
       k match
         case CharKey('q') | CharKey('Q') => Cmd.GCmd(OpenDialog)
         case Escape                      => Cmd.GCmd(OpenDialog)
+        // Notifications demo — exercises Cmd.Notify and Cmd.RequestAttention.
+        case CharKey('n') => Cmd.GCmd(TestNotification)
+        case CharKey('N') => Cmd.GCmd(TestAttention)
         // Route mouse so clicks on the Tabs bar still switch tabs from
         // here — without this, the Help tab traps the user.
         case Mouse(ev) => tabBarMouseDispatch(ev)
@@ -1912,6 +1930,7 @@ object Stage1ShowcaseApp:
       val sepWidth  = math.max(20, r.width - 4)
       val sepNodes  = widgets.Separator.horizontal(width = sepWidth, at = Coord(2.x, 2.y), title = "Tabs")
       val sepNodes2 = widgets.Separator.horizontal(width = sepWidth, at = Coord(2.x, 28.y), title = "Anywhere")
+      val sepNotify = widgets.Separator.horizontal(width = sepWidth, at = Coord(2.x, 33.y), title = "Notifications")
 
       val rows = List(
         TextNode(2.x, 3.y, List(" 1..9 ".themed(_.primary), "  switch tab".text)),
@@ -1934,9 +1953,37 @@ object Stage1ShowcaseApp:
         TextNode(2.x, 25.y, List(" 6 Wizard / 7 Dashboard / 9 Editor (MultiLineInput)".themed(_.success))),
         TextNode(2.x, 26.y, List("   editor: Enter newline, ↑/↓ between rows, Esc leaves the tab".text)),
         TextNode(2.x, 29.y, List("   q / Esc  open quit confirmation".text)),
-        TextNode(2.x, 30.y, List("   click on Tabs bar  switch tab".text))
+        TextNode(2.x, 30.y, List("   click on Tabs bar  switch tab".text)),
+        TextNode(
+          2.x,
+          34.y,
+          List(
+            " kind ".themed(_.secondary),
+            notificationKindLabel(m.capabilities.notifications).themed(_.success)
+          )
+        ),
+        TextNode(
+          2.x,
+          35.y,
+          List(
+            " n ".themed(_.primary),
+            "  send a desktop notification (Cmd.Notify) — fired ".text,
+            m.notifyCount.toString.themed(_.success),
+            " time(s)".text
+          )
+        ),
+        TextNode(
+          2.x,
+          36.y,
+          List(
+            " N ".themed(_.primary),
+            "  request attention (Cmd.RequestAttention) — fired ".text,
+            m.attentionCount.toString.themed(_.success),
+            " time(s)".text
+          )
+        )
       )
-      List(panel(r, theme, (title :: sepNodes) ++ sepNodes2 ++ rows))
+      List(panel(r, theme, (title :: sepNodes) ++ sepNodes2 ++ sepNotify ++ rows))
 
     /**
      * Body content for the "Wizard" tab — embeds [[WizardApp]]'s view by
@@ -2062,3 +2109,10 @@ object Stage1ShowcaseApp:
       case ColorDepth.Ansi16     => "Ansi16"
       case ColorDepth.Indexed256 => "Indexed256"
       case ColorDepth.Truecolor  => "Truecolor"
+
+    private def notificationKindLabel(k: NotificationKind): String = k match
+      case NotificationKind.Disabled => "Disabled"
+      case NotificationKind.BellOnly => "BellOnly (BEL)"
+      case NotificationKind.ITerm2   => "iTerm2 (OSC 9 / 1337)"
+      case NotificationKind.Kitty    => "kitty (OSC 99)"
+      case NotificationKind.Vte      => "VTE (OSC 777)"

--- a/modules/termflow-sample/src/test/scala/termflow/apps/chat/ChatStreamAppSpec.scala
+++ b/modules/termflow-sample/src/test/scala/termflow/apps/chat/ChatStreamAppSpec.scala
@@ -109,6 +109,27 @@ class ChatStreamAppSpec extends AnyFunSuite:
     assert(tailed.autoTail)
     assert(tailed.scrollOffset == drained.scrollOffset)
 
+  test("mouse-wheel up over the transcript scrolls back and disables auto-tail"):
+    val m       = freshModel
+    val full    = (1 to 20).foldLeft(m)((acc, _) => submit(acc, "long"))
+    val drained = (1 to 1000).foldLeft(full)((acc, _) => tick(acc))
+    assert(drained.autoTail)
+    // Origin is (col=2, row=4); scroll inside the transcript pane.
+    val wheelEvents = termflow.testkit.MouseSim.scrollUp(col = 5, row = 8, ticks = 1)
+    val scrolled    = wheelEvents.foldLeft(drained)((acc, ev) => stepKey(acc, ev))
+    assert(!scrolled.autoTail)
+    assert(scrolled.scrollOffset < drained.scrollOffset)
+
+  test("mouse-wheel scroll outside the transcript pane is a no-op"):
+    val m       = freshModel
+    val full    = (1 to 20).foldLeft(m)((acc, _) => submit(acc, "long"))
+    val drained = (1 to 1000).foldLeft(full)((acc, _) => tick(acc))
+    // Wheel over the prompt row (last line) — should not affect scroll state.
+    val outsideEvents = termflow.testkit.MouseSim.scrollUp(col = 5, row = drained.height, ticks = 3)
+    val unchanged     = outsideEvents.foldLeft(drained)((acc, ev) => stepKey(acc, ev))
+    assert(unchanged.autoTail)
+    assert(unchanged.scrollOffset == drained.scrollOffset)
+
   // ---- Clear / Quit -------------------------------------------------------
 
   test("Ctrl+L clears the transcript back to the welcome entries"):

--- a/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
@@ -232,7 +232,25 @@ enum Layout:
     Layout.resolve(this, at)
 
   /**
-   * Resolve this layout at `(1, 1)` and wrap the result in a [[RootNode]].
+   * Eagerly resolve this layout at `at` and wrap the resulting positioned
+   * vnodes in a [[RootNode.children]] list.
+   *
+   * '''Caveat — no size budget.''' This form calls [[Layout.resolve]],
+   * which uses each layout's natural size and ignores the `width` /
+   * `height` arguments for sizing. As a result:
+   *
+   *   - [[Layout.Fill]] regions collapse to their natural (zero) size.
+   *   - The frame does not reflow when the terminal resizes — children
+   *     are baked at the resolution time.
+   *
+   * Use this form for fixed-size sub-regions, dialogs, panels you have
+   * already sized by hand, and golden-snapshot tests where you want
+   * deterministic positions.
+   *
+   * For full-screen / resizable apps that want `Fill` and reflow,
+   * use [[toBudgetedRootNode]] instead — it puts the layout into
+   * [[RootNode.layout]] so the renderer resolves it against the actual
+   * frame size at render time.
    *
    * @param width Terminal width to advertise on the root.
    * @param height Terminal height to advertise on the root.
@@ -246,6 +264,32 @@ enum Layout:
     at: Coord = Coord(XCoord(1), YCoord(1))
   ): RootNode =
     RootNode(width, height, resolve(at), input)
+
+  /**
+   * Wrap this layout in a [[RootNode]] with `layout = Some(this)`, so the
+   * renderer resolves it at render time against the frame's full
+   * `(width, height)` budget.
+   *
+   * Prefer this form for full-screen apps and any layout containing
+   * [[Layout.Fill]] / [[Layout.Grid]] / [[Layout.Border]]: the resolved
+   * positions update with the terminal size, and `Fill` regions actually
+   * fill the available space instead of collapsing.
+   *
+   * Equivalent to:
+   * {{{
+   * RootNode(width, height, Nil, input, layout = Some(this))
+   * }}}
+   *
+   * @param width Frame width — the resolver's available width budget.
+   * @param height Frame height — the resolver's available height budget.
+   * @param input Optional focused input to attach to the root.
+   */
+  def toBudgetedRootNode(
+    width: Int,
+    height: Int,
+    input: Option[InputNode] = None
+  ): RootNode =
+    RootNode(width, height, Nil, input, layout = Some(this))
 
 /**
  * A cell in a [[Layout.Grid]]: content plus optional row / column span.

--- a/modules/termflow-screen/src/test/scala/termflow/tui/LayoutSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/LayoutSpec.scala
@@ -200,6 +200,44 @@ class LayoutSpec extends AnyFunSuite:
     assert(root.children.size == 2)
     assert(root.input.isEmpty)
 
+  test("toBudgetedRootNode defers resolution to render time via RootNode.layout"):
+    val layout = Layout.Fill(tn("center").asLayout)
+    val root   = layout.toBudgetedRootNode(width = 40, height = 3)
+    assert(root.width == 40 && root.height == 3)
+    assert(root.children.isEmpty, "deferred form leaves children empty")
+    assert(root.layout.contains(layout), "layout is wired through to RootNode.layout")
+    assert(root.input.isEmpty)
+
+  test("toRootNode is unbudgeted: Fill collapses to natural size"):
+    // A Fill wrapping a 1-cell text resolves with availableWidth = -1
+    // through Layout.resolve, so the Fill effectively contributes its
+    // natural (= inner) size — the children rect spans only that natural
+    // size, not the frame width.
+    val layout = Layout.row(gap = 0)(tn("A"), tn("B"))
+    val eager  = layout.toRootNode(width = 80, height = 1)
+    val frame  = AnsiRenderer.buildFrame(eager)
+    // Cells past the natural size are blank, even though the frame is 80 wide.
+    assert(frame.cells(0)(0).ch == 'A')
+    assert(frame.cells(0)(1).ch == 'B')
+    assert(frame.cells(0)(10).ch == ' ')
+
+  test("toBudgetedRootNode is budgeted: Fill expands to the frame width"):
+    // Row(Elem("A"), Fill(Elem("B"))) — 'B' should be pushed to the rightmost
+    // column the Fill region reaches when resolved with the full width budget.
+    val layout = Layout.Row(
+      gap = 0,
+      children = List(tn("A").asLayout, Layout.Fill(tn("B").asLayout))
+    )
+    val budgeted = layout.toBudgetedRootNode(width = 10, height = 1)
+    val frame    = AnsiRenderer.buildFrame(budgeted)
+    assert(frame.cells(0)(0).ch == 'A')
+    // The Fill region occupies cols 2..10 with 'B' at the start of that
+    // region (col 2). The key invariant is that the layout actually got the
+    // size budget — which is observable by the Fill having a non-zero width.
+    assert(frame.cells(0)(1).ch == 'B')
+    // And nothing got positioned past the frame.
+    assert(frame.cells(0).map(_.ch).mkString.length == 10)
+
   // --- end-to-end integration -------------------------------------------
 
   test("a resolved layout renders as expected through AnsiRenderer.buildFrame"):

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/Capabilities.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/Capabilities.scala
@@ -18,6 +18,29 @@ enum ColorDepth:
   def supports(other: ColorDepth): Boolean = this.ordinal >= other.ordinal
 
 /**
+ * How an attention / notification request from the app reaches the user.
+ *
+ * `BellOnly` is the universal fallback — emits `` (BEL), which most
+ * terminals translate into a tab-bar activity flag and tmux/screen translate
+ * into a window-bell indicator.
+ *
+ * The richer kinds also emit a desktop notification when supported:
+ *   - `ITerm2` uses iTerm2's `OSC 9` banner + `OSC 1337 RequestAttention`.
+ *   - `Kitty` uses kitty's `OSC 99` desktop notification protocol.
+ *   - `Vte` uses the `OSC 777 ; notify` sequence (GNOME Terminal,
+ *     xfce4-terminal, Tilix, …).
+ *
+ * `Disabled` suppresses notifications entirely — used when the user sets
+ * `TERMFLOW_NOTIFICATIONS=off` or when running on a `dumb` terminal.
+ */
+enum NotificationKind:
+  case Disabled
+  case BellOnly
+  case ITerm2
+  case Kitty
+  case Vte
+
+/**
  * Best-effort terminal capabilities, populated either from environment
  * variables (see [[Capabilities.detect]]) or supplied explicitly by tests.
  *
@@ -41,13 +64,16 @@ enum ColorDepth:
  *                       parser will see the pasted bytes as a stream of
  *                       individual keypresses, just as if the user had typed
  *                       them.
+ * @param notifications  How `Cmd.RequestAttention` and `Cmd.Notify` reach the
+ *                       user. See [[NotificationKind]].
  */
 final case class Capabilities(
   colorDepth: ColorDepth,
   unicode: Boolean,
   mouse: Boolean,
   extendedStyles: Boolean = true,
-  bracketedPaste: Boolean = true
+  bracketedPaste: Boolean = true,
+  notifications: NotificationKind = NotificationKind.BellOnly
 )
 
 object Capabilities:
@@ -62,7 +88,8 @@ object Capabilities:
     unicode = true,
     mouse = false,
     extendedStyles = true,
-    bracketedPaste = true
+    bracketedPaste = true,
+    notifications = NotificationKind.BellOnly
   )
 
   /**
@@ -116,7 +143,30 @@ object Capabilities:
     // because the start/end markers would otherwise echo as literal text.
     val bracketedPaste = isXtermFamily(term)
 
-    Capabilities(colorDepth, unicode, mouse, extendedStyles, bracketedPaste)
+    val notifications = detectNotificationKind(env, term)
+
+    Capabilities(colorDepth, unicode, mouse, extendedStyles, bracketedPaste, notifications)
+
+  /**
+   * Resolve which notification protocol (if any) to use for the current
+   * terminal. Honours an explicit `TERMFLOW_NOTIFICATIONS` override
+   * (`off` / `bell` / `auto`); otherwise sniffs `TERM_PROGRAM`,
+   * `KITTY_WINDOW_ID`, and `VTE_VERSION` to pick the richest available kind.
+   *
+   * `dumb` and unknown TERMs disable notifications entirely so primitive
+   * backends don't echo escape sequences as literal text.
+   */
+  private def detectNotificationKind(env: Map[String, String], term: String): NotificationKind =
+    val override_ = env.getOrElse("TERMFLOW_NOTIFICATIONS", "").toLowerCase
+    if override_ == "off" then NotificationKind.Disabled
+    else if override_ == "bell" then NotificationKind.BellOnly
+    else if term.isEmpty || term == "dumb" then NotificationKind.Disabled
+    else
+      val termProgram = env.getOrElse("TERM_PROGRAM", "").toLowerCase
+      if termProgram == "iterm.app" then NotificationKind.ITerm2
+      else if env.contains("KITTY_WINDOW_ID") || term == "xterm-kitty" then NotificationKind.Kitty
+      else if env.contains("VTE_VERSION") then NotificationKind.Vte
+      else NotificationKind.BellOnly
 
   private def isXtermFamily(term: String): Boolean =
     term.startsWith("xterm")

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/NotificationEscapes.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/NotificationEscapes.scala
@@ -1,0 +1,58 @@
+package termflow.tui
+
+/**
+ * Escape sequences for terminal-attention requests and desktop notifications.
+ *
+ * Returns `None` for [[NotificationKind.Disabled]] so callers can write
+ * conditionally without branching themselves.
+ *
+ * Two output forms:
+ *
+ *   - [[attentionFor]] — minimum signal for "this session needs attention".
+ *     Emits BEL on every kind except `Disabled`; iTerm2 additionally emits
+ *     `OSC 1337 RequestAttention=yes` so the dock icon bounces.
+ *   - [[notifyFor]] — desktop notification with title / body for the kinds
+ *     that support it; falls back to BEL on [[NotificationKind.BellOnly]].
+ */
+private[tui] object NotificationEscapes:
+
+  private val BEL: String = ""
+  private val ESC: String = ""
+  private val ST: String  = ESC + "\\"
+
+  def attentionFor(kind: NotificationKind): Option[String] = kind match
+    case NotificationKind.Disabled => None
+    case NotificationKind.BellOnly => Some(BEL)
+    case NotificationKind.ITerm2   => Some(s"${ESC}]1337;RequestAttention=yes${BEL}${BEL}")
+    case NotificationKind.Kitty    => Some(BEL)
+    case NotificationKind.Vte      => Some(BEL)
+
+  def notifyFor(kind: NotificationKind, title: String, body: String): Option[String] =
+    val t = sanitize(title)
+    val b = sanitize(body)
+    kind match
+      case NotificationKind.Disabled => None
+      case NotificationKind.BellOnly => Some(BEL)
+      case NotificationKind.ITerm2   =>
+        // OSC 9 takes a single message; combine title+body when both are set.
+        val msg = if t.isEmpty then b else if b.isEmpty then t else s"$t: $b"
+        Some(s"${ESC}]9;$msg${BEL}")
+      case NotificationKind.Kitty =>
+        // OSC 99 ; metadata ; payload ST. Empty metadata uses defaults.
+        // Format the title in the metadata so the notification has a heading.
+        val payload = if b.isEmpty then t else b
+        val meta    = if t.isEmpty then "" else s"i=1:d=0:p=title;$t"
+        Some(s"${ESC}]99;$meta;$payload$ST")
+      case NotificationKind.Vte =>
+        // OSC 777 ; notify ; <title> ; <body> BEL
+        Some(s"${ESC}]777;notify;$t;$b${BEL}")
+
+  /**
+   * Strip bytes that would terminate or confuse the OSC envelope: BEL, ESC,
+   * and any other C0 control. Semicolons and pipes inside content are kept
+   * — terminals tolerate them inside the trailing payload field.
+   */
+  private def sanitize(s: String): String =
+    val out = new StringBuilder(s.length)
+    s.foreach(c => if c >= 0x20 && c != 0x7f then out.append(c))
+    out.toString

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/TerminalBackend.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/TerminalBackend.scala
@@ -30,6 +30,39 @@ trait TerminalBackend extends TerminalInfo:
   def capabilities: Capabilities = Capabilities.default
 
   /**
+   * Ring the terminal bell or pop the iTerm2 "request attention" indicator.
+   *
+   * Most terminals translate the BEL byte (`U+0007`) into a tab-bar activity
+   * flag; tmux / screen translate it into a window-bell indicator (subject to
+   * `monitor-bell`). iTerm2 also accepts an explicit `OSC 1337` request that
+   * bounces the dock icon.
+   *
+   * No-ops when [[Capabilities.notifications]] is `Disabled`.
+   *
+   * The default trait implementation routes through
+   * [[NotificationEscapes.attentionFor]]; tests can override.
+   */
+  def requestAttention(): Unit =
+    NotificationEscapes.attentionFor(capabilities.notifications).foreach { seq =>
+      writer.write(seq)
+      writer.flush()
+    }
+
+  /**
+   * Show a desktop notification (iTerm2 / kitty / VTE) or fall back to BEL.
+   *
+   * The body is interpreted as plain text. Carets, semicolons, and ESC bytes
+   * inside `title` / `body` are stripped to avoid breaking the OSC sequence.
+   *
+   * No-ops when [[Capabilities.notifications]] is `Disabled`.
+   */
+  def notify(title: String, body: String): Unit =
+    NotificationEscapes.notifyFor(capabilities.notifications, title, body).foreach { seq =>
+      writer.write(seq)
+      writer.flush()
+    }
+
+  /**
    * Register a listener to be invoked when the terminal is resized.
    *
    * Returns `Some(unregister)` if the backend supports event-based resize

--- a/modules/termflow-terminal/src/test/scala/termflow/tui/CapabilitiesSpec.scala
+++ b/modules/termflow-terminal/src/test/scala/termflow/tui/CapabilitiesSpec.scala
@@ -124,3 +124,49 @@ class CapabilitiesSpec extends AnyFunSuite:
     assert(!Capabilities.detect(Map("TERM" -> "vt100")).bracketedPaste)
     assert(!Capabilities.detect(Map.empty).bracketedPaste)
   }
+
+  test("notifications: TERM_PROGRAM=iTerm.app → ITerm2") {
+    val caps = Capabilities.detect(Map("TERM" -> "xterm-256color", "TERM_PROGRAM" -> "iTerm.app"))
+    assert(caps.notifications == NotificationKind.ITerm2)
+  }
+
+  test("notifications: KITTY_WINDOW_ID set → Kitty") {
+    val caps = Capabilities.detect(Map("TERM" -> "xterm-kitty", "KITTY_WINDOW_ID" -> "1"))
+    assert(caps.notifications == NotificationKind.Kitty)
+  }
+
+  test("notifications: VTE_VERSION set → Vte") {
+    val caps = Capabilities.detect(Map("TERM" -> "xterm-256color", "VTE_VERSION" -> "6800"))
+    assert(caps.notifications == NotificationKind.Vte)
+  }
+
+  test("notifications: plain xterm falls back to BellOnly") {
+    assert(Capabilities.detect(Map("TERM" -> "xterm-256color")).notifications == NotificationKind.BellOnly)
+  }
+
+  test("notifications: dumb TERM disables notifications") {
+    assert(Capabilities.detect(Map("TERM" -> "dumb")).notifications == NotificationKind.Disabled)
+    assert(Capabilities.detect(Map.empty).notifications == NotificationKind.Disabled)
+  }
+
+  test("notifications: TERMFLOW_NOTIFICATIONS=off forces Disabled even on iTerm2") {
+    val caps = Capabilities.detect(
+      Map(
+        "TERM"                   -> "xterm-256color",
+        "TERM_PROGRAM"           -> "iTerm.app",
+        "TERMFLOW_NOTIFICATIONS" -> "off"
+      )
+    )
+    assert(caps.notifications == NotificationKind.Disabled)
+  }
+
+  test("notifications: TERMFLOW_NOTIFICATIONS=bell forces BellOnly even on kitty") {
+    val caps = Capabilities.detect(
+      Map(
+        "TERM"                   -> "xterm-kitty",
+        "KITTY_WINDOW_ID"        -> "1",
+        "TERMFLOW_NOTIFICATIONS" -> "bell"
+      )
+    )
+    assert(caps.notifications == NotificationKind.BellOnly)
+  }

--- a/modules/termflow-terminal/src/test/scala/termflow/tui/NotificationEscapesSpec.scala
+++ b/modules/termflow-terminal/src/test/scala/termflow/tui/NotificationEscapesSpec.scala
@@ -1,0 +1,58 @@
+package termflow.tui
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class NotificationEscapesSpec extends AnyFunSuite:
+
+  private val BEL = "\u0007"
+  private val ESC = "\u001b"
+  private val ST  = ESC + "\\"
+
+  test("attentionFor Disabled returns None") {
+    assert(NotificationEscapes.attentionFor(NotificationKind.Disabled).isEmpty)
+  }
+
+  test("attentionFor BellOnly emits BEL") {
+    assert(NotificationEscapes.attentionFor(NotificationKind.BellOnly).contains(BEL))
+  }
+
+  test("attentionFor ITerm2 emits OSC 1337 RequestAttention plus BEL") {
+    val seq = NotificationEscapes.attentionFor(NotificationKind.ITerm2).get
+    assert(seq.contains("1337;RequestAttention=yes"))
+    assert(seq.endsWith(BEL))
+  }
+
+  test("notifyFor Disabled returns None") {
+    assert(NotificationEscapes.notifyFor(NotificationKind.Disabled, "t", "b").isEmpty)
+  }
+
+  test("notifyFor BellOnly returns BEL regardless of title/body") {
+    assert(NotificationEscapes.notifyFor(NotificationKind.BellOnly, "t", "b").contains(BEL))
+  }
+
+  test("notifyFor ITerm2 wraps in OSC 9 with 'title: body'") {
+    val seq = NotificationEscapes.notifyFor(NotificationKind.ITerm2, "Build", "done").get
+    assert(seq == s"${ESC}]9;Build: done${BEL}")
+  }
+
+  test("notifyFor ITerm2 omits the colon when title is empty") {
+    val seq = NotificationEscapes.notifyFor(NotificationKind.ITerm2, "", "ping").get
+    assert(seq == s"${ESC}]9;ping${BEL}")
+  }
+
+  test("notifyFor Kitty uses OSC 99 with title metadata and ST terminator") {
+    val seq = NotificationEscapes.notifyFor(NotificationKind.Kitty, "Build", "done").get
+    assert(seq.startsWith(s"${ESC}]99;"))
+    assert(seq.contains("p=title;Build"))
+    assert(seq.endsWith(ST))
+  }
+
+  test("notifyFor Vte uses OSC 777;notify;title;body BEL") {
+    val seq = NotificationEscapes.notifyFor(NotificationKind.Vte, "Build", "done").get
+    assert(seq == s"${ESC}]777;notify;Build;done${BEL}")
+  }
+
+  test("sanitize strips embedded ESC and BEL so the envelope stays valid") {
+    val seq = NotificationEscapes.notifyFor(NotificationKind.Vte, s"a${ESC}b", s"c${BEL}d").get
+    assert(seq == s"${ESC}]777;notify;ab;cd${BEL}")
+  }

--- a/modules/termflow-testkit/src/main/scala/termflow/testkit/TuiTestDriver.scala
+++ b/modules/termflow-testkit/src/main/scala/termflow/testkit/TuiTestDriver.scala
@@ -36,12 +36,14 @@ final class TuiTestDriver[Model, Msg](
   val ctx: TestRuntimeCtx[Msg]
 ):
 
-  private var _model: Model                              = uninitialized
-  private var _initialized: Boolean                      = false
-  private var _exited: Boolean                           = false
-  private val pending: mutable.Queue[Cmd[Msg]]           = mutable.Queue.empty
-  private val observed: mutable.ArrayBuffer[Cmd[Msg]]    = mutable.ArrayBuffer.empty
-  private val errors: mutable.ArrayBuffer[TermFlowError] = mutable.ArrayBuffer.empty
+  private var _model: Model                                        = uninitialized
+  private var _initialized: Boolean                                = false
+  private var _exited: Boolean                                     = false
+  private val pending: mutable.Queue[Cmd[Msg]]                     = mutable.Queue.empty
+  private val observed: mutable.ArrayBuffer[Cmd[Msg]]              = mutable.ArrayBuffer.empty
+  private val errors: mutable.ArrayBuffer[TermFlowError]           = mutable.ArrayBuffer.empty
+  private val attentionRequests: mutable.ArrayBuffer[Unit]         = mutable.ArrayBuffer.empty
+  private val notifications: mutable.ArrayBuffer[(String, String)] = mutable.ArrayBuffer.empty
 
   /** Current model. Throws if `init` hasn't been called yet. */
   def model: Model =
@@ -56,6 +58,16 @@ final class TuiTestDriver[Model, Msg](
 
   /** Every `TermFlowError` surfaced via `Cmd.TermFlowErrorCmd` since construction. */
   def observedErrors: List[TermFlowError] = errors.toList
+
+  /** Number of `Cmd.RequestAttention` commands the driver has processed. */
+  def attentionCount: Int = attentionRequests.size
+
+  /**
+   * Title / body pairs from every `Cmd.Notify` the driver has processed,
+   * in order. Useful for asserting that a flow surfaces the right
+   * notification at the right moment.
+   */
+  def observedNotifications: List[(String, String)] = notifications.toList
 
   /** Render the current model to a frame. Throws if `init` hasn't been called. */
   def frame: RenderFrame =
@@ -114,6 +126,10 @@ final class TuiTestDriver[Model, Msg](
       case Cmd.GCmd(msg) => dispatch(msg)
       case Cmd.TermFlowErrorCmd(e) =>
         errors += e
+      case Cmd.RequestAttention =>
+        attentionRequests += (())
+      case Cmd.Notify(title, body) =>
+        notifications += ((title, body))
       case fc: Cmd.FCmd[a, ?] =>
         // Mirror runtime: onEnqueue fires immediately (synchronously), then
         // resolve the future eagerly. Tests must supply Future.successful.

--- a/modules/termflow-testkit/src/test/scala/termflow/testkit/TuiTestDriverSpec.scala
+++ b/modules/termflow-testkit/src/test/scala/termflow/testkit/TuiTestDriverSpec.scala
@@ -22,6 +22,8 @@ class TuiTestDriverSpec extends AnyFunSuite:
       case Async(value: Int)
       case AsyncUnresolved
       case ReportError(text: String)
+      case Bell
+      case Notify(title: String, body: String)
       case Quit
       case Noop
 
@@ -61,8 +63,10 @@ class TuiTestDriverSpec extends AnyFunSuite:
           )
         case Msg.ReportError(text) =>
           Tui(model, Cmd.TermFlowErrorCmd(TermFlowError.Validation(text)))
-        case Msg.Quit => Tui(model, Cmd.Exit)
-        case Msg.Noop => Tui(model, Cmd.NoCmd)
+        case Msg.Bell                => Tui(model, Cmd.RequestAttention)
+        case Msg.Notify(title, body) => Tui(model, Cmd.Notify(title, body))
+        case Msg.Quit                => Tui(model, Cmd.Exit)
+        case Msg.Noop                => Tui(model, Cmd.NoCmd)
 
     override def view(model: Int): RootNode =
       RootNode(
@@ -149,6 +153,19 @@ class TuiTestDriverSpec extends AnyFunSuite:
     val d = driver()
     d.send(TinyApp.Msg.Noop)
     assert(d.model == 0)
+
+  test("Cmd.RequestAttention is recorded by attentionCount"):
+    val d = driver()
+    d.send(TinyApp.Msg.Bell)
+    d.send(TinyApp.Msg.Bell)
+    assert(d.attentionCount == 2)
+    assert(!d.exited)
+
+  test("Cmd.Notify is recorded as (title, body) in order"):
+    val d = driver()
+    d.send(TinyApp.Msg.Notify("Build", "done"))
+    d.send(TinyApp.Msg.Notify("Tests", "green"))
+    assert(d.observedNotifications == List(("Build", "done"), ("Tests", "green")))
 
   test("cmds records every applied Cmd in order"):
     val d = driver()

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/LogView.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/LogView.scala
@@ -128,3 +128,60 @@ object LogView:
    */
   def maxScroll(lines: Seq[String], width: Int, height: Int, wrap: Boolean): Int =
     math.max(0, displayLineCount(lines, width, wrap) - math.max(1, height))
+
+  /**
+   * Map a `MouseEvent.Scroll` to a `LogView` scroll delta (negative for
+   * up / older lines, positive for down / newer lines), provided the
+   * scroll happened inside the viewport rectangle. Horizontal scroll
+   * (`Left` / `Right`) is ignored.
+   *
+   * Apps wire this into their `update`:
+   *
+   * {{{
+   * case Msg.Key(InputKey.Mouse(ev)) =>
+   *   val viewportRect = LogView.Viewport(at, width, height)
+   *   LogView.scrollDelta(ev, viewportRect) match
+   *     case Some(d) => Tui(scrollBy(model, d))
+   *     case None    => model.tui
+   * }}}
+   *
+   * @param event           The decoded mouse event.
+   * @param viewport        Viewport rectangle the scroll must land in.
+   * @param ticksPerDetent  Lines moved per wheel detent. Defaults to
+   *                        `3`, which roughly matches the OS-level
+   *                        scroll-acceleration users expect from a real
+   *                        terminal log pane. Pass `1` for one-line-per-
+   *                        detent semantics.
+   * @return `Some(delta)` if the event is a vertical scroll inside the
+   *         viewport, `None` otherwise.
+   */
+  def scrollDelta(
+    event: MouseEvent,
+    viewport: Viewport,
+    ticksPerDetent: Int = 3
+  ): Option[Int] =
+    event match
+      case MouseEvent.Scroll(direction, col, row, _) if viewport.contains(col, row) =>
+        val step = math.max(1, ticksPerDetent)
+        direction match
+          case ScrollDirection.Up    => Some(-step)
+          case ScrollDirection.Down  => Some(+step)
+          case ScrollDirection.Left  => None
+          case ScrollDirection.Right => None
+      case _ => None
+
+  /**
+   * Rectangle in absolute terminal cells the viewport occupies. Used by
+   * [[scrollDelta]] to decide whether a mouse-wheel event should drive
+   * the LogView; sized identically to the `width` / `height` / `at`
+   * arguments passed to `LogView.apply`.
+   */
+  final case class Viewport(at: Coord, width: Int, height: Int):
+    private val left: Int   = at.x.value
+    private val top: Int    = at.y.value
+    private val right: Int  = left + math.max(0, width) - 1
+    private val bottom: Int = top + math.max(0, height) - 1
+
+    /** True if the absolute `(col, row)` lies within the viewport. */
+    def contains(col: Int, row: Int): Boolean =
+      col >= left && col <= right && row >= top && row <= bottom

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/LogViewSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/LogViewSpec.scala
@@ -124,3 +124,49 @@ class LogViewSpec extends AnyFunSuite:
         assert(runs.head.style == custom)
       case _ => fail()
   }
+
+  // ---- Viewport / scrollDelta --------------------------------------------
+
+  private val Viewport = LogView.Viewport(at = Coord(XCoord(2), YCoord(4)), width = 10, height = 5)
+  private val NoMods   = KeyDecoder.Modifiers.none
+
+  test("Viewport.contains is true on every cell of the rectangle") {
+    assert(Viewport.contains(2, 4))   // top-left
+    assert(Viewport.contains(11, 8))  // bottom-right (inclusive)
+    assert(!Viewport.contains(1, 4))  // one column to the left
+    assert(!Viewport.contains(12, 4)) // one column past the right
+    assert(!Viewport.contains(2, 3))  // one row above
+    assert(!Viewport.contains(2, 9))  // one row below
+  }
+
+  test("scrollDelta returns -ticksPerDetent for an Up scroll inside the viewport") {
+    val ev = MouseEvent.Scroll(ScrollDirection.Up, col = 5, row = 6, mods = NoMods)
+    assert(LogView.scrollDelta(ev, Viewport) == Some(-3))
+  }
+
+  test("scrollDelta returns +ticksPerDetent for a Down scroll inside the viewport") {
+    val ev = MouseEvent.Scroll(ScrollDirection.Down, col = 5, row = 6, mods = NoMods)
+    assert(LogView.scrollDelta(ev, Viewport) == Some(3))
+  }
+
+  test("scrollDelta honours a custom ticksPerDetent") {
+    val ev = MouseEvent.Scroll(ScrollDirection.Down, col = 5, row = 6, mods = NoMods)
+    assert(LogView.scrollDelta(ev, Viewport, ticksPerDetent = 1) == Some(1))
+  }
+
+  test("scrollDelta drops scrolls that land outside the viewport") {
+    val outside = MouseEvent.Scroll(ScrollDirection.Up, col = 1, row = 4, mods = NoMods)
+    assert(LogView.scrollDelta(outside, Viewport).isEmpty)
+  }
+
+  test("scrollDelta ignores horizontal scroll directions") {
+    val left  = MouseEvent.Scroll(ScrollDirection.Left, col = 5, row = 6, mods = NoMods)
+    val right = MouseEvent.Scroll(ScrollDirection.Right, col = 5, row = 6, mods = NoMods)
+    assert(LogView.scrollDelta(left, Viewport).isEmpty)
+    assert(LogView.scrollDelta(right, Viewport).isEmpty)
+  }
+
+  test("scrollDelta ignores non-Scroll mouse events") {
+    val click = MouseEvent.Press(MouseButton.Left, col = 5, row = 6, mods = NoMods)
+    assert(LogView.scrollDelta(click, Viewport).isEmpty)
+  }


### PR DESCRIPTION
## Summary

Five commits closing four pre-1.0 roadmap items and bundling the in-flight doc updates from this session.

- **`a50b8f7` feat: terminal-attention notifications.** New `Cmd.RequestAttention` and `Cmd.Notify(title, body)`, env-var detection (iTerm2 OSC 9 / 1337, kitty OSC 99, VTE OSC 777, BEL fallback), `TERMFLOW_NOTIFICATIONS=off|bell|auto` override. Wired through the showcase Help tab. Includes the earlier roadmap refresh, RUN_EXAMPLES additions for `tree`/`editor`/`chat`, and the slim README.
- **`9374071` feat(app): surface `TermFlowErrorCmd` (Stage 4 §4.1).** `SimpleANSIRenderer` now overlays a red, bold banner across the top row of the next frame and clears it on the following render. Long messages truncate with an ellipsis. App-layer guide gains a "How errors reach the user" section.
- **`cf1eba7` feat(screen): `Layout.toBudgetedRootNode` (Stage 4 §4.4).** Deferred sibling to the eager `toRootNode` — puts the layout into `RootNode.layout` so the renderer applies the frame budget and `Fill`/reflow Just Work. New `full-screen-layout.md` cookbook recipe walks the trade-off.
- **`4fe4acf` feat(widgets): mouse-wheel scrollback (Stage 4 §4.6).** `LogView.scrollDelta(event, viewport, ticksPerDetent)` plus `LogView.Viewport(at, width, height)` give apps a one-call hook for wheel scroll deltas only when the wheel lands inside the viewport rect. Wired into `chatDemo`; covered with `MouseSim`. Streaming-output recipe documents the pattern.
- **`5395be7` docs(roadmap): mark §4.1 / §4.4 / §4.6 as landed.**

The remaining 1.0 critical-path items: §3.3 (killer demo + README screenshot), §3.5 (migration guide), and §4.2 / §4.3 / §4.5 / §4.7 / §4.8 (release-doc sweep, API audit, rolling-console recipe, coverage quick wins, zero-warning build). MiMa (§3.1) is post-1.0.

## Test plan

- [x] `sbt ciCheck` — 1006+ tests green across all modules.
- [x] `sbt scalafmtAll` clean.
- [ ] Manual smoke: `sbt chatDemo` and verify mouse-wheel scrollback over the transcript pane (3 lines per detent), `End` re-tails, wheel-over-prompt is a no-op.
- [ ] Manual smoke: trigger a `Cmd.TermFlowErrorCmd` (e.g. submit `:bogus` in any sample) and verify the red banner appears for one frame.
- [ ] Manual smoke: notification keys (`n` / `N`) on the showcase Help tab — confirm the right detection kind is shown for the local terminal.