### PR TITLE
fix: width-aware input/layout, prompt paste, and FCmd mapper guard

### DIFF
--- a/modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala
@@ -82,6 +82,16 @@ object Prompt:
         val newBuf = state.buffer.patch(state.cursor, chars.toIndexedSeq, 0)
         (normalized(state.copy(buffer = newBuf, cursor = state.cursor + chars.length)), None)
 
+      case KeyDecoder.InputKey.Paste(text) =>
+        if text.isEmpty then (state, None)
+        else
+          // Single-line prompt: keep only the first pasted line so a
+          // multi-line clipboard payload can't smuggle newlines into a
+          // one-row buffer. Mirrors TextField's paste behaviour.
+          val line   = text.takeWhile(ch => ch != '\n' && ch != '\r')
+          val newBuf = state.buffer.patch(state.cursor, line.toVector, 0)
+          (normalized(state.copy(buffer = newBuf, cursor = state.cursor + line.length)), None)
+
       case KeyDecoder.InputKey.ArrowLeft =>
         // Grapheme-aware step so the cursor doesn't strand combining marks.
         val text    = state.buffer.mkString

--- a/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext
 import scala.util.Failure
 import scala.util.Success
+import scala.util.control.NonFatal
 
 /**
  * Pluggable renderer invoked by the runtime loop once per frame.
@@ -249,7 +250,15 @@ object TuiRuntime:
           case Cmd.FCmd(task, toCmd, onEnqueue) =>
             task.onComplete:
               case Success(result) =>
-                bus.publish(toCmd(result))
+                // Guard the success mapper too: if `toCmd` throws, the
+                // failure would otherwise die silently on the execution
+                // context and the app would stay stuck in its loading state.
+                val next =
+                  try toCmd(result)
+                  catch
+                    case NonFatal(e) =>
+                      Cmd.TermFlowErrorCmd(TermFlowError.Unexpected(unexpectedMessage(e), Some(e)))
+                bus.publish(next)
               case Failure(e) =>
                 bus.publish(Cmd.TermFlowErrorCmd(TermFlowError.Unexpected(unexpectedMessage(e), Some(e))))
             onEnqueue match

--- a/modules/termflow-app/src/test/scala/termflow/tui/PromptSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/PromptSpec.scala
@@ -147,3 +147,23 @@ class PromptSpec extends AnyFunSuite:
   test("cursorColumn counts combining marks as 0 columns"):
     val state = Prompt.State(buffer = "é".toVector, cursor = 2)
     assert(Prompt.cursorColumn(state) == 1, "e=1, combining mark=0")
+
+  // ---- bracketed paste ----------------------------------------------------
+
+  test("Paste inserts text at the cursor and advances by its length"):
+    val state       = Prompt.State(buffer = Vector('a', 'd'), cursor = 1)
+    val (next, cmd) = Prompt.handleKey[String](state, InputKey.Paste("bc"))(noopToMsg)
+    assert(cmd.isEmpty)
+    assert(Prompt.render(next) == "abcd")
+    assert(next.cursor == 3)
+
+  test("Paste keeps only the first line of a multi-line payload"):
+    val (next, _) = Prompt.handleKey[String](Prompt.State(), InputKey.Paste("one\ntwo\r\nthree"))(noopToMsg)
+    assert(Prompt.render(next) == "one")
+    assert(next.cursor == 3)
+
+  test("Paste of empty text is a no-op"):
+    val state     = Prompt.State(buffer = Vector('a'), cursor = 1)
+    val (next, _) = Prompt.handleKey[String](state, InputKey.Paste(""))(noopToMsg)
+    assert(Prompt.render(next) == "a")
+    assert(next.cursor == 1)

--- a/modules/termflow-app/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
@@ -167,6 +167,55 @@ class TuiRuntimeSpec extends AnyFunSuite:
         }
     )
 
+  test("TuiRuntime surfaces an error when the FCmd success mapper throws"):
+    final class StopRuntime extends RuntimeException("stop-runtime")
+
+    val seenErr = new AtomicReference[Option[TermFlowError]](None)
+
+    val renderer = new TuiRenderer:
+      override def render(
+        textNode: RootNode,
+        err: Option[TermFlowError],
+        terminal: TerminalBackend,
+        renderMetrics: RenderMetrics
+      ): Unit =
+        err.foreach { e =>
+          seenErr.set(Some(e))
+          throw new StopRuntime
+        }
+
+    object App extends TuiApp[Int, Unit]:
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] =
+        Tui(
+          model = 0,
+          // The Future succeeds, but the success mapper blows up. Without the
+          // guard this throws on the execution-context thread and the runtime
+          // never sees either the intended command or an error.
+          cmd = Cmd.FCmd(
+            task = Future.successful(()),
+            toCmd = _ => throw new RuntimeException("mapper-boom"),
+            onEnqueue = None
+          )
+        )
+
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model)
+      override def view(model: Int): RootNode             = RootNode(80, 24, children = List.empty, input = None)
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val backend = new TestTerminalBackend
+    intercept[StopRuntime]:
+      TuiRuntime.run(
+        app = App,
+        renderer = renderer,
+        terminalBackend = backend,
+        config = TestConfig
+      )
+
+    assert(seenErr.get().exists {
+      case TermFlowError.Unexpected(msg, Some(_: RuntimeException)) => msg == "mapper-boom"
+      case _                                                        => false
+    })
+
   test("TuiRuntime dispatches GCmd and runs onEnqueue follow-up before completion"):
     enum Msg:
       case Step, Done

--- a/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -356,6 +356,40 @@ object AnsiRenderer:
     out.append(moveTo(x, y + (h - 1))).append(s"${chars.bottomLeft}$horizontal${chars.bottomRight}")
     out.append(reset)
 
+  /**
+   * Longest prefix of `s` whose rendered cell width is at most `maxCells`,
+   * never splitting a code point (so wide glyphs and surrogate pairs stay
+   * whole). For pure-ASCII input this returns `s.take(maxCells)`.
+   */
+  private def takeCells(s: String, maxCells: Int): String =
+    if maxCells <= 0 then ""
+    else
+      var w = 0
+      var i = 0
+      while i < s.length do
+        val cp = s.codePointAt(i)
+        val cw = math.max(0, WCWidth.codePointWidth(cp))
+        if w + cw > maxCells then return s.substring(0, i)
+        w += cw
+        i += java.lang.Character.charCount(cp)
+      s
+
+  /**
+   * Smallest char (UTF-16) index `i` such that `WCWidth.stringWidth(s.take(i))`
+   * is at least `targetCells`. Used to translate a desired scroll column back
+   * to a code-point boundary. For pure-ASCII input this returns `targetCells`.
+   */
+  private def charIndexAtCell(s: String, targetCells: Int): Int =
+    if targetCells <= 0 then 0
+    else
+      var w = 0
+      var i = 0
+      while i < s.length && w < targetCells do
+        val cp = s.codePointAt(i)
+        w += math.max(0, WCWidth.codePointWidth(cp))
+        i += java.lang.Character.charCount(cp)
+      i
+
   private def visibleInput(inp: InputNode, rootWidth: Int): VisibleInput =
     val clampedCursor =
       if inp.cursor >= 0 && inp.cursor <= inp.prompt.length then inp.cursor
