### PR TITLE
Fix border corner overlap

### DIFF
--- a/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
@@ -179,12 +179,17 @@ enum Layout:
   case Grid(columns: Int, rowGap: Int, colGap: Int, cells: List[GridCell])
 
   /**
-   * Five-zone border layout: top and bottom span the full width, left and
-   * right take their natural width and fill the middle band, center fills
-   * what's left. Any zone may be `None` and its space collapses.
+   * Five-zone border layout: top and bottom span the middle columns (the
+   * span between the left and right zones), left and right take their
+   * natural width and fill the middle band, center fills what's left. Any
+   * zone may be `None` and its space collapses.
    *
    * **Sizing.** Designed for a budgeted resolve. With a budget:
-   *   - `top` / `bottom` each take their natural height; full width.
+   *   - `top` / `bottom` each take their natural height and span the middle
+   *     columns: their width is `availableWidth - left.w - right.w` and they
+   *     start at `left.w` (the CSS-grid "header spans the middle columns"
+   *     convention). When neither `left` nor `right` is present this is the
+   *     full width.
    *   - `left` / `right` each take their natural width; the middle band's
    *     height is `availableHeight - top.h - bottom.h - 2*gap` (gap is only
    *     subtracted when both border zones are present).
@@ -195,17 +200,18 @@ enum Layout:
    * bottom.w), top.h + gap + max(left.h, center.h, right.h) + gap +
    * bottom.h)` with gap terms only when the adjacent zones are non-empty.
    *
-   * **Out of scope.** Independent gaps for the four borders; alignment of
-   * shorter top/bottom strips against the left/right edges (today they
-   * span the full width even when adjacent corners are occupied by left/
-   * right zones). Hit-test passthrough works because any zone can be a
-   * [[Zone]].
+   * Insetting the top/bottom strips by the left/right widths keeps the
+   * corner columns clear, so a five-zone bordered box no longer draws
+   * overlapping / inconsistent corners (issue #209).
    *
-   * @param top    Optional top zone (full width, natural height).
+   * **Out of scope.** Independent gaps for the four borders. Hit-test
+   * passthrough works because any zone can be a [[Zone]].
+   *
+   * @param top    Optional top zone (middle-column width, natural height).
    * @param left   Optional left zone (natural width, middle-band height).
    * @param center Optional center zone (fills remaining rectangle).
    * @param right  Optional right zone (natural width, middle-band height).
-   * @param bottom Optional bottom zone (full width, natural height).
+   * @param bottom Optional bottom zone (middle-column width, natural height).
    * @param gap    Cells between adjacent zones; clamps to 0.
    */
   case Border(
@@ -715,9 +721,10 @@ object Layout:
 
   /**
    * Resolve a [[Border]] at `at`. With a budget, top / bottom take their
-   * natural height across the full width; left / right take their natural
-   * width down the middle band; center fills the remainder. Without a
-   * budget every zone takes its natural size.
+   * natural height across the middle columns (inset by the left / right
+   * widths so the corner columns stay clear); left / right take their
+   * natural width down the middle band; center fills the remainder. Without
+   * a budget every zone takes its natural size.
    */
   private def resolveBorder[Id](
     b: Border,
@@ -788,12 +795,18 @@ object Layout:
         case Some(bb) => out ++= resolveTrackedImpl(zone, origin, w, h, bb)
         case None     => out ++= resolveTo(zone, origin, w, h)
 
-    b.top.foreach(z => emit(z, Coord(XCoord(leftX), YCoord(topY)), budgetW, topActualH))
+    // Inset top/bottom to the middle columns so the corner columns owned by
+    // left/right stay clear (issue #209). Collapses to the full width when
+    // neither left nor right is present.
+    val midX     = leftX + leftActualW
+    val midSpanW = math.max(0, budgetW - leftActualW - rightActualW)
+
+    b.top.foreach(z => emit(z, Coord(XCoord(midX), YCoord(topY)), midSpanW, topActualH))
     if midH > 0 then
       b.left.foreach(z => emit(z, Coord(XCoord(leftX), YCoord(midY)), leftActualW, midH))
       b.center.foreach(z => emit(z, Coord(XCoord(centerX), YCoord(midY)), centerW2, midH))
       b.right.foreach(z => emit(z, Coord(XCoord(rightX), YCoord(midY)), rightActualW, midH))
-    b.bottom.foreach(z => emit(z, Coord(XCoord(leftX), YCoord(botY)), budgetW, botActualH))
+    b.bottom.foreach(z => emit(z, Coord(XCoord(midX), YCoord(botY)), midSpanW, botActualH))
     out.result()
 
   /**

--- a/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
+++ b/modules/termflow-screen/src/main/scala/termflow/tui/Layout.scala
@@ -195,10 +195,14 @@ enum Layout:
    *     subtracted when both border zones are present).
    *   - `center` consumes the rest.
    *
-   * Without a budget, every zone takes its natural size; the overall
-   * measure is `(max(top.w, left.w + gap + center.w + gap + right.w,
-   * bottom.w), top.h + gap + max(left.h, center.h, right.h) + gap +
-   * bottom.h)` with gap terms only when the adjacent zones are non-empty.
+   * Without a budget, every zone takes its natural size. Because top/bottom
+   * are inset between the left/right zones, the width they contribute is
+   * `left.w + top.w + right.w` (and likewise for bottom), so the overall
+   * measure is `(max(left.w + top.w + right.w, left.w + gap + center.w + gap
+   * + right.w, left.w + bottom.w + right.w), top.h + gap + max(left.h,
+   * center.h, right.h) + gap + bottom.h)` with gap terms only when the
+   * adjacent zones are non-empty. The left/right widths are zero when those
+   * zones are absent, so the band's width collapses to its own natural width.
    *
    * Insetting the top/bottom strips by the left/right widths keeps the
    * corner columns clear, so a five-zone bordered box no longer draws
@@ -465,7 +469,12 @@ object Layout:
         case n if n >= 2 => g * (n - 1)
         case _           => 0
     val midRowW = leftW + centerW + rightW + midRowGap
-    val width   = List(topW, midRowW, botW).max
+    // Top/bottom are inset between the left/right zones (issue #209), so the
+    // width they need is left.w + band.w + right.w. (left/right widths are 0
+    // when absent, collapsing to the band's own width.)
+    val topBandW = leftW + topW + rightW
+    val botBandW = leftW + botW + rightW
+    val width    = List(topBandW, midRowW, botBandW).max
     val verticalGap =
       List(b.top.isDefined, midH > 0, b.bottom.isDefined).count(identity) match
         case n if n >= 2 => g * (n - 1)
@@ -724,7 +733,9 @@ object Layout:
    * natural height across the middle columns (inset by the left / right
    * widths so the corner columns stay clear); left / right take their
    * natural width down the middle band; center fills the remainder. Without
-   * a budget every zone takes its natural size.
+   * a budget every zone takes its natural size, and the synthesised width
+   * leaves room for the inset top/bottom (`left.w + band.w + right.w`) so a
+   * wide top/bottom keeps its full width instead of being clipped.
    */
   private def resolveBorder[Id](
     b: Border,
@@ -745,7 +756,10 @@ object Layout:
       else
         val midZones = List(b.left, b.center, b.right).count(_.isDefined)
         val midGap   = if midZones >= 2 then gap * (midZones - 1) else 0
-        List(topW, leftW + centerW + rightW + midGap, botW).max
+        // Top/bottom are inset between left/right (issue #209): the width they
+        // need is left.w + band.w + right.w, so they keep their full natural
+        // width in the inset position. left/right widths are 0 when absent.
+        List(leftW + topW + rightW, leftW + centerW + rightW + midGap, leftW + botW + rightW).max
     val budgetH =
       if availableHeight >= 0 then availableHeight
       else

--- a/modules/termflow-screen/src/test/scala/termflow/tui/LayoutBorderSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/LayoutBorderSpec.scala
@@ -103,6 +103,44 @@ class LayoutBorderSpec extends AnyFunSuite:
     assert(!hits.hit(1, 5).contains("bottom"))
     assert(!hits.hit(20, 5).contains("bottom"))
 
+  test("Border (unbudgeted) keeps a wide top at full natural width, corners clear (issue #209)"):
+    // top is wider than the left+center+right mid row. The unbudgeted resolve
+    // must synthesise enough width for the inset top (left.w + top.w + right.w)
+    // so the top is not clipped, and the measured size must match what's drawn.
+    val b = Layout.border(
+      top = Layout.Elem(tn("TTTTTTTT")), // (8, 1)
+      left = Layout.Elem(tn("L")),       // (1, 1)
+      center = Layout.Elem(tn("C")),     // (1, 1)
+      right = Layout.Elem(tn("R")),      // (1, 1)
+      bottom = Layout.Elem(tn("B")),     // (1, 1)
+      gap = 0
+    )
+    // Natural width = left.w + top.w + right.w = 1 + 8 + 1 = 10; height = 3.
+    assert(b.measure == (10, 3))
+
+    val (_, hits) = Layout.resolveTracked[String](
+      Layout.border(
+        top = Layout.zone("top", tn("TTTTTTTT")),
+        left = Layout.zone("left", tn("L")),
+        center = Layout.zone("center", tn("C")),
+        right = Layout.zone("right", tn("R")),
+        bottom = Layout.zone("bottom", tn("B")),
+        gap = 0
+      ),
+      Coord(1.x, 1.y),
+      availableWidth = -1,
+      availableHeight = -1
+    )
+    // Top keeps its full 8-column width, inset by left.w to x = 2..9, leaving
+    // the corner columns x = 1 and x = 10 clear.
+    assert(hits.hit(2, 1).contains("top"))
+    assert(hits.hit(9, 1).contains("top"))
+    assert(!hits.hit(1, 1).contains("top"))
+    assert(!hits.hit(10, 1).contains("top"))
+    // Left/right own the corner columns in the middle band (row 2).
+    assert(hits.hit(1, 2).contains("left"))
+    assert(hits.hit(10, 2).contains("right"))
+
   test("Border collapses the middle band when none of left/center/right are set"):
     val b = Layout.border(
       top = Layout.Elem(tn("T")),

--- a/modules/termflow-screen/src/test/scala/termflow/tui/LayoutBorderSpec.scala
+++ b/modules/termflow-screen/src/test/scala/termflow/tui/LayoutBorderSpec.scala
@@ -76,6 +76,33 @@ class LayoutBorderSpec extends AnyFunSuite:
     // Center fills x=2..19 on rows 2..4.
     assert(hits.hit(10, 3).contains("center"))
 
+  test("Border insets top/bottom so corner columns stay clear of left/right (issue #209)"):
+    val (_, hits) = Layout.resolveTracked[String](
+      Layout.border(
+        top = Layout.zone("top", tn("T")),
+        left = Layout.zone("left", tn("L")),
+        center = Layout.zone("center", tn("C")),
+        right = Layout.zone("right", tn("R")),
+        bottom = Layout.zone("bottom", tn("B")),
+        gap = 0
+      ),
+      Coord(1.x, 1.y),
+      20,
+      5
+    )
+    // left.w = right.w = 1, so top/bottom span only the middle columns
+    // (x = 2..19). The corner columns (x = 1, x = 20) are left for the
+    // left/right zones in the middle band and must not be claimed by
+    // top/bottom — otherwise the corners overlap.
+    assert(hits.hit(2, 1).contains("top"))
+    assert(hits.hit(19, 1).contains("top"))
+    assert(!hits.hit(1, 1).contains("top"))
+    assert(!hits.hit(20, 1).contains("top"))
+    assert(hits.hit(2, 5).contains("bottom"))
+    assert(hits.hit(19, 5).contains("bottom"))
+    assert(!hits.hit(1, 5).contains("bottom"))
+    assert(!hits.hit(20, 5).contains("bottom"))
+
   test("Border collapses the middle band when none of left/center/right are set"):
     val b = Layout.border(
       top = Layout.Elem(tn("T")),


### PR DESCRIPTION
# Decisions — fix 5-zone Layout.Border corner overlap (#209)

## What changed
- `Layout.scala` `resolveBorder`: top/bottom zones are now inset to the middle
  columns. Added `midX = leftX + leftActualW` and
  `midSpanW = max(0, budgetW - leftActualW - rightActualW)`; the top/bottom
  `emit` calls use `midX` as x-origin and `midSpanW` as width (previously
  `leftX` / `budgetW`).
- Updated both `Border` ScalaDoc blocks: removed the "top/bottom span full
  width / corner overlap is out-of-scope" note; documented the inset and that
  it collapses to full width when neither left nor right is present.
- Added test `Border insets top/bottom so corner columns stay clear...` in
  `LayoutBorderSpec.scala` pinning that, in a 20×5 five-zone border (left.w =
  right.w = 1), top/bottom cover x=2..19 but NOT the corner columns x=1/x=20.

## Why / approach
- Made the inset the **default** (not gated behind an option) per the brief's
  preference. Inset is by `leftActualW` / `rightActualW` only (not gaps), the
  "header spans the middle columns" convention, matching the brief.
- When left/right are absent, `leftActualW`/`rightActualW` are 0, so
  `midX == leftX` and `midSpanW == budgetW` — full-width behaviour is preserved
  for the common top+center / top+center+bottom cases.

## Compatibility / risk
- Existing 5-zone test asserts `hit(10,1)`/`hit(10,5)` (middle column) — still
  within the inset span, so it passes unchanged. No test asserted the corner
  columns, so nothing depended on the old full-width corners.
- Full `sbt ciCheck` passes (fmt/scalafix/tests).
- Risk: a downstream app relying on top/bottom hit-test rects covering the
  corner columns would see them shrink by left/right width. Considered low —
  that was the buggy behaviour being fixed.
- Pre-existing unused-`val b` warning in the older 5-zone test left untouched
  (out of scope).

## Follow-up: natural-size consistency (codex P2)

Codex flagged the unbudgeted path as inconsistent: `budgetW = max(topW, midRow,
botW)`, so when top/bottom is the widest zone, `budgetW == topW` but
`midSpanW = topW - left.w - right.w` clipped the top, and the reported natural
width disagreed with what was drawn. Concern was valid.

Fix (both must stay in lockstep — `measure` uses `measureBorder`, `resolveTo`
uses `resolveBorder`):
- `resolveBorder` unbudgeted `budgetW`: top/bottom band width is now
  `left.w + top.w + right.w` (resp. bottom), so the inset top keeps its full
  natural width. `List(leftW + topW + rightW, midRowW, leftW + botW + rightW).max`.
- `measureBorder`: same change — `width = max(leftW+topW+rightW, midRowW,
  leftW+botW+rightW)`.
- Relies on `leftW`/`rightW` being 0 when those zones are absent (the
  `fold((0,0))`), so collapse-to-full-width is automatic; budgeted path
  untouched.
- Updated `Border` + `resolveBorder` ScalaDoc to state the natural width is
  `left.w + band.w + right.w`.
- New test `Border (unbudgeted) keeps a wide top at full natural width...`:
  top.w=8 wider than the 3-wide mid row, asserts `measure == (10,3)`, top spans
  x=2..9 (full 8 cols), corners x=1/x=10 clear, left/right own corners in mid band.
- ciCheck green.
