### PR TITLE
fix: width-aware input/layout + review bug fixes (crashes & robustness)

### DIFF
--- a/modules/termflow-app/src/main/scala/termflow/tui/Devtools.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Devtools.scala
@@ -229,10 +229,14 @@ object Devtools:
    *   maybeIdx match
    *     case None      => model.copy(devCursor = cursor).tui
    *     case Some(idx) =>
-   *       // Rewind: restore the selected frame's model.
-   *       val frame = model.history.at(idx).get
-   *       frame.model.copy(history = model.history.rewindTo(idx).get,
-   *                        devCursor = cursor).tui
+   *       // Rewind: restore the selected frame's model. Use the Option API
+   *       // rather than `.get` — the frame can be evicted from the ring
+   *       // buffer between the keypress and a later rewind across ticks.
+   *       (model.history.at(idx), model.history.rewindTo(idx)) match
+   *         case (Some(frame), Some(rewound)) =>
+   *           frame.model.copy(history = rewound, devCursor = cursor).tui
+   *         case _ =>
+   *           model.copy(devCursor = cursor).tui
    *
    * // In view:
    * Devtools.Panel.view(

--- a/modules/termflow-app/src/main/scala/termflow/tui/Dialogs.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Dialogs.scala
@@ -241,9 +241,15 @@ object Dialogs:
     cancelLabel: String = "Cancel",
     position: OverlayPosition = OverlayPosition.Centered
   )(using theme: Theme): Overlay =
-    val layout     = listSelectLayout(items.size, selectedIndex, maxVisible)
-    val visible    = layout.visibleCount
-    val anchor     = layout.anchorIndex
+    val layout  = listSelectLayout(items.size, selectedIndex, maxVisible)
+    val visible = layout.visibleCount
+    val anchor  = layout.anchorIndex
+    // Clamp to match the scroll anchor (which already clamps). Without this
+    // an out-of-range `selectedIndex` (e.g. the app's list shrank before it
+    // re-clamped) scrolls to a valid window but highlights no row, so the
+    // list looks frozen with nothing selected.
+    val clampedSelectedIndex =
+      if items.isEmpty then -1 else math.max(0, math.min(items.size - 1, selectedIndex))
     val choices    = List(Choice(okLabel, okFocused), Choice(cancelLabel, !okFocused))
     val titleLen   = title.length + 4
     val actionsLen = choiceWidth(choices) + 4
