### PR TITLE
Splitpane drag symmetry

### DIFF
--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/SplitPane.scala
@@ -242,17 +242,24 @@ object SplitPane:
     col: Int,
     row: Int
   ): Double =
+    // Map the pointer onto a symmetric raw ratio in [0, 1]: the first and
+    // last cells of the region map to exactly 0 and 1, so the reachable
+    // range is symmetric about the centre (0.5) before `clampRatio`. Using
+    // `span - 1` as the denominator (rather than `span`, with a `+1` bias)
+    // is what makes far-left and far-right drags mirror images.
     direction match
       case Direction.Horizontal =>
         val span    = math.max(1, width)
-        val rel     = col - at.x.value + 1 // 1..width inside the region
-        val clamped = math.max(1, math.min(span, rel))
-        clamped.toDouble / span
+        val denom   = math.max(1, span - 1)
+        val rel     = col - at.x.value // 0..width-1 inside the region
+        val clamped = math.max(0, math.min(span - 1, rel))
+        clamped.toDouble / denom
       case Direction.Vertical =>
         val span    = math.max(1, height)
-        val rel     = row - at.y.value + 1
-        val clamped = math.max(1, math.min(span, rel))
-        clamped.toDouble / span
+        val denom   = math.max(1, span - 1)
+        val rel     = row - at.y.value // 0..height-1 inside the region
+        val clamped = math.max(0, math.min(span - 1, rel))
+        clamped.toDouble / denom
 
   private def clampRatio(ratio: Double): Double =
     math.max(MinSizeRatio, math.min(1.0 - MinSizeRatio, ratio))

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/SplitPaneSpec.scala
@@ -114,8 +114,8 @@ class SplitPaneSpec extends AnyFunSuite:
     val armed = SplitPane.DragState(0.5, dragging = true)
     val ev    = MouseEvent.Drag(MouseButton.Left, col = 15, row = 3, mods)
     val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
-    // 15 / 20 = 0.75
-    assert(math.abs(next.splitRatio - 0.75) < 1e-6, s"expected ~0.75, got ${next.splitRatio}")
+    // rel = (15 - 1) = 14 of 19 (= width - 1) → 14/19
+    assert(math.abs(next.splitRatio - 14.0 / 19.0) < 1e-6, s"expected ~${14.0 / 19.0}, got ${next.splitRatio}")
     assert(next.dragging, "still dragging")
   }
 
@@ -124,8 +124,8 @@ class SplitPaneSpec extends AnyFunSuite:
     val ev    = MouseEvent.Release(MouseButton.Left, col = 5, row = 3, mods)
     val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Horizontal, 20, 5, gap = 1)
     assert(!next.dragging, "release ends the drag")
