### PR TITLE
chore: §4.8 zero-warning build + Scaladoc link polish

### DIFF
--- a/docs/contrib/ROADMAP.md
+++ b/docs/contrib/ROADMAP.md
@@ -306,16 +306,30 @@ Acceptance:
 - Keep `coverageLib` green and ensure the combined trend moves up, with
   particular attention to `termflow-terminal` and `termflow-screen`.
 
-### 4.8 Zero-warning build and Scaladoc polish
+### 4.8 Zero-warning build and Scaladoc polish — ☑ landed
 
-The 1.0 branch should build cleanly enough that new warnings stand out.
+`sbt --batch ciCheck` is warning-free across all published modules and
+the sample/testkit projects.
 
-Acceptance:
+`sbt --batch unidoc` is clean of unresolved-link warnings: five Scaladoc
+`[[…]]` references that pointed at out-of-scope or unqualified members
+were corrected — `[[InputKey]]` / `[[InputKey.Tab]]` now spell
+`KeyDecoder.InputKey…`, `Theme.box`'s `[[chars]]` / `[[border]]`
+references the slot via `[[Theme.chars]]` / `[[Theme.border]]`,
+`[[Move]]` and friends in `MouseEvent` are qualified as
+`[[MouseEvent.Move]]` etc., and `TerminalBackend.onResize`'s JLine
+`Terminal.Signal.WINCH` reference dropped its broken `[[…]]` wrapper
+(JLine is on the runtime classpath but not a unidoc target). A
+non-exhaustive `match` warning in `Keymap.renderKey` (missing the
+`InputKey.NoOp` case) was closed at the same time.
 
-- `sbt --batch ciCheck` emits no Scala compiler warnings.
-- `sbt --batch unidoc` completes without unresolved-link warnings where
-  a simple Scaladoc link fix is available.
-- mdBook/linkcheck remain green.
+The remaining `[warn] Flag -classpath set repeatedly` is a structural
+sbt-unidoc / Scala-3-doctool quirk (the doc invocation receives
+`-classpath` once from sbt-unidoc and once from the dotty front-end).
+It is not an unresolved-link warning and there is no in-tree fix; track
+upstream if it becomes load-bearing.
+
+mdBook/linkcheck stay green; the docs site builds unchanged.
 
 ---
 
@@ -430,6 +444,12 @@ Two TermFlow-only wins worth preserving through 1.0:
 
 ## 8. Recent decisions (rolling, last ~3 months)
 
+- *2026-04-30* — Stage 4 §4.8 closed: `ciCheck` is warning-free and
+  `unidoc` clean of unresolved-link warnings. Five Scaladoc `[[…]]`
+  references rewritten to qualified forms; a non-exhaustive
+  `Keymap.renderKey` match closed by adding the `InputKey.NoOp` arm.
+  The remaining `Flag -classpath set repeatedly` is a structural
+  sbt-unidoc / Scala-3-doctool warning with no in-tree fix.
 - *2026-04-30* — Stage 4 §4.3 closed: public-API and docs-example audit
   swept eight signature drifts out of the tutorials, guides, and cookbook;
   `docs/reference/migration.md` populated with the explicit "no migration