@@ -363,29 +397,38 @@ object AnsiRenderer:
 
     val requestedWidth =
       if inp.lineWidth > 0 then inp.lineWidth
-      else math.max(1, inp.prompt.length + 1)
+      else math.max(1, WCWidth.stringWidth(inp.prompt) + 1)
 
     val remainingWidth = math.max(1, rootWidth - inp.x.value + 1)
     val width          = math.max(1, math.min(requestedWidth, remainingWidth))
     val prefixLength   = math.max(0, math.min(inp.prefixLength, inp.prompt.length))
-    val fixedPrefix    = inp.prompt.take(prefixLength).take(width)
+    // `width` is a cell budget, so clip the fixed prefix and scroll the
+    // editable suffix by rendered cell width — not UTF-16 length. Otherwise
+    // CJK/emoji input overflows the declared input width or scrolls past the
+    // cursor, even though cursor placement below already uses WCWidth.
+    val fixedPrefix    = takeCells(inp.prompt.take(prefixLength), width)
+    val prefixCells    = WCWidth.stringWidth(fixedPrefix)
     val suffix         = inp.prompt.drop(prefixLength)
-    val availableWidth = math.max(0, width - fixedPrefix.length)
+    val availableCells = math.max(0, width - prefixCells)
     val suffixCursor   = math.max(0, clampedCursor - prefixLength)
     val suffixStart =