-    // 5 / 20 = 0.25
-    assert(math.abs(next.splitRatio - 0.25) < 1e-6, s"expected 0.25, got ${next.splitRatio}")
+    // rel = (5 - 1) = 4 of 19 (= width - 1) → 4/19
+    assert(math.abs(next.splitRatio - 4.0 / 19.0) < 1e-6, s"expected ${4.0 / 19.0}, got ${next.splitRatio}")
   }
 
   test("Release outside the region keeps the previous ratio (no snap-back)") {
@@ -157,6 +157,35 @@ class SplitPaneSpec extends AnyFunSuite:
     val armed = SplitPane.DragState(0.5, dragging = true)
     val ev    = MouseEvent.Drag(MouseButton.Left, col = 5, row = 8, mods)
     val next  = SplitPane.handleMouse(armed, ev, SplitPane.Direction.Vertical, 10, 16, gap = 1)
-    // 8 / 16 = 0.5 — but cursor inside the region from the top.
-    assert(math.abs(next.splitRatio - 0.5) < 1e-6, s"expected ~0.5, got ${next.splitRatio}")
+    // rel = (8 - 1) = 7 of 15 (= height - 1) → 7/15
+    assert(math.abs(next.splitRatio - 7.0 / 15.0) < 1e-6, s"expected ~${7.0 / 15.0}, got ${next.splitRatio}")
+  }
+
+  // ---- drag symmetry (regression for llm4s/termflow#208) ------------------
+
+  test("far-left and far-right horizontal drags are mirror images about 0.5") {
+    // The divider should reach both ends symmetrically: a drag d cells in
+    // from the left and the matching drag d cells in from the right must map
+    // to ratios that sum to 1 (mirror about the centre).
+    for
+      width <- Seq(2, 5, 10, 20, 21)
+      d     <- 0 to (width - 1) / 2
+    do
+      val left  = MouseEvent.Drag(MouseButton.Left, col = 1 + d, row = 3, mods)
+      val right = MouseEvent.Drag(MouseButton.Left, col = 1 + (width - 1 - d), row = 3, mods)
+      val armed = SplitPane.DragState(0.5, dragging = true)
+      val lr    = SplitPane.handleMouse(armed, left, SplitPane.Direction.Horizontal, width, 5, gap = 1).splitRatio
+      val rr    = SplitPane.handleMouse(armed, right, SplitPane.Direction.Horizontal, width, 5, gap = 1).splitRatio
+      assert(math.abs((lr + rr) - 1.0) < 1e-9, s"not symmetric at width=$width d=$d: $lr + $rr")
+  }
+
+  test("far-left/far-right drags reach the symmetric raw endpoints 0.0 and 1.0") {
+    val armed   = SplitPane.DragState(0.5, dragging = true)
+    val width   = 20
+    val leftEv  = MouseEvent.Drag(MouseButton.Left, col = 1, row = 3, mods)             // far left
+    val rightEv = MouseEvent.Drag(MouseButton.Left, col = 1 + width - 1, row = 3, mods) // far right
+    val l       = SplitPane.handleMouse(armed, leftEv, SplitPane.Direction.Horizontal, width, 5, gap = 1).splitRatio
+    val r       = SplitPane.handleMouse(armed, rightEv, SplitPane.Direction.Horizontal, width, 5, gap = 1).splitRatio
+    assert(math.abs(l - 0.0) < 1e-9, s"far-left raw ratio should be 0.0, got $l")
+    assert(math.abs(r - 1.0) < 1e-9, s"far-right raw ratio should be 1.0, got $r")
   }


### PR DESCRIPTION
# DECISIONS — splitpane-drag-symmetry (fixes llm4s/termflow#208)

## Problem
`SplitPane.ratioAt` mapped pointer→ratio asymmetrically. With `at.x = 1` the
old code computed `rel = col - at.x + 1` (range `1..width`) and divided by
`width`, giving a raw ratio range of `[1/width, 1]`. The far-right edge reached
`1.0` but the far-left edge bottomed out at `1/width`, never near `0` — a
half-cell bias that broke symmetry about the centre.

## Change
`modules/termflow-widgets/.../SplitPane.scala`, `ratioAt`:
- Dropped the `+1`: `rel = col - at.x.value` (range `0..width-1`).
- Divided by `denom = max(1, span - 1)` instead of `span`.

Result: first/last cells map to exactly `0.0` / `1.0`, so the reachable raw
ratio is a symmetric `[0, 1]` about `0.5` before `clampRatio`. Applied the same
correction to the `Vertical` branch (using `row`/`height`).

### Why `width - 1`, not just dropping `+1`
The issue offered "drop the `+1` **and/or** divide by `width - 1`". Dropping
`+1` alone (still `/width`) yields `[0, (width-1)/width]` — reaches `0` but not
`1`, still asymmetric. Only `/(width-1)` puts both endpoints symmetric, which is
the stated goal. Guarded `denom`/`span-1` with `max(1, …)` so `width == 1`
(single-cell region) can't divide by zero.

## Tests
- Updated three existing drag magic-number assertions that encoded the old
  `/width` mapping (Drag `col=15`→`14/19`, Release `col=5`→`4/19`, Vertical
  `row=8`→`7/15`). These had to change — they asserted the buggy mapping by
  construction; no symmetric denominator keeps `col/width` values like `0.75`.
- Added two regressions: (a) for several widths, drags `d` cells from each end
  produce ratios summing to `1.0` (mirror about `0.5`); (b) far-left/far-right
  drags hit the exact raw endpoints `0.0` / `1.0`.
- Layout tests and the sample showcase spec are untouched and green.

## Risk
Low. Behaviour change is confined to drag-resize ratio; `clampRatio`
(`MinSizeRatio = 0.05`) still bounds the committed ratio, and layout math is
unchanged. The only observable difference is that mid-drag ratios shift
slightly (denominator `width-1` vs `width`) and the divider now reaches both
extremes evenly.