--- a/modules/termflow-app/src/main/scala/termflow/tui/Keymap.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Keymap.scala
@@ -99,7 +99,7 @@ object Keymap:
   /**
    * Conventional focus bindings: `Tab` advances, `Shift+Tab` retreats.
    *
-   * `Tab` is a distinct [[InputKey.Tab]] (decoded from ASCII 9); `Shift+Tab` arrives
+   * `Tab` is a distinct [[KeyDecoder.InputKey.Tab]] (decoded from ASCII 9); `Shift+Tab` arrives
    * as `InputKey.BackTab` (decoded from the `[Z` escape sequence).
    *
    * @param next     Message dispatched on `Tab`.
@@ -231,6 +231,7 @@ object Keymap:
     case InputKey.Mouse(_)     => "Mouse"
     case InputKey.Unknown(seq) => s"?($seq)"
     case InputKey.EndOfInput   => "EOF"
+    case InputKey.NoOp         => "NoOp"
 
 /**
  * One step in a [[ChordKeymap]] dispatch.
@@ -265,7 +266,7 @@ final case class ChordState(prefix: Vector[InputKey] = Vector.empty):
 /**
  * Keymap supporting multi-key chord sequences.
  *
- * A chord is a [[Vector]] of [[InputKey]]s that, when typed in sequence,
+ * A chord is a [[Vector]] of [[KeyDecoder.InputKey]]s that, when typed in sequence,
  * dispatches a single message. Chords can share a prefix
  * (`Ctrl+X Ctrl+C` and `Ctrl+X Ctrl+S` both start with `Ctrl+X`) — the
  * dispatcher tracks how far through a chord the user is and only fires

--- a/modules/termflow-app/src/test/scala/termflow/tui/KeymapSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/KeymapSpec.scala
@@ -99,6 +99,21 @@ class KeymapSpec extends AnyFunSuite:
     assert(k.lookup(InputKey.ArrowLeft).contains(DemoMsg.NextFocus))
     assert(k.lookup(InputKey.ArrowRight).contains(DemoMsg.Quit))
 
+  test("renderKey covers every InputKey case (incl. NoOp / EndOfInput)"):
+    // Spot-check the cases that don't share a common shape, so the match
+    // stays exhaustive: bare singletons, parameterised cases, the synthetic
+    // NoOp / EndOfInput sinks, and a Modified wrapper.
+    assert(Keymap.renderKey(InputKey.Tab) == "Tab")
+    assert(Keymap.renderKey(InputKey.BackTab) == "S-Tab")
+    assert(Keymap.renderKey(InputKey.CharKey(' ')) == "Space")
+    assert(Keymap.renderKey(InputKey.CharKey('q')) == "q")
+    assert(Keymap.renderKey(InputKey.Ctrl('C')) == "C-c")
+    assert(Keymap.renderKey(InputKey.NoOp) == "NoOp")
+    assert(Keymap.renderKey(InputKey.EndOfInput) == "EOF")
+    assert(Keymap.renderKey(InputKey.Unknown("xyz")) == "?(xyz)")
+    val mods = KeyDecoder.Modifiers(shift = true, alt = false, ctrl = true, meta = false)
+    assert(Keymap.renderKey(InputKey.Modified(InputKey.Tab, mods)) == "S-C-Tab")
+
   test("layered keymaps form a baseline plus app-specific overrides"):
     val baseline = Keymap.quit(DemoMsg.Quit) ++
       Keymap.focus(next = DemoMsg.NextFocus, previous = DemoMsg.A)

--- a/modules/termflow-screen/src/main/scala/termflow/tui/Theme.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Theme.scala
@@ -225,8 +225,8 @@ object Theme:
       Text(txt, Style(fg = select(t)))
 
   /**
-   * Build a [[VNode.BoxNode]] using the ambient theme's [[chars]] and
-   * [[border]] slot.
+   * Build a [[VNode.BoxNode]] using the ambient theme's [[Theme.chars]] and
+   * [[Theme.border]] slot.
    *
    * This is the idiomatic way to draw a themed bordered container — apps
    * stay free of any direct reference to `BorderChars`, and the visual

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/Mouse.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/Mouse.scala
@@ -24,9 +24,10 @@ enum ScrollDirection:
  * library — `col=1, row=1` is the top-left cell.
  *
  * The capture mode (xterm "any-event tracking", `CSI ?1003h`) decides
- * whether [[Move]] events without a held button arrive at all; today the
- * runtime enables button-event tracking only (`CSI ?1002h`), so apps will
- * see [[Press]] / [[Release]] / [[Drag]] / [[Scroll]] but no bare moves.
+ * whether [[MouseEvent.Move]] events without a held button arrive at all;
+ * today the runtime enables button-event tracking only (`CSI ?1002h`), so
+ * apps will see [[MouseEvent.Press]] / [[MouseEvent.Release]] /
+ * [[MouseEvent.Drag]] / [[MouseEvent.Scroll]] but no bare moves.
  * The enum is wired up regardless so a future "track everything" toggle
  * doesn't change the public API.
  */

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/TerminalBackend.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/TerminalBackend.scala
@@ -105,10 +105,10 @@ final class JLineTerminalBackend extends TerminalBackend:
     Capabilities.detect(System.getenv().asScala.toMap)
 
   /**
-   * Hook into JLine's SIGWINCH delivery. JLine raises [[Terminal.Signal.WINCH]]
+   * Hook into JLine's SIGWINCH delivery. JLine raises `Terminal.Signal.WINCH`
    * when the underlying tty resizes (or, on Windows, when its emulator reports
    * a console-buffer change). The listener is invoked on JLine's signal
-   * dispatch path; we adapt it through a Java [[Terminal.SignalHandler]] and
+   * dispatch path; we adapt it through a JLine `Terminal.SignalHandler` and
    * return the previous handler so callers can restore it on unregister.
    */
   override def onResize(listener: () => Unit): Option[() => Unit] =