@@ -261,7 +267,7 @@ object Dialogs:
         .zipWithIndex
         .map { case (item, i) =>
           val absIdx = anchor + i
-          val sel    = absIdx == selectedIndex
+          val sel    = absIdx == clampedSelectedIndex
           val marker = if sel then "▸ " else "  "
           val style =
             if sel then Style(fg = theme.background, bg = theme.primary, bold = true)
@@ -498,6 +504,10 @@ object Dialogs:
     val visible = layout.visibleCount
     val anchor  = layout.anchorIndex
     val choices = List(Choice(okLabel, okFocused), Choice(cancelLabel, !okFocused))
+    // Clamp to match the scroll anchor so an out-of-range selectedIndex still
+    // highlights a row instead of leaving the list visually unselected.
+    val clampedSelectedIndex =
+      if entries.isEmpty then -1 else math.max(0, math.min(entries.size - 1, selectedIndex))
 
     val pathStr    = currentPath.toString
     val titleLen   = title.length + 4
@@ -535,7 +545,7 @@ object Dialogs:
         .zipWithIndex
         .map { case (entry, i) =>
           val absIdx = anchor + i
-          val sel    = absIdx == selectedIndex
+          val sel    = absIdx == clampedSelectedIndex
           renderEntryRow(entry, sel, layout.firstRowOffset + i, innerWidth, showSizes, theme)
         }
         .toList

--- a/modules/termflow-app/src/main/scala/termflow/tui/InMemoryHistoryStore.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/InMemoryHistoryStore.scala
@@ -7,11 +7,19 @@ final case class InMemoryHistoryStore(
 
   private val entries = scala.collection.mutable.ArrayBuffer.from(initialEntries.takeRight(maxEntries))
 
+  // `ArrayBuffer` is not thread-safe. The runtime drives update on its loop
+  // thread while input is decoded on a separate thread, so guard every access
+  // with a lock — otherwise a concurrent append vs. load can throw
+  // ArrayIndexOutOfBounds / ConcurrentModification or corrupt the buffer.
+  private val lock = new Object
+
   override def load(): Vector[String] =
-    entries.toVector
+    lock.synchronized(entries.toVector)
 
   override def append(entry: String): Unit =
     val trimmed = entry.trim
     if trimmed.nonEmpty then
-      entries += trimmed
-      if entries.length > maxEntries then entries.remove(0, entries.length - maxEntries)
+      lock.synchronized {
+        entries += trimmed
+        if entries.length > maxEntries then entries.remove(0, entries.length - maxEntries)
+      }

--- a/modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/Prompt.scala
@@ -82,6 +82,16 @@ object Prompt:
         val newBuf = state.buffer.patch(state.cursor, chars.toIndexedSeq, 0)
         (normalized(state.copy(buffer = newBuf, cursor = state.cursor + chars.length)), None)
 
+      case KeyDecoder.InputKey.Paste(text) =>
+        if text.isEmpty then (state, None)
+        else
+          // Single-line prompt: keep only the first pasted line so a
+          // multi-line clipboard payload can't smuggle newlines into a
+          // one-row buffer. Mirrors TextField's paste behaviour.
+          val line   = text.takeWhile(ch => ch != '\n' && ch != '\r')
+          val newBuf = state.buffer.patch(state.cursor, line.toVector, 0)
+          (normalized(state.copy(buffer = newBuf, cursor = state.cursor + line.length)), None)
+
       case KeyDecoder.InputKey.ArrowLeft =>
         // Grapheme-aware step so the cursor doesn't strand combining marks.
         val text    = state.buffer.mkString

--- a/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext
 import scala.util.Failure
 import scala.util.Success
+import scala.util.control.NonFatal
 
 /**
  * Pluggable renderer invoked by the runtime loop once per frame.
@@ -249,7 +250,15 @@ object TuiRuntime:
           case Cmd.FCmd(task, toCmd, onEnqueue) =>
             task.onComplete:
               case Success(result) =>
-                bus.publish(toCmd(result))
+                // Guard the success mapper too: if `toCmd` throws, the
+                // failure would otherwise die silently on the execution
+                // context and the app would stay stuck in its loading state.
+                val next =
+                  try toCmd(result)
+                  catch
+                    case NonFatal(e) =>
+                      Cmd.TermFlowErrorCmd(TermFlowError.Unexpected(unexpectedMessage(e), Some(e)))
+                bus.publish(next)
               case Failure(e) =>
                 bus.publish(Cmd.TermFlowErrorCmd(TermFlowError.Unexpected(unexpectedMessage(e), Some(e))))
             onEnqueue match

--- a/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
+++ b/modules/termflow-app/src/main/scala/termflow/tui/TuiRuntime.scala
@@ -243,9 +243,18 @@ object TuiRuntime:
             shouldRender = true
 
           case Cmd.GCmd(g) =>
-            val next: Tui[Model, Msg] = app.update(model, g, bus)
-            model = next.model
-            bus.publish(next.cmd)
+            // Guard the synchronous update the same way FCmd guards its async
+            // mapper: a throw here used to escape the loop and kill the app.
+            // Surface it as an error banner and keep the previous model so a
+            // single bad transition doesn't tear the whole UI down.
+            try
+              val next: Tui[Model, Msg] = app.update(model, g, bus)
+              model = next.model
+              bus.publish(next.cmd)
+            catch
+              case NonFatal(e) =>
+                pendingErr = Some(TermFlowError.Unexpected(unexpectedMessage(e), Some(e)))
+                shouldRender = true
 
           case Cmd.FCmd(task, toCmd, onEnqueue) =>
             task.onComplete:
@@ -306,7 +315,16 @@ object TuiRuntime:
           else renderMetrics.recordCoalescing(consumed)
 
           if !shouldExit then
-            renderer.render(app.view(model), pendingErr, terminalBackend, renderMetrics)
+            // A throwing `view` would otherwise crash the render loop. Fall
+            // back to an empty frame and surface the failure as an error
+            // banner so the app stays alive.
+            val frame: RootNode =
+              try app.view(model)
+              catch
+                case NonFatal(e) =>
+                  pendingErr = Some(TermFlowError.Unexpected(unexpectedMessage(e), Some(e)))
+                  RootNode(math.max(1, terminalBackend.width), math.max(1, terminalBackend.height), Nil, None)
+            renderer.render(frame, pendingErr, terminalBackend, renderMetrics)
             pendingErr = None
             shouldRender = false
             lastRenderAtNanos = System.nanoTime()

--- a/modules/termflow-app/src/test/scala/termflow/tui/DialogsSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/DialogsSpec.scala
@@ -118,6 +118,14 @@ class DialogsSpec extends AnyFunSuite:
     assert(s.contains("▸ banana"), s"selected row must carry the marker, got: $s")
   }
 
+  test("Dialogs.listSelect clamps an out-of-range selectedIndex to a visible highlight") {
+    // selectedIndex past the end (e.g. the list shrank before the app
+    // re-clamped) must still highlight a row, not render nothing selected.
+    val o = Dialogs.listSelect(title = "Pick", items = Seq("apple", "banana", "cherry"), selectedIndex = 9)
+    val s = stringForm(o)
+    assert(s.contains("▸ cherry"), s"out-of-range selection should clamp to last row, got: $s")
+  }
+
   test("Dialogs.listSelect scrolls so the selected row stays visible") {
     val items = (1 to 30).map(i => s"item-$i")
     val o     = Dialogs.listSelect(title = "Long list", items = items, selectedIndex = 25, maxVisible = 6)

--- a/modules/termflow-app/src/test/scala/termflow/tui/HistorySpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/HistorySpec.scala
@@ -123,6 +123,18 @@ class HistorySpec extends AnyFunSuite:
     store.append("  four  ")
     assert(store.load() == Vector("three", "four"))
 
+  test("InMemoryHistoryStore tolerates concurrent append/load without corruption"):
+    // Regression: the backing ArrayBuffer was unsynchronized, so concurrent
+    // append vs. load could throw or corrupt state. Hammer it from several
+    // threads and assert it neither throws nor exceeds maxEntries.
+    val store = InMemoryHistoryStore(maxEntries = 50)
+    val threads = (0 until 8).map { t =>
+      new Thread(() => for i <- 0 until 500 do { store.append(s"e-$t-$i"); store.load(): Unit })
+    }
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+    assert(store.load().size <= 50)
+
   test("Ctrl+C exits without appending history"):
     val store = new StubStore(Vector("one"))
     val start = PromptHistory.initial(store)

--- a/modules/termflow-app/src/test/scala/termflow/tui/PromptSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/PromptSpec.scala
@@ -147,3 +147,23 @@ class PromptSpec extends AnyFunSuite:
   test("cursorColumn counts combining marks as 0 columns"):
     val state = Prompt.State(buffer = "é".toVector, cursor = 2)
     assert(Prompt.cursorColumn(state) == 1, "e=1, combining mark=0")
+
+  // ---- bracketed paste ----------------------------------------------------
+
+  test("Paste inserts text at the cursor and advances by its length"):
+    val state       = Prompt.State(buffer = Vector('a', 'd'), cursor = 1)
+    val (next, cmd) = Prompt.handleKey[String](state, InputKey.Paste("bc"))(noopToMsg)
+    assert(cmd.isEmpty)
+    assert(Prompt.render(next) == "abcd")
+    assert(next.cursor == 3)
+
+  test("Paste keeps only the first line of a multi-line payload"):
+    val (next, _) = Prompt.handleKey[String](Prompt.State(), InputKey.Paste("one\ntwo\r\nthree"))(noopToMsg)
+    assert(Prompt.render(next) == "one")
+    assert(next.cursor == 3)
+
+  test("Paste of empty text is a no-op"):
+    val state     = Prompt.State(buffer = Vector('a'), cursor = 1)
+    val (next, _) = Prompt.handleKey[String](state, InputKey.Paste(""))(noopToMsg)
+    assert(Prompt.render(next) == "a")
+    assert(next.cursor == 1)

--- a/modules/termflow-app/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
@@ -167,6 +167,55 @@ class TuiRuntimeSpec extends AnyFunSuite:
         }
     )
 
+  test("TuiRuntime surfaces an error when the FCmd success mapper throws"):
+    final class StopRuntime extends RuntimeException("stop-runtime")
+
+    val seenErr = new AtomicReference[Option[TermFlowError]](None)
+
+    val renderer = new TuiRenderer:
+      override def render(
+        textNode: RootNode,
+        err: Option[TermFlowError],
+        terminal: TerminalBackend,
+        renderMetrics: RenderMetrics
+      ): Unit =
+        err.foreach { e =>
+          seenErr.set(Some(e))
+          throw new StopRuntime
+        }
+
+    object App extends TuiApp[Int, Unit]:
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] =
+        Tui(
+          model = 0,
+          // The Future succeeds, but the success mapper blows up. Without the
+          // guard this throws on the execution-context thread and the runtime
+          // never sees either the intended command or an error.
+          cmd = Cmd.FCmd(
+            task = Future.successful(()),
+            toCmd = _ => throw new RuntimeException("mapper-boom"),
+            onEnqueue = None
+          )
+        )
+
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model)
+      override def view(model: Int): RootNode             = RootNode(80, 24, children = List.empty, input = None)
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val backend = new TestTerminalBackend
+    intercept[StopRuntime]:
+      TuiRuntime.run(
+        app = App,
+        renderer = renderer,
+        terminalBackend = backend,
+        config = TestConfig
+      )
+
+    assert(seenErr.get().exists {
+      case TermFlowError.Unexpected(msg, Some(_: RuntimeException)) => msg == "mapper-boom"
+      case _                                                        => false
+    })
+
   test("TuiRuntime dispatches GCmd and runs onEnqueue follow-up before completion"):
     enum Msg:
       case Step, Done

--- a/modules/termflow-app/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
+++ b/modules/termflow-app/src/test/scala/termflow/tui/TuiRuntimeSpec.scala
@@ -435,3 +435,54 @@ class TuiRuntimeSpec extends AnyFunSuite:
     val printed = backend.out.toString
     assert(!printed.contains(ANSI.enableBracketedPaste))
     assert(!printed.contains(ANSI.disableBracketedPaste))
+
+  final private class CapturingRenderer(onError: TermFlowError => Unit) extends TuiRenderer:
+    override def render(
+      textNode: RootNode,
+      err: Option[TermFlowError],
+      terminal: TerminalBackend,
+      renderMetrics: RenderMetrics
+    ): Unit = err.foreach(onError)
+
+  test("a throwing update is surfaced as an error banner without crashing the loop"):
+    val captured = new AtomicReference[Option[TermFlowError]](None)
+    val done     = scala.concurrent.Promise[Unit]()
+
+    object App extends TuiApp[Int, Unit]:
+      // onEnqueue = Some(()) publishes a GCmd(()) (which throws in update);
+      // the future, completed once the error banner renders, drives Exit.
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] =
+        Tui(0, Cmd.FCmd(done.future, _ => Cmd.Exit, onEnqueue = Some(())))
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] =
+        throw new RuntimeException("update boom")
+      override def view(model: Int): RootNode             = RootNode(80, 24, children = List.empty, input = None)
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val renderer = new CapturingRenderer(err =>
+      if captured.get().isEmpty then
+        captured.set(Some(err))
+        done.trySuccess(()): Unit
+    )
+    Console.withOut(new PrintStream(new ByteArrayOutputStream())):
+      TuiRuntime.run(app = App, renderer = renderer, terminalBackend = new TestTerminalBackend, config = TestConfig)
+    assert(captured.get().nonEmpty, "a throwing update should surface a TermFlowError")
+
+  test("a throwing view falls back to an error banner instead of crashing"):
+    val captured = new AtomicReference[Option[TermFlowError]](None)
+    val done     = scala.concurrent.Promise[Unit]()
+
+    object App extends TuiApp[Int, Unit]:
+      override def init(ctx: RuntimeCtx[Unit]): Tui[Int, Unit] =
+        Tui(0, Cmd.FCmd(done.future, _ => Cmd.Exit, onEnqueue = None))
+      override def update(model: Int, msg: Unit, ctx: RuntimeCtx[Unit]): Tui[Int, Unit] = Tui(model)
+      override def view(model: Int): RootNode             = throw new RuntimeException("view boom")
+      override def toMsg(input: PromptLine): Result[Unit] = Right(())
+
+    val renderer = new CapturingRenderer(err =>
+      if captured.get().isEmpty then
+        captured.set(Some(err))
+        done.trySuccess(()): Unit
+    )
+    Console.withOut(new PrintStream(new ByteArrayOutputStream())):
+      TuiRuntime.run(app = App, renderer = renderer, terminalBackend = new TestTerminalBackend, config = TestConfig)
+    assert(captured.get().nonEmpty, "a throwing view should surface a TermFlowError")

--- a/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -356,6 +356,40 @@ object AnsiRenderer:
     out.append(moveTo(x, y + (h - 1))).append(s"${chars.bottomLeft}$horizontal${chars.bottomRight}")
     out.append(reset)
 
+  /**
+   * Longest prefix of `s` whose rendered cell width is at most `maxCells`,
+   * never splitting a code point (so wide glyphs and surrogate pairs stay
+   * whole). For pure-ASCII input this returns `s.take(maxCells)`.
+   */
+  private def takeCells(s: String, maxCells: Int): String =
+    if maxCells <= 0 then ""
+    else
+      var w = 0
+      var i = 0
+      while i < s.length do
+        val cp = s.codePointAt(i)
+        val cw = math.max(0, WCWidth.codePointWidth(cp))
+        if w + cw > maxCells then return s.substring(0, i)
+        w += cw
+        i += java.lang.Character.charCount(cp)
+      s
+
+  /**
+   * Smallest char (UTF-16) index `i` such that `WCWidth.stringWidth(s.take(i))`
+   * is at least `targetCells`. Used to translate a desired scroll column back
+   * to a code-point boundary. For pure-ASCII input this returns `targetCells`.
+   */
+  private def charIndexAtCell(s: String, targetCells: Int): Int =
+    if targetCells <= 0 then 0
+    else
+      var w = 0
+      var i = 0
+      while i < s.length && w < targetCells do
+        val cp = s.codePointAt(i)
+        w += math.max(0, WCWidth.codePointWidth(cp))
+        i += java.lang.Character.charCount(cp)
+      i
+
   private def visibleInput(inp: InputNode, rootWidth: Int): VisibleInput =
     val clampedCursor =
       if inp.cursor >= 0 && inp.cursor <= inp.prompt.length then inp.cursor
@@ -363,29 +397,38 @@ object AnsiRenderer:
 
     val requestedWidth =
       if inp.lineWidth > 0 then inp.lineWidth
-      else math.max(1, inp.prompt.length + 1)
+      else math.max(1, WCWidth.stringWidth(inp.prompt) + 1)
 
     val remainingWidth = math.max(1, rootWidth - inp.x.value + 1)
     val width          = math.max(1, math.min(requestedWidth, remainingWidth))
     val prefixLength   = math.max(0, math.min(inp.prefixLength, inp.prompt.length))
-    val fixedPrefix    = inp.prompt.take(prefixLength).take(width)
+    // `width` is a cell budget, so clip the fixed prefix and scroll the
+    // editable suffix by rendered cell width — not UTF-16 length. Otherwise
+    // CJK/emoji input overflows the declared input width or scrolls past the
+    // cursor, even though cursor placement below already uses WCWidth.
+    val fixedPrefix    = takeCells(inp.prompt.take(prefixLength), width)
+    val prefixCells    = WCWidth.stringWidth(fixedPrefix)
     val suffix         = inp.prompt.drop(prefixLength)
-    val availableWidth = math.max(0, width - fixedPrefix.length)
+    val availableCells = math.max(0, width - prefixCells)
     val suffixCursor   = math.max(0, clampedCursor - prefixLength)
     val suffixStart =
-      if availableWidth == 0 then 0
+      if availableCells == 0 then 0
       else
-        val maxStart              = math.max(0, suffix.length - availableWidth)
-        val preferredRightContext = math.min(2, math.max(0, availableWidth - 1))
-        val desiredStart          = suffixCursor - availableWidth + preferredRightContext + 1
-        math.max(0, math.min(maxStart, desiredStart))
+        val suffixCells           = WCWidth.stringWidth(suffix)
+        val cursorCell            = WCWidth.stringWidth(suffix.take(suffixCursor))
+        val maxStartCell          = math.max(0, suffixCells - availableCells)
+        val preferredRightContext = math.min(2, math.max(0, availableCells - 1))
+        val desiredStartCell      = cursorCell - availableCells + preferredRightContext + 1
+        val startCell             = math.max(0, math.min(maxStartCell, desiredStartCell))
+        charIndexAtCell(suffix, startCell)
     val visibleSuffix =
-      if availableWidth == 0 then ""
-      else suffix.slice(suffixStart, suffixStart + availableWidth)
+      if availableCells == 0 then ""
+      else takeCells(suffix.drop(suffixStart), availableCells)
     val visibleText =
-      val text = fixedPrefix + visibleSuffix
-      if text.length >= width then text.take(width)
-      else text + (" " * (width - text.length))
+      val text  = fixedPrefix + visibleSuffix
+      val cells = WCWidth.stringWidth(text)
+      if cells >= width then text
+      else text + (" " * (width - cells))
 
     // Cursor column = sum of WCWidth across visible characters up to the
     // cursor's char index. This makes wide-char input (CJK, emoji) and
@@ -442,7 +485,7 @@ object AnsiRenderer:
         }
 
       case InputNode(x, y, prompt, _, _, lineWidth, _) =>
-        val w     = if lineWidth > 0 then lineWidth else prompt.length
+        val w     = if lineWidth > 0 then lineWidth else WCWidth.stringWidth(prompt)
         val right = x.value + math.max(0, w - 1)
         (right, y.value)
 

--- a/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/AnsiRenderer.scala
@@ -535,10 +535,20 @@ object AnsiRenderer:
         // Combining marks / variation selectors / control / zero-width:
         // attach them to the previous visible glyph so emoji presentation
         // sequences like U+2764 U+FE0F survive into the emitted cell text.
+        //
+        // Bounds-check the target cell explicitly: the leading glyph may have
+        // landed off-grid (e.g. an overlay child or overflowing layout drawn
+        // beyond the frame the grid was sized for), in which case `putCell`
+        // silently dropped it but `lastGlyphCol` still points past the array.
+        // Indexing `cells` directly there throws ArrayIndexOutOfBounds and
+        // crashes the whole render loop.
         else if lastGlyphCol >= 1 then
-          val prev  = cells(y - 1)(lastGlyphCol - 1)
-          val extra = str.substring(i, i + java.lang.Character.charCount(cp))
-          cells(y - 1)(lastGlyphCol - 1) = prev.copy(glyph = prev.renderedGlyph + extra)
+          val gx = lastGlyphCol - 1
+          val gy = y - 1
+          if gy >= 0 && gy < height && gx >= 0 && gx < width then
+            val prev  = cells(gy)(gx)
+            val extra = str.substring(i, i + java.lang.Character.charCount(cp))
+            cells(gy)(gx) = prev.copy(glyph = prev.renderedGlyph + extra)
         i += java.lang.Character.charCount(cp)
 
     def drawBorder(x: Int, y: Int, w: Int, h: Int, style: Style, chars: BorderChars): Unit =

--- a/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
@@ -470,14 +470,17 @@ object Layout:
   /** Natural `(width, height)` of a concrete [[VNode]]. */
   def measureVNode(v: VNode): (Int, Int) = v match
     case TextNode(_, _, segments) =>
-      val width = segments.foldLeft(0)((acc, seg) => acc + seg.txt.length)
+      // Rendered cell width, not UTF-16 length: wide (CJK/emoji) and
+      // combining text must measure the same here as the renderer draws,
+      // or siblings, fills, and hit-test zones land at the wrong column.
+      val width = segments.foldLeft(0)((acc, seg) => acc + WCWidth.stringWidth(seg.txt))
       (width, 1)
 
     case BoxNode(_, _, w, h, _, _, _) =>
       (math.max(0, w), math.max(0, h))
 
     case InputNode(_, _, prompt, _, _, lineWidth, _) =>
-      val width = if lineWidth > 0 then lineWidth else prompt.length
+      val width = if lineWidth > 0 then lineWidth else WCWidth.stringWidth(prompt)
       (width, 1)
 
   /**

--- a/modules/termflow-screen/src/test/scala/termflow/tui/AnsiRendererSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/AnsiRendererSpec.scala
@@ -419,6 +419,17 @@ class AnsiRendererSpec extends AnyFunSuite:
     assert(frame.cells(0)(2).ch == 'A')
     assert(frame.cells(0)(2).width == 1)
 
+  test("buildFrame does not crash on a combining mark drawn off-grid"):
+    // Regression: an overlay anchored beyond the frame the grid was sized
+    // for, whose child carries a combining mark, used to hit an unchecked
+    // `cells(y - 1)(lastGlyphCol - 1)` access and throw
+    // ArrayIndexOutOfBounds, crashing the render loop.
+    val child   = TextNode(XCoord(1), YCoord(1), List(Text("á", Style())))
+    val overlay = Overlay(OverlayPosition.At(XCoord(10), YCoord(10)), width = 2, height = 1, children = List(child))
+    val root    = RootNode(width = 5, height = 3, children = Nil, input = None, overlays = List(overlay))
+    val frame   = AnsiRenderer.buildFrame(root)
+    assert(frame.width == 5 && frame.height == 3)
+
   test("buildFrame preserves supplementary emoji glyphs instead of lone surrogates"):
     val root = RootNode(
       width = 4,

--- a/modules/termflow-screen/src/test/scala/termflow/tui/AnsiRendererSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/AnsiRendererSpec.scala
@@ -466,6 +466,24 @@ class AnsiRendererSpec extends AnyFunSuite:
     val frame = AnsiRenderer.buildFrame(root)
     assert(frame.width >= 6, s"expected frame width >= 6, got ${frame.width}")
 
+  test("input viewport bounds wide-char text to the declared cell width"):
+    // prompt is 4 CJK glyphs = 8 cells; lineWidth is 4 cells. The viewport
+    // must show only the last two glyphs (4 cells), not slice 4 *chars*
+    // (8 cells) and overflow. Cursor sits at the end.
+    val root = RootNode(
+      width = 20,
+      height = 1,
+      children = Nil,
+      input = Some(InputNode(XCoord(1), YCoord(1), prompt = "你好世界", style = Style(), cursor = 4, lineWidth = 4))
+    )
+    val frame = AnsiRenderer.buildFrame(root)
+    assert(frame.cells(0)(0).glyph == "世", "first visible cell is the scrolled-to glyph")
+    assert(frame.cells(0)(1).width == 0, "continuation cell after wide glyph")
+    assert(frame.cells(0)(2).glyph == "界")
+    assert(frame.cells(0)(3).width == 0, "continuation cell after wide glyph")
+    assert(frame.cells(0)(4).ch == ' ', "nothing rendered past the 4-cell budget")
+    assert(frame.cursor.contains(Coord(XCoord(5), YCoord(1))), "hardware cursor lands one cell past the last glyph")
+
   // ---- renderPatch / depth & extended overloads ----
 
   test("renderPatch default overload uses Ansi8 depth and extended styles"):

--- a/modules/termflow-screen/src/test/scala/termflow/tui/LayoutSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/LayoutSpec.scala
@@ -18,6 +18,13 @@ class LayoutSpec extends AnyFunSuite:
     val multi = TextNode(1.x, 1.y, List(Text("ab", Style()), Text("cde", Style())))
     assert(Layout.measureVNode(multi) == (5, 1))
 
+  test("measureVNode on TextNode measures rendered cell width, not UTF-16 length"):
+    // 2 CJK glyphs = 4 cells (not 2 chars); emoji surrogate pair = 2 cells
+    // (not 2 chars); a combining mark adds 0. Matches the renderer's WCWidth.
+    assert(Layout.measureVNode(tn("你好")) == (4, 1))
+    assert(Layout.measureVNode(tn("😀")) == (2, 1))
+    assert(Layout.measureVNode(tn("é")) == (1, 1)) // e + combining acute
+
   test("measureVNode on BoxNode returns declared dimensions"):
     assert(Layout.measureVNode(BoxNode(1.x, 1.y, 10, 4, children = Nil)) == (10, 4))
 

--- a/modules/termflow-terminal/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
+++ b/modules/termflow-terminal/src/main/scala/termflow/tui/ConsoleKeyPressSource.scala
@@ -28,6 +28,16 @@ object ConsoleKeyPressSource:
   private val DefaultModifierIfMissing: Int = 1
 
   /**
+   * Upper bound on the number of CSI parameter characters we buffer. A
+   * well-behaved terminal never sends more than a handful; the cap stops a
+   * malformed or hostile stream of digits from growing the buffer without
+   * limit. Excess digits are dropped — combined with the overflow-safe parse
+   * below, an over-long parameter degrades to `Unknown` rather than killing
+   * the decoder thread.
+   */
+  private val MaxCsiParamChars: Int = 64
+
+  /**
    * Top-level decoder: classifies a single byte as a printable, control,
    * standalone Escape, or the start of a CSI / SS3 sequence and dispatches
    * to the appropriate sub-parser.
@@ -83,7 +93,9 @@ object ConsoleKeyPressSource:
         done = true
       else
         val ch = n.intValue().toChar
-        if (ch >= '0' && ch <= '9') || ch == ';' then builder.append(ch)
+        if (ch >= '0' && ch <= '9') || ch == ';' then
+          // Drop overflow digits rather than buffering an unbounded run.
+          if builder.length < MaxCsiParamChars then builder.append(ch): Unit
         else if prefix == '\u0000' && (ch == '?' || ch == '<' || ch == '>' || ch == '!') then prefix = ch
         else
           finalByte = ch
@@ -93,7 +105,12 @@ object ConsoleKeyPressSource:
     else
       val params: Vector[Int] =
         if builder.isEmpty then Vector.empty
-        else builder.toString.split(";", -1).toVector.map(p => if p.isEmpty then 0 else p.toInt)
+        // `toIntOption` guards against parameter values that overflow `Int`
+        // (e.g. a malformed `CSI 99999999999999 A`). Before this guard the
+        // resulting `NumberFormatException` propagated out of the decoder
+        // thread, which then died and left keyboard/mouse input frozen for
+        // the rest of the session. Unparseable / empty params fall back to 0.
+        else builder.toString.split(";", -1).toVector.map(p => p.toIntOption.getOrElse(0))
       prefix match
         case '<'      => decodeSgrMouse(params, finalByte)
         case '\u0000' => csiToKey(params, finalByte, queueBridge)
@@ -206,9 +223,12 @@ object ConsoleKeyPressSource:
   private def decodeSgrMouse(params: Vector[Int], finalByte: Char): InputKey =
     if params.length < 3 then InputKey.Unknown(s"CSI <${params.mkString(";")}$finalByte")
     else
-      val button       = params(0)
-      val col          = params(1)
-      val row          = params(2)
+      val button = params(0)
+      // SGR mouse coordinates are 1-based; clamp to honour the invariant
+      // documented on `MouseEvent` so downstream `col - 1` indexing can't
+      // land at -1 if a terminal ever reports a 0.
+      val col          = math.max(1, params(1))
+      val row          = math.max(1, params(2))
       val releaseFinal = finalByte == 'm'
       // `fromSgr` returns None for the scroll-wheel release byte some
       // terminals duplicate after each press — surface as NoOp so the

--- a/modules/termflow-terminal/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
+++ b/modules/termflow-terminal/src/test/scala/termflow/tui/ConsoleKeyPressSourceSpec.scala
@@ -299,6 +299,22 @@ class ConsoleKeyPressSourceSpec extends AnyFunSuite:
       case InputKey.Unknown(_) => ()
       case other               => fail(s"expected Unknown, got $other")
 
+  test("CSI param that overflows Int does not kill the decoder thread"):
+    // Regression: a parameter too large for Int used to throw
+    // NumberFormatException on the decoder thread, which then died and left
+    // all keyboard/mouse input frozen. The oversized sequence must decode to
+    // Unknown and the *following* key must still be delivered.
+    val src = ConsoleKeyPressSource(new StringReader("[99999999999999Ax"))
+    try
+      // The exact decoding of the oversized sequence is unimportant (the
+      // overflowing param degrades to 0); what matters is that the decoder
+      // survives and still delivers the following 'x'.
+      src.next(): Unit
+      assert(src.next() == InputRead.Key(InputKey.CharKey('x')))
+    finally
+      assert(src.close().isSuccess)
+      ()
+
   // ---- Paste content reaching EOF before the end marker ----
 
   test("end-of-stream during paste collection flushes any partial match"):

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MenuBar.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MenuBar.scala
@@ -167,7 +167,7 @@ object MenuBar:
           val style =
             if sel then Style(fg = theme.background, bg = theme.primary, bold = true)
             else Style(fg = theme.foreground)
-          val padded = item.padTo(menu.items.map(_.length).max + 2, ' ')
+          val padded = item.padTo(dropdownInnerWidth(menu), ' ')
           TextNode(at.x + (left - 1), at.y + (1 + j), List(Text(padded, style)))
         }
         barNode :: itemNodes
@@ -194,12 +194,22 @@ object MenuBar:
         case Some(idx) =>
           val menu    = state.menus(idx)
           val left    = at.x.value + titleStartCol(state, idx) - 1
-          val width   = menu.items.map(_.length).max + 2
+          val width   = dropdownInnerWidth(menu)
           val itemRow = row - (at.y.value + 1)
           if itemRow < 0 || itemRow >= menu.items.size then None
           else if col < left || col >= left + width then None
           else Some(Right(itemRow))
         case None => None
+
+  /**
+   * Inner cell width of `menu`'s dropdown: the widest item label plus a
+   * two-cell padding. `maxOption` guards the empty-items case — an empty
+   * menu can still be opened via Enter/Arrow, and `Vector.empty.max` would
+   * otherwise throw `UnsupportedOperationException` from both [[apply]] and
+   * [[hitTest]].
+   */
+  private def dropdownInnerWidth(menu: Menu): Int =
+    menu.items.map(_.length).maxOption.getOrElse(0) + 2
 
   /**
    * Column offset (1-based, relative to `at.x`) where the title cell

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MultiLineInput.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MultiLineInput.scala
@@ -318,18 +318,33 @@ object MultiLineInput:
   ): VNode =
     val width = math.max(1, viewportWidth)
     val cur   = math.max(0, math.min(text.length, cursorCol))
-    val before =
-      if cur > 0 then text.substring(0, cur) else ""
-    val cursorChar =
-      if cur < text.length then text.substring(cur, math.min(text.length, cur + 1))
-      else " "
-    val after =
-      if cur < text.length then text.substring(math.min(text.length, cur + 1)) else ""
 
-    // Pad the row out to the viewport so reverse-video cell stays visible
-    // even when the buffer is shorter than the row.
-    val tail   = math.max(0, width - WCWidth.stringWidth(before) - WCWidth.stringWidth(cursorChar))
-    val padded = if after.length < tail then after + (" " * (tail - after.length)) else after
+    // The cursor row, unlike the other rows, used to emit the entire line
+    // verbatim — so a line longer than the viewport overflowed `width`
+    // (spilling past any surrounding box border). Horizontally scroll the
+    // row so it is always exactly `width` cells and the cursor stays visible.
+    val cursorCharWidth =
+      if cur < text.length then math.max(1, WCWidth.codePointWidth(text.codePointAt(cur))) else 1
+    val cursorCell = WCWidth.stringWidth(text.substring(0, cur))
+    // Pin the cursor to the right edge once the text to its left overflows,
+    // reserving enough columns for the (possibly wide) cursor glyph.
+    val startCell = math.max(0, cursorCell - math.max(0, width - cursorCharWidth))
+    val startIdx  = charIndexAtCell(text, startCell)
+
+    val before = clipToWidth(text.substring(startIdx, cur), width)
+    val rest   = text.substring(cur)
+    val (cursorChar, afterRaw) =
+      if rest.isEmpty then (" ", "")
+      else
+        val n = java.lang.Character.charCount(rest.codePointAt(0))
+        (rest.substring(0, n), rest.substring(n))
+
+    val usedCells = WCWidth.stringWidth(before) + WCWidth.stringWidth(cursorChar)
+    val after     = clipToWidth(afterRaw, math.max(0, width - usedCells))
+    // Pad out to the viewport so the reverse-video cell stays visible even
+    // when the (clipped) content is shorter than the row.
+    val pad    = math.max(0, width - usedCells - WCWidth.stringWidth(after))
+    val padded = after + (" " * pad)
     TextNode(
       at.x,
       at.y,
@@ -361,3 +376,20 @@ object MultiLineInput:
         w += add
         i += n
       sb.toString
+
+  /**
+   * Smallest UTF-16 index `i` such that `WCWidth.stringWidth(text.take(i))`
+   * is at least `targetCells`. Translates a desired horizontal scroll column
+   * back to a code-point boundary (never splitting a wide glyph or surrogate
+   * pair). For pure-ASCII input this returns `targetCells`.
+   */
+  private def charIndexAtCell(text: String, targetCells: Int): Int =
+    if targetCells <= 0 then 0
+    else
+      var w = 0
+      var i = 0
+      while i < text.length && w < targetCells do
+        val cp = text.codePointAt(i)
+        w += math.max(0, WCWidth.codePointWidth(cp))
+        i += java.lang.Character.charCount(cp)
+      i

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
@@ -92,8 +92,17 @@ object SplitPane:
     val gapClamped = math.max(0, math.min(gap, math.max(0, major - 2)))
     val available  = math.max(0, major - gapClamped)
     val ratio      = math.max(MinSizeRatio, math.min(1.0 - MinSizeRatio, splitRatio))
-    val firstSize  = math.max(1, (available * ratio).round.toInt)
-    val secondSize = math.max(1, available - firstSize)
+    // Cap firstSize at `available - 1` so the second pane always has room and
+    // `firstSize + gap + secondSize == major` holds exactly. Previously both
+    // sizes independently floored at 1, so for a small region the panes summed
+    // to more than `available` and the second pane (and divider) spilled past
+    // the region edge. When `available < 2` there is no room for two non-empty
+    // panes, so the surplus pane resolves to width/height 0 rather than
+    // overflowing.
+    val firstSize =
+      if available <= 1 then math.min(available, 1)
+      else math.max(1, math.min(available - 1, (available * ratio).round.toInt))
+    val secondSize = math.max(0, available - firstSize)
 
     direction match
       case Direction.Horizontal =>

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Table.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/Table.scala
@@ -127,19 +127,47 @@ object Table:
       val (nextBody, msg) = ListView.handleKey(state.body, key)(onSelect)
       (state.copy(body = nextBody), msg)
 
-  /** Pad / truncate `s` to exactly `w` cells using the given alignment. */
+  /** Pad / truncate `s` to exactly `w` *display cells* using the alignment. */
   private def align(s: String, w: Int, align: Align): String =
     if w <= 0 then ""
-    else if s.length >= w then s.take(w)
     else
-      val pad = w - s.length
-      align match
-        case Align.Left  => s + " " * pad
-        case Align.Right => " " * pad + s
-        case Align.Center =>
-          val left  = pad / 2
-          val right = pad - left
-          " " * left + s + " " * right
+      // Measure in display cells, not UTF-16 length, so wide (CJK/emoji)
+      // content aligns to the column grid and truncation never splits a
+      // surrogate pair or a wide glyph.
+      val clipped = clipToCells(s, w)
+      val sw      = WCWidth.stringWidth(clipped)
+      if sw >= w then clipped
+      else
+        val pad = w - sw
+        align match
+          case Align.Left  => clipped + " " * pad
+          case Align.Right => " " * pad + clipped
+          case Align.Center =>
+            val left  = pad / 2
+            val right = pad - left
+            " " * left + clipped + " " * right
+
+  /** Longest prefix of `s` whose display width is at most `maxCells`. */
+  private def clipToCells(s: String, maxCells: Int): String =
+    if maxCells <= 0 then ""
+    else
+      val sb = new StringBuilder
+      var w  = 0
+      var i  = 0
+      while i < s.length do
+        val cp = s.codePointAt(i)
+        val cw = math.max(0, WCWidth.codePointWidth(cp))
+        if w + cw > maxCells then return sb.toString
+        sb.append(s.substring(i, i + java.lang.Character.charCount(cp)))
+        w += cw
+        i += java.lang.Character.charCount(cp)
+      sb.toString
+
+  /** Clip `s` to `cells` display cells, then right-pad with spaces to fill. */
+  private def fitToCells(s: String, cells: Int): String =
+    val clipped = clipToCells(s, cells)
+    val w       = WCWidth.stringWidth(clipped)
+    if w >= cells then clipped else clipped + " " * (cells - w)
 
   /** Total visible width = sum of column widths + single-space separators between them. */
   def width[A](columns: Vector[Column[A]]): Int =
@@ -182,7 +210,7 @@ object Table:
 
     val headerStyle  = Style(fg = theme.primary, bold = true)
     val dividerStyle = Style(fg = theme.primary)
-    val headerText   = formatHeader(cols).take(totalW).padTo(totalW, ' ')
+    val headerText   = fitToCells(formatHeader(cols), totalW)
     val dividerText  = "─" * totalW
 
     val headerRow  = TextNode(at.x, at.y, List(Text(headerText, headerStyle)))
@@ -199,7 +227,7 @@ object Table:
       if idx >= state.size then TextNode(at.x, rowY, List(Text(" " * totalW, Style())))
       else
         val rowData    = state.rows(idx)
-        val rendered   = formatRow(cols, rowData).take(totalW).padTo(totalW, ' ')
+        val rendered   = fitToCells(formatRow(cols, rowData), totalW)
         val isSelected = state.selectable && idx == state.body.selected
         val showCursor = isSelected && focused
         val style =

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/TextField.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/TextField.scala
@@ -253,10 +253,20 @@ object TextField:
     val padded          = padToWidth(clipped, width)
 
     if focused then
-      val cIdx        = math.min(width - 1, math.max(0, state.cursor))
-      val before      = padded.take(cIdx)
-      val cursorChar  = padded.charAt(cIdx).toString
-      val after       = padded.drop(cIdx + 1)
+      // `state.cursor` is a UTF-16 code-unit offset, but `padded` is measured
+      // in display cells — the two diverge as soon as the buffer holds a wide
+      // (CJK/emoji) or zero-width glyph, so indexing `padded` by the raw
+      // cursor threw StringIndexOutOfBounds (and split surrogate pairs even
+      // when it didn't throw). Split on the cursor's *display column* instead.
+      val safeCursor = math.max(0, math.min(state.buffer.length, state.cursor))
+      val cursorCol  = math.min(width - 1, WCWidth.stringWidth(state.buffer.take(safeCursor)))
+      val before     = clipToWidth(padded, cursorCol)
+      val rest       = padded.substring(before.length)
+      val (cursorChar, after) =
+        if rest.isEmpty then (" ", "")
+        else
+          val n = java.lang.Character.charCount(rest.codePointAt(0))
+          (rest.substring(0, n), rest.substring(n))
       val baseStyle   = Style(fg = theme.primary)
       val cursorStyle = Style(fg = theme.background, bg = theme.primary)
       TextNode(

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MenuBarSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MenuBarSpec.scala
@@ -118,3 +118,13 @@ class MenuBarSpec extends AnyFunSuite:
     assert(MenuBar.hitTest(sample, at, col = 999, row = 1).isEmpty)
     assert(MenuBar.hitTest(sample, at, col = 1, row = 99).isEmpty)
   }
+
+  test("an opened empty-items menu does not crash apply / hitTest") {
+    // Regression: `menu.items.map(_.length).max` threw on empty items once
+    // such a menu was opened.
+    val st0    = MenuBar.State(menus = Vector(MenuBar.Menu("File", Vector.empty)))
+    val opened = MenuBar.handleKey(st0, KeyDecoder.InputKey.Enter).state
+    val at     = Coord(1.x, 1.y)
+    assert(MenuBar.apply(opened, at).nonEmpty)                    // render must not throw
+    assert(MenuBar.hitTest(opened, at, col = 3, row = 2).isEmpty) // hit-test must not throw
+  }

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MultiLineInputSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MultiLineInputSpec.scala
@@ -216,6 +216,17 @@ class MultiLineInputSpec extends AnyFunSuite:
     val texts = nodes.map { case t: TextNode => t.txt.map(_.txt).mkString; case _ => "" }
     assert(texts.last.startsWith("line-9"))
 
+  test("cursor row is clipped to the viewport width and keeps the cursor visible"):
+    // Regression: the cursor row emitted the whole line verbatim, so a line
+    // longer than the viewport overflowed `width` cells. It must now render
+    // exactly `width` cells with the cursor scrolled into view.
+    val long  = "x" * 100
+    val s     = MultiLineInput.State(lines = Vector(long), cursorRow = 0, cursorCol = 80)
+    val nodes = MultiLineInput.render(s, width = 10, height = 1)
+    assert(nodes.size == 1)
+    val rowText = nodes.head.asInstanceOf[TextNode].txt.map(_.txt).mkString
+    assert(WCWidth.stringWidth(rowText) == 10, s"row width ${WCWidth.stringWidth(rowText)} for [$rowText]")
+
   test("render returns Nil for non-positive size"):
     val s = MultiLineInput.State.empty
     assert(MultiLineInput.render(s, width = 0, height = 5).isEmpty)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
@@ -21,6 +21,24 @@ class SplitPaneSpec extends AnyFunSuite:
     assert(l.divider.isEmpty)
   }
 