-      if availableWidth == 0 then 0
+      if availableCells == 0 then 0
       else
-        val maxStart              = math.max(0, suffix.length - availableWidth)
-        val preferredRightContext = math.min(2, math.max(0, availableWidth - 1))
-        val desiredStart          = suffixCursor - availableWidth + preferredRightContext + 1
-        math.max(0, math.min(maxStart, desiredStart))
+        val suffixCells           = WCWidth.stringWidth(suffix)
+        val cursorCell            = WCWidth.stringWidth(suffix.take(suffixCursor))
+        val maxStartCell          = math.max(0, suffixCells - availableCells)
+        val preferredRightContext = math.min(2, math.max(0, availableCells - 1))
+        val desiredStartCell      = cursorCell - availableCells + preferredRightContext + 1
+        val startCell             = math.max(0, math.min(maxStartCell, desiredStartCell))
+        charIndexAtCell(suffix, startCell)
     val visibleSuffix =
-      if availableWidth == 0 then ""
-      else suffix.slice(suffixStart, suffixStart + availableWidth)
+      if availableCells == 0 then ""
+      else takeCells(suffix.drop(suffixStart), availableCells)
     val visibleText =
-      val text = fixedPrefix + visibleSuffix
-      if text.length >= width then text.take(width)
-      else text + (" " * (width - text.length))
+      val text  = fixedPrefix + visibleSuffix
+      val cells = WCWidth.stringWidth(text)
+      if cells >= width then text
+      else text + (" " * (width - cells))
 
     // Cursor column = sum of WCWidth across visible characters up to the
     // cursor's char index. This makes wide-char input (CJK, emoji) and
@@ -442,7 +485,7 @@ object AnsiRenderer:
         }
 
       case InputNode(x, y, prompt, _, _, lineWidth, _) =>
-        val w     = if lineWidth > 0 then lineWidth else prompt.length
+        val w     = if lineWidth > 0 then lineWidth else WCWidth.stringWidth(prompt)
         val right = x.value + math.max(0, w - 1)
         (right, y.value)
 

--- a/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
@@ -470,14 +470,17 @@ object Layout:
   /** Natural `(width, height)` of a concrete [[VNode]]. */
   def measureVNode(v: VNode): (Int, Int) = v match
     case TextNode(_, _, segments) =>
-      val width = segments.foldLeft(0)((acc, seg) => acc + seg.txt.length)
+      // Rendered cell width, not UTF-16 length: wide (CJK/emoji) and
+      // combining text must measure the same here as the renderer draws,
+      // or siblings, fills, and hit-test zones land at the wrong column.
+      val width = segments.foldLeft(0)((acc, seg) => acc + WCWidth.stringWidth(seg.txt))
       (width, 1)
 
     case BoxNode(_, _, w, h, _, _, _) =>
       (math.max(0, w), math.max(0, h))
 
     case InputNode(_, _, prompt, _, _, lineWidth, _) =>