### PR DESCRIPTION
## Summary

Pre-1.0 roadmap §4.8. Closes the residual `sbt --batch unidoc` warnings so new ones stand out, and tightens one non-exhaustive `match` warning that surfaced during the Scaladoc compile.

### What changed

| File | Issue | Fix |
|---|---|---|
| `modules/termflow-app/src/main/scala/termflow/tui/Keymap.scala` | `[[InputKey]]` and `[[InputKey.Tab]]` Scaladoc links don't resolve through the file-top `import` — Scaladoc's link resolver needs the qualified path | `[[KeyDecoder.InputKey]]` / `[[KeyDecoder.InputKey.Tab]]` |
| `Keymap.scala` | `renderKey` non-exhaustive match (missing `InputKey.NoOp`) | Added the `NoOp` arm |
| `modules/termflow-screen/src/main/scala/termflow/tui/Theme.scala` | `Theme.box` lives on the companion; bare `[[chars]]` / `[[border]]` don't resolve | `[[Theme.chars]]` / `[[Theme.border]]` |
| `modules/termflow-terminal/src/main/scala/termflow/tui/Mouse.scala` | `[[Move]]` (and friends) in `MouseEvent`'s enum-level Scaladoc | Qualified with `[[MouseEvent.Move]]` etc. |
| `modules/termflow-terminal/src/main/scala/termflow/tui/TerminalBackend.scala` | `[[Terminal.Signal.WINCH]]` / `[[Terminal.SignalHandler]]` point at JLine — not a unidoc target, can never resolve | Dropped the `[[…]]` wrappers; text remains in backticks |

### Status

- `sbt --batch ciCheck` — **0 `[warn]` lines** across the published modules + samples + testkit (was already 0 at baseline; this PR doesn't regress).
- `sbt --batch unidoc` — **0 unresolved-link warnings** (was 5).
- `mdbook build` (with `linkcheck`) — green.

### Out of scope

`[warn] Flag -classpath set repeatedly` is a structural `sbt-unidoc` / Scala-3-doctool quirk: the doc invocation receives `-classpath` once from sbt-unidoc and once from dotty's front-end. Not an unresolved-link warning, no in-tree fix without forking sbt-unidoc — recorded under §4.8 in the roadmap so future readers don't chase it again.

### Roadmap

§4.8 marked ☑ landed; 2026-04-30 decision entry added under §8.

## Test plan

- [x] `sbt --batch ciCheck` — clean (0 warnings, 1 015 tests pass)
- [x] `sbt --batch unidoc` — only the structural `-classpath` warning remains
- [x] `mdbook build` (linkcheck backend) — clean
- [ ] Reviewer eyeballs the five Scaladoc edits to confirm the qualified link forms render correctly in the published Scaladoc