### PR TITLE
docs: §4.3 API & docs example audit

### DIFF
--- a/docs/contrib/ROADMAP.md
+++ b/docs/contrib/ROADMAP.md
@@ -218,20 +218,21 @@ Acceptance:
   `v1.0.0`.
 - Any stale `0.2.0` / `0.3.0` examples are intentional and explained.
 
-### 4.3 Public API and docs example audit
+### 4.3 Public API and docs example audit — ☑ landed
 
-Do a final pass over the public-facing APIs and every tutorial/guide
-snippet. The goal is not to freeze internals forever; it is to remove
-surprise from the surface users will copy into their apps.
-
-Acceptance:
-
-- Public names, signatures, and examples line up (`Cmd.asyncResult`,
-  widget constructors, `Sub.TerminalResize`, layout helpers, etc.).
-- Any deliberately sharp/advanced APIs are marked as SPI or documented
-  with constraints.
-- Migration notes list every known user-visible API adjustment, or
-  explicitly say no migration is required.
+Walked the public-facing APIs and every tutorial / guide / cookbook
+snippet against the source. Eight signature drifts and dead-code blocks
+in the docs were corrected (`Cmd.asyncResult`, `Sub.TerminalResize`,
+`Cmd.FCmd` type params, `MultiLineInput.handleKey` curried form,
+`Capabilities.notifications`, missing `RootNode.input` arg, mistyped
+`Cmd.FCmd` in the file-picker recipe, orphaned `Layout.column` block
+in the full-screen-layout recipe). `Cmd.RequestAttention` and
+`Cmd.Notify` are now reflected in the app-layer Cmd table.
+`docs/reference/migration.md` is populated with the explicit
+no-migration-required statement plus a catalogue of additive changes
+since 0.2.0. `mdbook build` (with linkcheck) is green. SPI markers on
+`TuiRenderer` / `CmdConsumer` / `CmdBus` / `EventSink` / `EventSource`
+were already in place; any further Scaladoc polish belongs in §4.8.
 
 ### 4.4 Layout ergonomics audit — ☑ landed
 
@@ -423,6 +424,11 @@ Two TermFlow-only wins worth preserving through 1.0:
 
 ## 8. Recent decisions (rolling, last ~3 months)
 
+- *2026-04-30* — Stage 4 §4.3 closed: public-API and docs-example audit
+  swept eight signature drifts out of the tutorials, guides, and cookbook;
+  `docs/reference/migration.md` populated with the explicit "no migration
+  required for 0.2.x → 1.0" statement plus a catalogue of additive
+  changes. `mdbook build` (with linkcheck) clean.
 - *2026-04-30* — Killer demo (§3.3) will live in `llm4s`, not in this
   repo. Reason: llm4s already depends on termflow for samples, so
   hosting an llm4s-backed demo here would create a sibling cycle even

--- a/docs/cookbook/file-picker.md
+++ b/docs/cookbook/file-picker.md
@@ -118,8 +118,8 @@ def view(m: Model): RootNode =
   never shows them. Adding a `showHidden: Boolean` to `PickerState`
   is straightforward.
 - **Read the file inside `FileChosen`** if it's small. For larger
-  loads, return `Cmd.FCmd(Future { … }, Msg.LoadDone.apply)` and
-  treat it as async work — the
+  loads, hand it to `Cmd.asyncResult(future, Msg.LoadDone.apply,
+  Msg.LoadFailed.apply)` and treat it as async work — the
   [Async tutorial](../tut/03-async.md) covers the pattern.
 - **Symlink loops** are not detected by `listDir` above — guard with
   `Files.readAttributes(..., LinkOption.NOFOLLOW_LINKS)` if you walk

--- a/docs/cookbook/full-screen-layout.md
+++ b/docs/cookbook/full-screen-layout.md
@@ -57,11 +57,8 @@ object App extends TuiApp[Model, Msg]:
     val body   = TextNode(1.x, 1.y, List(m.log.lastOption.getOrElse("(idle)").text))
     val footer = TextNode(1.x, 1.y, List(s" ${m.width}×${m.height}  q: quit ".text))
 