-      val width = if lineWidth > 0 then lineWidth else prompt.length
+      val width = if lineWidth > 0 then lineWidth else WCWidth.stringWidth(prompt)
       (width, 1)
 
   /**

--- a/modules/termflow-screen/src/test/scala/termflow/tui/AnsiRendererSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/AnsiRendererSpec.scala
@@ -466,6 +466,24 @@ class AnsiRendererSpec extends AnyFunSuite:
     val frame = AnsiRenderer.buildFrame(root)
     assert(frame.width >= 6, s"expected frame width >= 6, got ${frame.width}")
 
+  test("input viewport bounds wide-char text to the declared cell width"):
+    // prompt is 4 CJK glyphs = 8 cells; lineWidth is 4 cells. The viewport
+    // must show only the last two glyphs (4 cells), not slice 4 *chars*
+    // (8 cells) and overflow. Cursor sits at the end.
+    val root = RootNode(
+      width = 20,
+      height = 1,
+      children = Nil,
+      input = Some(InputNode(XCoord(1), YCoord(1), prompt = "你好世界", style = Style(), cursor = 4, lineWidth = 4))
+    )
+    val frame = AnsiRenderer.buildFrame(root)
+    assert(frame.cells(0)(0).glyph == "世", "first visible cell is the scrolled-to glyph")
+    assert(frame.cells(0)(1).width == 0, "continuation cell after wide glyph")
+    assert(frame.cells(0)(2).glyph == "界")
+    assert(frame.cells(0)(3).width == 0, "continuation cell after wide glyph")
+    assert(frame.cells(0)(4).ch == ' ', "nothing rendered past the 4-cell budget")
+    assert(frame.cursor.contains(Coord(XCoord(5), YCoord(1))), "hardware cursor lands one cell past the last glyph")
+
   // ---- renderPatch / depth & extended overloads ----
 
   test("renderPatch default overload uses Ansi8 depth and extended styles"):

--- a/modules/termflow-screen/src/test/scala/termflow/tui/LayoutSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/LayoutSpec.scala
@@ -18,6 +18,13 @@ class LayoutSpec extends AnyFunSuite:
     val multi = TextNode(1.x, 1.y, List(Text("ab", Style()), Text("cde", Style())))
     assert(Layout.measureVNode(multi) == (5, 1))
 
+  test("measureVNode on TextNode measures rendered cell width, not UTF-16 length"):
+    // 2 CJK glyphs = 4 cells (not 2 chars); emoji surrogate pair = 2 cells
+    // (not 2 chars); a combining mark adds 0. Matches the renderer's WCWidth.
+    assert(Layout.measureVNode(tn("你好")) == (4, 1))
+    assert(Layout.measureVNode(tn("😀")) == (2, 1))
+    assert(Layout.measureVNode(tn("é")) == (1, 1)) // e + combining acute
+
   test("measureVNode on BoxNode returns declared dimensions"):
     assert(Layout.measureVNode(BoxNode(1.x, 1.y, 10, 4, children = Nil)) == (10, 4))
 


### PR DESCRIPTION
Addresses the code-review findings.

## Findings addressed

**High — Prompt drops bracketed paste.** `Prompt.handleKey` had no `InputKey.Paste` case and fell through to no-op. It now inserts the first pasted line at the cursor, mirroring `TextField`'s single-line paste behaviour. (`TextField` and `MultiLineInput` already gained paste handling in #203, so only `Prompt` remained.)

**High — Input viewport sized by char count, not cells.** `AnsiRenderer.visibleInput` budgeted the fixed prefix and scrolled the editable suffix with `length` / `take` / `slice`, while cursor placement already used `WCWidth`. CJK/emoji text could overflow the declared `lineWidth` or scroll incorrectly. The prefix is now clipped and the suffix scrolled by **rendered cell width**, with new `takeCells` / `charIndexAtCell` helpers. For pure-ASCII input the math reduces to the previous behaviour (existing goldens unchanged). `nodeExtents`' auto-size fallback measures the prompt the same way.

**Medium — Layout measured text by `String.length`.** `Layout.measureVNode` now measures `TextNode`/`InputNode` width via `WCWidth.stringWidth`, so rows, columns, grids, fills, and hit-test zones place wide/combining text consistently with the renderer.

**Medium — `Cmd.FCmd` success mapper unguarded.** A throwing `toCmd(result)` died on the execution context, publishing neither the intended command nor an error and leaving the app stuck loading. The success branch now catches `NonFatal` and surfaces a `TermFlowError.Unexpected`, matching the existing failure path.

**Medium — supplementary-plane emoji in the diff renderer:** already resolved on `main` by the `RenderCell.glyph` / `renderedGlyph` plumbing (`drawString` stores the full glyph; the diff emits `renderedGlyph`). No change needed; noting for completeness.

## Tests
- `PromptSpec`: paste inserts at cursor, keeps only the first line, empty paste is a no-op.
- `AnsiRendererSpec`: wide-char input viewport bounded to the declared cell width with the cursor landing correctly.
- `LayoutSpec`: `measureVNode` returns rendered cell width for CJK / emoji / combining text.
- `TuiRuntimeSpec`: a throwing FCmd success mapper surfaces a `TermFlowError`.

`sbt ciCheck` is green.