+  test("panes never overflow a small region (first + gap + second <= major)") {
+    // Regression: independent max(1, ...) floors let the panes sum to more
+    // than the region, so the second pane / divider spilled past the edge.
+    for
+      w     <- 1 to 6
+      gap   <- 0 to 2
+      ratio <- Seq(0.05, 0.5, 0.95)
+    do
+      val l = SplitPane.layout(SplitPane.Direction.Horizontal, width = w, height = 3, splitRatio = ratio, gap = gap)
+      val dividerW = l.divider.map(_.width).getOrElse(0)
+      assert(
+        l.first.width + dividerW + l.second.width <= w,
+        s"overflow at w=$w gap=$gap ratio=$ratio: ${l.first.width}+$dividerW+${l.second.width} > $w"
+      )
+      // The second pane must also stay within the region's right edge.
+      assert(l.second.at.x.value + l.second.width - 1 <= w, s"second pane past edge at w=$w gap=$gap ratio=$ratio")
+  }
+
   test("horizontal split with gap reserves a divider rect") {
     val l = SplitPane.layout(SplitPane.Direction.Horizontal, width = 10, height = 3, splitRatio = 0.5, gap = 2)
     assert(l.divider.isDefined)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/TableSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/TableSpec.scala
@@ -101,6 +101,19 @@ class TableSpec extends AnyFunSuite:
     // Name col width=6; "strawberry" truncated to "strawb".
     assert(r.startsWith("strawb"))
 
+  test("formatRow aligns wide (CJK) content by display width, not char count"):
+    // A column of width 4 holding a 2-cell glyph pads to 4 *cells*, and a
+    // wide overflow truncates on a glyph boundary (no lone surrogate / half).
+    val wcols = Vector(
+      Table.Column[String]("h", width = 4, align = Table.Align.Left, render = identity)
+    )
+    val padded = Table.formatRow(wcols, "中")
+    assert(WCWidth.stringWidth(padded) == 4, s"width ${WCWidth.stringWidth(padded)} for [$padded]")
+    assert(padded == "中  ")
+    val truncated = Table.formatRow(wcols, "中文字")
+    assert(WCWidth.stringWidth(truncated) == 4, s"width ${WCWidth.stringWidth(truncated)} for [$truncated]")
+    assert(truncated == "中文")
+
   // --- rendering -----------------------------------------------------------
 
   private def render(v: VNode, width: Int, height: Int): (Array[Array[Char]], Array[Array[Style]]) =

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/TextFieldSpec.scala
@@ -275,6 +275,21 @@ class TextFieldSpec extends AnyFunSuite:
     assert(cs.mkString == "abcd")
     assert(styles(3).bg == Theme.dark.primary)
 
+  test("focused field with wide chars and cursor at end renders without crashing"):
+    // Regression: cursor (a UTF-16 offset) was used to index the
+    // display-cell-measured padded string, throwing StringIndexOutOfBounds
+    // once the buffer held wide glyphs.
+    val s     = TextField.State(buffer = "你好", cursor = 2)
+    val v     = TextField.view(s, lineWidth = 4, focused = true)
+    val frame = AnsiRenderer.buildFrame(RootNode(4, 1, List(v), None))
+    assert(frame.width == 4)
+
+  test("focused cursor lands on the whole wide glyph (no surrogate/half-char split)"):
+    // buffer "a中b", cursor after 'a' (offset 1) → cursor cell is the wide 中.
+    val s = TextField.State(buffer = "a中b", cursor = 1)
+    val v = TextField.view(s, lineWidth = 6, focused = true)
+    assert(v.asInstanceOf[TextNode].txt(1).txt == "中")
+
   test("wide glyphs render intact without overpadding"):
     val v     = TextField.view(TextField.State.of("中"), lineWidth = 3)
     val frame = AnsiRenderer.buildFrame(RootNode(3, 1, List(v), None))


### PR DESCRIPTION
## Summary

A thorough bug-hunt review of TermFlow turned up four input/render **crashes** and several correctness/robustness weaknesses. This PR fixes all of them, one focused commit per finding, each with a regression test. The first commit (`dffeed3`) is the pre-existing width-aware input/layout base this branch was already built on; the ten that follow are the review fixes.

Every fix was reproduced with a failing test first, then made to pass. `sbt ciCheck` is green (1178 tests, scalafmt + scalafix clean).

## Fixes (one commit each)

**Crashes (High)**
- **CSI parameter overflow froze all input.** An oversized/malformed CSI numeric param (e.g. `ESC [ 99999999999999 A`, or a junk SGR mouse report) threw `NumberFormatException` on the decoder thread, which then died and left `next()` blocked forever — keyboard and mouse silently dead for the session. Now parsed with `toIntOption` (+ a digit-run cap); SGR mouse col/row clamped to ≥1.
- **`buildFrame` crashed on a combining mark drawn off-grid.** The combining-mark attachment bypassed `putCell`'s bounds check, so an overlay child / overflowing layout beyond the sized grid threw `ArrayIndexOutOfBounds` and crashed the render loop. Now bounds-guarded.
- **`TextField.view` crashed on wide/zero-width chars.** The cursor (UTF-16 offset) indexed the cell-measured display string → `StringIndexOutOfBounds` (e.g. buffer `你好`, cursor 2). Now splits on the cursor's display column.
- **`MenuBar` crashed when an empty-items menu was opened.** `items.map(_.length).max` threw on empty (`hitTest` unconditionally). Now guarded with `maxOption`.

**Correctness / robustness (Medium)**
- **`MultiLineInput` cursor row overflowed the viewport** — it emitted the whole line verbatim while other rows clipped. Now horizontally scrolls/clips to exactly `width` cells.
- **`Table` columns misaligned on CJK/emoji** — padded/truncated by `String.length` instead of display width (and could split a surrogate). Now WCWidth-aware.
- **`Dialogs` list highlight vanished** when `selectedIndex` was briefly out of range (e.g. list shrank before re-clamp). Now clamps the highlight to match the scroll anchor.
- **`SplitPane` panes overflowed a small region** — independent `max(1,…)` floors let `first + gap + second` exceed the region. Now `firstSize` is capped so the invariant holds.
- **A throwing `update`/`view` killed the whole app.** The FCmd async mapper was guarded but the sync paths weren't. Now both surface a `TermFlowError` banner and keep the app alive.

**Low**
- **`InMemoryHistoryStore`** wrapped an unsynchronized `ArrayBuffer` (runtime loop vs. input decoder threads) — now lock-guarded.
- **Devtools ScalaDoc** demonstrated `history.at(idx).get` / `rewindTo(idx).get`, which throw after ring-buffer eviction across ticks — replaced with the safe `Option`-matching pattern.

## Test plan
- `sbt ciCheck` — all suites pass, formatting + scalafix clean.
- New regression tests accompany each fix (terminal/screen/widgets/app modules).