-    Layout.column(gap = 0)(
-      header,
-      // Fill takes the rest of the column once header / footer are sized.
-      // Outside toBudgetedRootNode this would collapse to zero rows.
-    )
+    // Fill takes the rest of the column once header / footer are sized.
+    // Without toBudgetedRootNode the Fill region would collapse to zero rows.
     val layout = Layout.Column(
       gap = 0,
       children = List(

--- a/docs/guide/app-layer.md
+++ b/docs/guide/app-layer.md
@@ -53,6 +53,8 @@ enum Cmd[+Msg]:
   case GCmd(msg: Msg)                                              extends Cmd[Msg]
   case FCmd[A, M](task: Future[A], toCmd: A => Cmd[M], onEnqueue: Option[M] = None) extends Cmd[M]
   case TermFlowErrorCmd(msg: TermFlowError)                        extends Cmd[Msg]
+  case RequestAttention                                            extends Cmd[Nothing]
+  case Notify(title: String, body: String)                         extends Cmd[Nothing]
 ```
 
 | Cmd | When |
@@ -62,20 +64,29 @@ enum Cmd[+Msg]:
 | `GCmd(msg)` | Dispatch a follow-up `Msg` through `update`. Used to chain transitions. |
 | `FCmd(task, toCmd, onEnqueue)` | Bridge a `Future[A]` into the runtime — covered in the [async tutorial](../tut/03-async.md). |
 | `TermFlowErrorCmd(err)` | Surface a `TermFlowError` to the renderer (logged, not fatal). |
+| `RequestAttention` | Ring the bell / pop the terminal's "needs attention" indicator. |
+| `Notify(title, body)` | Send a desktop notification (iTerm2/kitty/VTE OSC, BEL fallback). |
+
+`RequestAttention` and `Notify` are documented end-to-end in the
+[notifications cookbook](../cookbook/notifications.md), including the
+`TERMFLOW_NOTIFICATIONS` opt-out.
 
 Plus the helper:
 
 ```scala
 def Cmd.asyncResult[A, Msg](
   task:      AsyncResult[A],
-  toCmd:     A => Cmd[Msg],
+  onSuccess: A => Msg,
+  onError:   TermFlowError => Msg,
   onEnqueue: Option[Msg] = None
 ): Cmd[Msg]
 ```
 
-`AsyncResult[A]` is `Future[Result[A]]`. Wrap fallible async work in
-this and the runtime will fold a `Left(err)` into a
-`TermFlowErrorCmd`.
+`AsyncResult[A]` is `Future[Result[A]]`. Use `asyncResult` whenever the
+async work has a domain failure mode: `Right(a)` is mapped through
+`onSuccess`, `Left(err)` through `onError`. `Future` failures (network
+drops, JVM exceptions) still surface via the runtime's standard
+`TermFlowErrorCmd` overlay — there's no need to recover them here.
 
 ## Sub — subscriptions
 
@@ -101,14 +112,23 @@ Sub.InputKey(
   ctx:     RuntimeCtx[Msg]
 ): Sub[Msg]
 
-Sub.TerminalResize(msg: () => Msg, sink: EventSink[Msg]): Sub[Msg]
+Sub.TerminalResize(
+  millis: Long,
+  mkMsg:  (Int, Int) => Msg,
+  ctx:    RuntimeCtx[Msg]
+): Sub[Msg]
 
 val Sub.NoSub: Sub[Nothing]   // inert placeholder for model fields
 ```
 
-When the third argument is a `RuntimeCtx[Msg]`, the sub
+When the sink/ctx argument is a `RuntimeCtx[Msg]`, the sub
 **auto-registers** for cleanup on `Cmd.Exit`. When it's a bare
 `EventSink`, you're responsible for the lifecycle.
+
+`Sub.TerminalResize` prefers the backend's resize signal (e.g.
+SIGWINCH on Unix) and only falls back to polling at `millis` for
+backends without signal support — typically the testkit's virtual
+backend.
 
 `.cancel()` is idempotent — safe to call on `NoSub` or on an
 already-cancelled sub.

--- a/docs/guide/terminal-layer.md
+++ b/docs/guide/terminal-layer.md
@@ -80,16 +80,22 @@ defaults so apps that ignore it still work:
 
 ```scala
 final case class Capabilities(
-  colorDepth:    ColorDepth, // Mono | Ansi8 | Ansi16 | Indexed256 | Truecolor
-  unicode:       Boolean,
-  mouse:         Boolean,
-  extendedStyles: Boolean,   // italic / dim / strike / blink
-  bracketedPaste: Boolean
+  colorDepth:     ColorDepth, // Mono | Ansi8 | Ansi16 | Indexed256 | Truecolor
+  unicode:        Boolean,
+  mouse:          Boolean,
+  extendedStyles: Boolean = true,    // italic / dim / strike / blink
+  bracketedPaste: Boolean = true,
+  notifications:  NotificationKind = NotificationKind.BellOnly
 )
 
 object Capabilities:
   def detect(env: Map[String, String]): Capabilities
 ```
+
+`notifications` controls how `Cmd.RequestAttention` and `Cmd.Notify`
+reach the user — values: `Disabled`, `BellOnly`, `ITerm2`, `Kitty`,
+`Vte`. The runtime resolves the right OSC sequence per kind; see the
+[notifications cookbook](../cookbook/notifications.md).
 
 `Capabilities.detect(sys.env)` honours `NO_COLOR`, `COLORTERM`, `TERM`,
 and `LANG` / `LC_*`. The `AnsiRenderer` calls this for you and

--- a/docs/guide/widgets.md
+++ b/docs/guide/widgets.md
@@ -56,7 +56,7 @@ Grapheme-aware navigation across all four arrows, Backspace, Delete.
 
 ```scala
 val state = MultiLineInput.State(lines = Vector("hello", "world"))
-val (next, _) = MultiLineInput.handleKey[Msg](state, key)(_ => None)
+val (next, _) = MultiLineInput.handleKey[Msg](state, key)
 val node = MultiLineInput.view(next, width = 60, height = 12, focused = true)
 ```
 

--- a/docs/intro/architecture.md
+++ b/docs/intro/architecture.md
@@ -58,8 +58,9 @@ Loop, repeat.
 ## What runs where
 
 - **Update is synchronous and pure.** No I/O. If you need async work,
-  return a `Cmd.FCmd[Future[A], Msg]` and the runtime will run the
-  `Future`, deliver the result back as a `Msg`.
+  return a `Cmd.FCmd[A, Msg]` (or the friendlier `Cmd.asyncResult`) and
+  the runtime will await the `Future`, then deliver the result back as
+  a `Msg`.
 - **View is pure.** It returns a `RootNode` from a `Model`. The renderer
   takes care of cursor placement, colour emission, and clipping.
 - **Subscriptions live outside `update`.** `Sub.InputKey` reads from JLine

--- a/docs/reference/migration.md
+++ b/docs/reference/migration.md
@@ -1,12 +1,80 @@
 # Migration notes
 
-> *Empty placeholder until 1.0.* TermFlow is currently 0.2.x and APIs
-> are still allowed to change between minor versions. Migration notes
-> will be populated alongside the first MiMa-enforced release.
+> **0.2.0 / 0.3.0 → 1.0 — no migration required.** TermFlow 1.0 is
+> source-compatible with 0.2.x / 0.3.x. Apps that compiled and ran
+> against either pre-1.0 release should compile and run against 1.0
+> unchanged.
 
-When 1.0 ships this page will contain:
+The pre-1.0 cycle deliberately froze the public API surface; every
+landing in the 0.2.x → 1.0 window has been additive. The list below
+catalogues the user-visible additions you can opt into in a 1.0 app
+that was originally written against 0.2.0.
 
-- A summary of breaking changes from the most recent 0.x line.
+## What's new since 0.2.0
+
+### Recoverable error overlay
+
+`Cmd.TermFlowErrorCmd(err: TermFlowError)` raises a transient red
+banner above the next frame and clears it on the following render —
+the runtime keeps looping. See
+[the app-layer guide](../guide/app-layer.md#how-errors-reach-the-user)
+for the rendered shape and the testkit hook
+(`TuiTestDriver.observedErrors`).
+
+`Cmd.asyncResult(task, onSuccess, onError, onEnqueue)` is the
+preferred bridge for fallible async work — it folds an
+`AsyncResult[A]` (i.e. `Future[Result[A]]`) into the runtime,
+routing `Right(a)` through `onSuccess` and `Left(err)` through
+`onError`. `Future` failures themselves still surface via
+`TermFlowErrorCmd` automatically.
+
+### Notifications
+
+Two new commands plus matching capability detection:
+
+- `Cmd.RequestAttention` — ring the bell or pop the terminal's
+  attention indicator.
+- `Cmd.Notify(title, body)` — desktop notification on iTerm2 / kitty /
+  GNOME Terminal (VTE), with BEL fallback.
+
+`Capabilities` gained a `notifications: NotificationKind` field
+(`Disabled | BellOnly | ITerm2 | Kitty | Vte`). The full pattern is
+documented in the
+[notifications cookbook](../cookbook/notifications.md).
+Override the protocol via `TERMFLOW_NOTIFICATIONS=off|bell|auto`.
+
+### Layout: Grid, Border, budgeted resolve
+
+`Layout.Grid(columns, rowGap, colGap, cells)` and
+`Layout.Border(top, left, center, right, bottom, gap)` join the
+existing `Row` / `Column` / `Fill` / `Zone` cases. `GridCell`
+expresses row / column spans. Both flow through `Layout.resolveTo` so
+the renderer reflows them on resize.
+
+`Layout.toBudgetedRootNode(width, height, input)` is the new deferred
+sibling to the eager `toRootNode` — it puts the layout into
+`RootNode.layout` so the renderer resolves it against the actual
+frame budget at render time. This is the right form for full-screen
+apps and any layout containing `Fill` / `Grid` / `Border`. See the
+[full-screen-layout cookbook](../cookbook/full-screen-layout.md) for
+the eager-vs-deferred trade-off.
+
+### Mouse-wheel scrollback
+
+`LogView.scrollDelta(event, viewport, ticksPerDetent)` plus
+`LogView.Viewport(at, width, height)` map a `MouseEvent.Scroll` onto
+a clamp-friendly scroll delta when the wheel lands inside the
+viewport, returning `None` for outside-the-rect or non-scroll events.
+Wired into the `chatDemo` sample; covered in the
+[streaming-output cookbook](../cookbook/streaming-output.md).
+
+## Post-1.0 — when MiMa lights up
+
+Binary-compatibility enforcement (`sbt-mima-plugin`) is scheduled for
+the 1.0.x / 1.1 cycle, with `1.0.0` as the baseline. From the first
+post-1.0 release onwards this page will list:
+
+- A summary of breaking changes from the most recent line.
 - The `mimaBinaryIssueFilters` rationale for any deliberately accepted
   breaks.
 - Code-level before / after recipes for the most common patterns
@@ -14,7 +82,5 @@ When 1.0 ships this page will contain:
 - Deprecation timelines for symbols slated for removal in the next
   major release.
 
-For the current pre-1.0 state, the
-[ROADMAP](../contrib/ROADMAP.md) and
-[release notes](https://github.com/llm4s/termflow/releases) are the
-source of truth.
+Until then, the [release notes](https://github.com/llm4s/termflow/releases)
+remain the source of truth for additive changes.

--- a/docs/tut/01-hello-world.md
+++ b/docs/tut/01-hello-world.md
@@ -218,7 +218,8 @@ object HelloApp:
         height   = 3,
         children = List(
           TextNode(2.x, 1.y, List(m.message.text))
-        )
+        ),
+        input    = None
       )
 
     def toMsg(input: PromptLine): Result[Msg] = Right(Msg.Quit)

--- a/docs/tut/03-async.md
+++ b/docs/tut/03-async.md
@@ -156,7 +156,7 @@ case Increment =>
 | Parameter | What |
 |---|---|
 | `task` | The `Future[A]` you want the runtime to await. |
-| `onComplete` | A function from the future's result to the next `Cmd`. |
+| `toCmd` | A function from the future's result to the next `Cmd`. |
 | `onEnqueue` | An optional `Msg` to dispatch *immediately* when the FCmd is enqueued — before the future completes. |
 
 What happens at runtime:
@@ -165,14 +165,18 @@ What happens at runtime:
 2. The runtime sees the `FCmd`, registers a callback on the future, and
    if `onEnqueue` was supplied, immediately dispatches that `Msg`.
 3. When the future completes (after ~5 seconds here),
-   `onComplete(result)` runs and the resulting `Cmd` (here
+   `toCmd(result)` runs and the resulting `Cmd` (here
    `Cmd.GCmd(UpdateWith(c))`) is enqueued.
 
 The result: `Busy("incrementing::...")` arrives within microseconds of
 pressing Enter, and `UpdateWith(newCount)` arrives ~5 seconds later.
 
-> If your future could fail, use `Cmd.FCmd` together with the `Result[A]`
-> alias. The Cookbook has a recipe for the pattern.
+> If your future already returns `Result[A]` (i.e. it can fail with a
+> `TermFlowError`), reach for `Cmd.asyncResult(task, onSuccess, onError,
+> onEnqueue)` instead — it folds the `Either` for you so the call site
+> stays one expression. Future-level exceptions still surface as a
+> `TermFlowErrorCmd` overlay automatically. See the [app-layer
+> guide](../guide/app-layer.md#cmd--effects) for the full signature.
 
 ## 5. Starting a `Sub.Every`
 


### PR DESCRIPTION
## Summary

Pre-1.0 hardening item §4.3 — walk the public surface, every tutorial / guide / cookbook snippet, and remove copy-into-your-app surprises.

### Doc fixes

| File | Issue | Fix |
|---|---|---|
| `docs/guide/app-layer.md` | `Cmd.asyncResult` signature wrong (`toCmd: A => Cmd[Msg]`); `Sub.TerminalResize` signature wrong (`(msg, sink)`); enum block missing `RequestAttention` / `Notify` | Corrected to `(task, onSuccess, onError, onEnqueue)`; corrected to `(millis, mkMsg, ctx)`; added new cases to enum + table |
| `docs/guide/widgets.md` | `MultiLineInput.handleKey[Msg](state, key)(_ => None)` — that variant doesn't take a curried second arg list | Dropped the bogus `(_ => None)` |
| `docs/guide/terminal-layer.md` | `Capabilities` definition missing `notifications: NotificationKind` field | Added the 6th field with one-line cookbook pointer |
| `docs/intro/architecture.md` | `Cmd.FCmd[Future[A], Msg]` — wrong type params | Changed to `Cmd.FCmd[A, Msg]`; pointed at `Cmd.asyncResult` |
| `docs/tut/01-hello-world.md` | Full-source `RootNode(...)` missing required `input` arg — wouldn't compile | Added `input = None` |
| `docs/tut/03-async.md` | `Cmd.FCmd` table mislabeled 2nd param as `onComplete`; vague "Cookbook has a recipe" footnote | Renamed to `toCmd`; replaced footnote with concrete `Cmd.asyncResult` pointer |
| `docs/cookbook/file-picker.md` | `Cmd.FCmd(Future{…}, Msg.LoadDone.apply)` — `A => Msg` ≠ `A => Cmd[M]`, wouldn't typecheck | Switched to `Cmd.asyncResult(future, Msg.LoadDone.apply, Msg.LoadFailed.apply)` |
| `docs/cookbook/full-screen-layout.md` | Orphaned `Layout.column(gap = 0)(header, …)` builder block before the real layout | Removed the dead block |

### Migration notes

`docs/reference/migration.md` is no longer an empty placeholder. Now states explicitly that 1.0 is source-compatible with 0.2.x / 0.3.x and catalogues the additive changes since 0.2.0 (error overlay, `asyncResult`, notifications, `Grid` / `Border` / `toBudgetedRootNode`, mouse-wheel scrollback) so apps can opt in. MiMa enforcement remains scheduled for the 1.0.x / 1.1 cycle as decided 2026-04-30.

### Roadmap

Marked §4.3 as ☑ landed and added a 2026-04-30 decision entry under §8.

### SPI surface

`TuiRenderer`, `CmdConsumer`, `CmdBus`, `EventSink`, `EventSource` already carry `@note SPI` in source Scaladoc. `TerminalBackend` is consumed by the runtime, rarely implemented by apps; an SPI annotation there is a Scaladoc tweak that fits §4.8 polish rather than this audit. ANSI raw escape constants in `AnsiRenderer` aren't surfaced in user docs.

## Test plan

- [x] `mdbook build` (with `linkcheck` backend) — clean, no warnings, no broken links
- [ ] Reviewer eyeballs the corrected snippets for the eight call sites listed above
- [ ] Reviewer confirms the migration-notes catalogue covers everything they consider user-visible since 0.2.0