### PR TITLE
Widget display width

### DIFF
--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/ListView.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/ListView.scala
@@ -181,8 +181,10 @@ object ListView:
       else
         val isSelected = itemIdx == state.selected
         val content    = render(state.items(itemIdx))
-        val truncated  = content.take(width - 2)
-        val padded     = truncated.padTo(width - 2, ' ')
+        // Truncate/pad by display cells (not UTF-16 units) so CJK/emoji rows
+        // align to the column grid and `.take` never splits a surrogate pair
+        // or a wide glyph at the truncation boundary.
+        val padded     = fitToCells(content, width - 2)
         val showCursor = isSelected && focused
         val prefix     = if showCursor then "▸ " else "  "
         val style =
@@ -199,3 +201,25 @@ object ListView:
 
   /** Width of a rendered list with the given `lineWidth`. Mirrors [[view]]. */
   def width(lineWidth: Int): Int = math.max(3, lineWidth)
+
+  /** Longest prefix of `s` whose display width is at most `maxCells`. */
+  private def clipToCells(s: String, maxCells: Int): String =
+    if maxCells <= 0 then ""
+    else
+      val sb = new StringBuilder
+      var w  = 0
+      var i  = 0
+      while i < s.length do
+        val cp = s.codePointAt(i)
+        val cw = math.max(0, WCWidth.codePointWidth(cp))
+        if w + cw > maxCells then return sb.toString
+        sb.append(s.substring(i, i + java.lang.Character.charCount(cp)))
+        w += cw
+        i += java.lang.Character.charCount(cp)
+      sb.toString
+
+  /** Clip `s` to `cells` display cells, then right-pad with spaces to fill. */
+  private def fitToCells(s: String, cells: Int): String =
+    val clipped = clipToCells(s, cells)
+    val w       = WCWidth.stringWidth(clipped)
+    if w >= cells then clipped else clipped + " " * (cells - w)

--- a/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MenuBar.scala
+++ b/modules/termflow-widgets/src/main/scala/termflow/tui/widgets/MenuBar.scala
@@ -167,7 +167,7 @@ object MenuBar:
           val style =
             if sel then Style(fg = theme.background, bg = theme.primary, bold = true)
             else Style(fg = theme.foreground)
-          val padded = item.padTo(dropdownInnerWidth(menu), ' ')
+          val padded = fitToCells(item, dropdownInnerWidth(menu))
           TextNode(at.x + (left - 1), at.y + (1 + j), List(Text(padded, style)))
         }
         barNode :: itemNodes
@@ -202,35 +202,60 @@ object MenuBar:
         case None => None
 
   /**
-   * Inner cell width of `menu`'s dropdown: the widest item label plus a
+   * Inner cell width of `menu`'s dropdown: the widest item label (measured in
+   * display cells, not UTF-16 length, so CJK/emoji labels align) plus a
    * two-cell padding. `maxOption` guards the empty-items case — an empty
    * menu can still be opened via Enter/Arrow, and `Vector.empty.max` would
    * otherwise throw `UnsupportedOperationException` from both [[apply]] and
    * [[hitTest]].
    */
   private def dropdownInnerWidth(menu: Menu): Int =
-    menu.items.map(_.length).maxOption.getOrElse(0) + 2
+    menu.items.map(WCWidth.stringWidth).maxOption.getOrElse(0) + 2
 
   /**
    * Column offset (1-based, relative to `at.x`) where the title cell
-   *  for `menuIdx` begins. Mirrors the rendering layout.
+   *  for `menuIdx` begins. Mirrors the rendering layout. Title width is
+   *  measured in display cells so a wide-char title doesn't mis-position
+   *  every later dropdown.
    */
   private def titleStartCol(state: State, menuIdx: Int): Int =
     var col = 1
     var i   = 0
     while i < menuIdx do
-      val cellWidth = state.menus(i).title.length + 4 + 1 // "[ X ]" plus separator
+      val cellWidth = WCWidth.stringWidth(state.menus(i).title) + 4 + 1 // "[ X ]" plus separator
       col += cellWidth
       i += 1
     col
 
-  /** Hit-test for the title row. */
+  /** Hit-test for the title row. Title width is measured in display cells. */
   private def hitTestTitles(state: State, baseCol: Int, clickCol: Int): Option[Int] =
     var col = baseCol
     var i   = 0
     while i < state.menus.size do
-      val cellWidth = state.menus(i).title.length + 4
+      val cellWidth = WCWidth.stringWidth(state.menus(i).title) + 4
       if clickCol >= col && clickCol < col + cellWidth then return Some(i)
       col += cellWidth + 1 // + separator
       i += 1
     None
+
+  /** Longest prefix of `s` whose display width is at most `maxCells`. */
+  private def clipToCells(s: String, maxCells: Int): String =
+    if maxCells <= 0 then ""
+    else
+      val sb = new StringBuilder
+      var w  = 0
+      var i  = 0
+      while i < s.length do
+        val cp = s.codePointAt(i)
+        val cw = math.max(0, WCWidth.codePointWidth(cp))
+        if w + cw > maxCells then return sb.toString
+        sb.append(s.substring(i, i + java.lang.Character.charCount(cp)))
+        w += cw
+        i += java.lang.Character.charCount(cp)
+      sb.toString
+
+  /** Clip `s` to `cells` display cells, then right-pad with spaces to fill. */
+  private def fitToCells(s: String, cells: Int): String =
+    val clipped = clipToCells(s, cells)
+    val w       = WCWidth.stringWidth(clipped)
+    if w >= cells then clipped else clipped + " " * (cells - w)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/ListViewSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/ListViewSpec.scala
@@ -196,6 +196,48 @@ class ListViewSpec extends AnyFunSuite:
     // "  " prefix (unfocused, no cursor) + 6 chars of truncated content.
     assert(cs(0).mkString == "  this-i")
 
+  // Reconstruct a row's logical content from the cell grid by concatenating
+  // each visible cell's glyph and skipping the width-0 filler the renderer
+  // inserts after a wide glyph. This recovers exactly what the widget emitted,
+  // so we can measure display width and detect split surrogates / glyphs.
+  private def rowContent(v: VNode, width: Int, row: Int): String =
+    val frame = AnsiRenderer.buildFrame(RootNode(width, row + 1, List(v), None))
+    val sb    = new StringBuilder
+    (0 until width).foreach { c =>
+      val cell = frame.cells(row)(c)
+      if cell.width > 0 then sb.append(cell.renderedGlyph)
+    }
+    sb.toString
+
+  test("renders wide (CJK) rows aligned by display width, not char count"):
+    // lineWidth 8 ⇒ content area is 6 cells. Three 2-cell glyphs fill it exactly.
+    val s   = ListView.State.of(Vector("中文字"), visibleRows = 1)
+    val v   = ListView.view(s, lineWidth = 8, focused = false, render = (x: String) => x)
+    val row = rowContent(v, 8, 0)
+    assert(row == "  中文字", s"got [$row]")
+    assert(WCWidth.stringWidth(row) == 8, s"width ${WCWidth.stringWidth(row)} for [$row]")
+
+  test("truncates wide content on a glyph boundary, never splitting a wide glyph"):
+    // Content area is 7 - 2 = 5 cells (odd). A run of 2-cell glyphs can only
+    // fill 4 cells; the boundary must land between glyphs, padded to width.
+    // The old `take(5)` kept all three glyphs (6 display cells) and overflowed.
+    val s   = ListView.State.of(Vector("中文字"), visibleRows = 1)
+    val v   = ListView.view(s, lineWidth = 7, focused = false, render = (x: String) => x)
+    val row = rowContent(v, 7, 0)
+    // "  " prefix + "中文" (4 cells) + one space pad = 7 cells, no half glyph.
+    assert(row == "  中文 ", s"got [$row]")
+    assert(WCWidth.stringWidth(row) == 7)
+
+  test("truncates emoji (surrogate pairs) without splitting a surrogate"):
+    // The old `take(5)` on "🎉🎉🎉" (6 UTF-16 units) would slice through the
+    // third emoji's surrogate pair, leaving a lone half.
+    val s   = ListView.State.of(Vector("🎉🎉🎉"), visibleRows = 1)
+    val v   = ListView.view(s, lineWidth = 7, focused = false, render = (x: String) => x)
+    val row = rowContent(v, 7, 0)
+    assert(row == "  🎉🎉 ", s"got [$row]")
+    assert(WCWidth.stringWidth(row) == 7, s"width ${WCWidth.stringWidth(row)} for [$row]")
+    assert(row.count(_.isSurrogate) % 2 == 0, "no lone surrogate half")
+
   test("width helper reports >= 3 regardless of input"):
     assert(ListView.width(30) == 30)
     assert(ListView.width(2) == 3)

--- a/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MenuBarSpec.scala
+++ b/modules/termflow-widgets/src/test/scala/termflow/tui/widgets/MenuBarSpec.scala
@@ -119,6 +119,44 @@ class MenuBarSpec extends AnyFunSuite:
     assert(MenuBar.hitTest(sample, at, col = 1, row = 99).isEmpty)
   }
 
+  // ---- wide-char (CJK/emoji) display-width handling -----------------------
+
+  private val wide = MenuBar.State(
+    menus = Vector(
+      MenuBar.Menu("文件", Vector("打开", "Save")), // title 4 cells; items 4 / 4 cells
+      MenuBar.Menu("Edit", Vector("Cut"))
+    )
+  )
+
+  test("dropdown rows pad to display width, not char count") {
+    val opened = wide.copy(openIdx = Some(0), cursor = 0)
+    val nodes  = MenuBar(opened)
+    // First node is the title row; the rest are the dropdown item rows.
+    val itemTexts = nodes.tail.collect { case TextNode(_, _, runs) => runs.head.txt }
+    // innerWidth = max(width("打开")=4, width("Save")=4) + 2 = 6 cells.
+    assert(itemTexts == List("打开  ", "Save  "), s"got $itemTexts")
+    itemTexts.foreach(t => assert(WCWidth.stringWidth(t) == 6, s"width ${WCWidth.stringWidth(t)} for [$t]"))
+  }
+
+  test("a wide-char title positions the next menu by display cells in hitTest") {
+    val at = Coord(1.x, 1.y)
+    // "文件" is 4 cells, cell = 4 + 4 padding = 8, occupying cols 1..8.
+    assert(MenuBar.hitTest(wide, at, col = 1, row = 1) == Some(Left(0)))
+    assert(MenuBar.hitTest(wide, at, col = 8, row = 1) == Some(Left(0)))
+    // Separator at col 9; "Edit" cell starts at col 1 + 8 + 1 = 10.
+    assert(MenuBar.hitTest(wide, at, col = 9, row = 1).isEmpty)
+    assert(MenuBar.hitTest(wide, at, col = 10, row = 1) == Some(Left(1)))
+  }
+
+  test("a wide-char title aligns the dropdown under the correct menu") {
+    val at     = Coord(1.x, 1.y)
+    val opened = wide.copy(openIdx = Some(1)) // open "Edit"
+    // Edit's dropdown left edge mirrors its title start (col 10).
+    assert(MenuBar.hitTest(opened, at, col = 10, row = 2) == Some(Right(0)))
+    // Just left of the dropdown is outside it.
+    assert(MenuBar.hitTest(opened, at, col = 9, row = 2).isEmpty)
+  }
+
   test("an opened empty-items menu does not crash apply / hitTest") {
     // Regression: `menu.items.map(_.length).max` threw on empty items once
     // such a menu was opened.


### PR DESCRIPTION
# DECISIONS — widget-display-width (#206)

Follow-up to #205. Converted the last two widgets that still sized text by UTF-16
`String.length` to measure by display cells (`WCWidth`).

## Changes

### MenuBar.scala
- `dropdownInnerWidth`: `_.length` → `WCWidth.stringWidth` (widest item by cells).
- dropdown rows: `item.padTo(innerWidth, ' ')` → `fitToCells(item, innerWidth)`
  (cell-aware clip + pad; ASCII unchanged).
- `titleStartCol` / `hitTestTitles`: `title.length + 4` → `WCWidth.stringWidth(title) + 4`.
  The `+4` (2-cell opener + 2-cell closer, same for `[ X ]` and `  X  `) is unchanged;
  only the title measurement moved to cells, so a wide-char title no longer
  mis-positions later dropdowns or mislands title hit-testing.

### ListView.scala
- `view`: `content.take(width-2).padTo(width-2, ' ')` → `fitToCells(content, width-2)`.
  Old `.take` could slice a surrogate pair / wide glyph at the boundary and could
  overflow the row (UTF-16 count < display cells for wide content).

## Key decision: helpers duplicated, not centralised
The #205 `clipToCells` / `fitToCells` are **private to `Table`**, and #205 itself
already duplicated the same logic privately into `TextField` and `MultiLineInput`
(`clipToWidth`/`padToWidth`). I followed that established per-widget-private pattern
rather than extracting a shared util — keeps this change minimal and consistent with
the codebase as it stands. The copies in MenuBar/ListView are byte-identical to
Table's. If a future task wants one home for these, `WCWidth` (termflow-terminal) is
the natural place; that refactor is out of scope here.

## Tests
- `MenuBarSpec`: wide-title (`文件`) hit-testing positions the next menu by cells;
  dropdown rows with a wide item (`打开`) pad to display width; open dropdown aligns
  under the correct menu. (Old `.length` math would have placed Edit at col 6 not 10.)
- `ListViewSpec`: CJK row aligns to the grid; wide content truncates on a glyph
  boundary (odd content width can't fit a half glyph); emoji (surrogate pairs)
  truncate without leaving a lone surrogate half.
- Rendered-cell assertions reconstruct logical content via `RenderCell.renderedGlyph`
  (skipping the width-0 filler the renderer inserts after a wide glyph), since the raw
  `.ch` grid interleaves a space after each 2-cell glyph.
- Full `termflowWidgets/test` green (309 tests).

## Risk
Low. Behaviour identical for pure-ASCII (`stringWidth == length`, `fitToCells` ==
`take`+`padTo`). `WCWidth` width tables (ambiguous-width = 1, curated emoji ranges)
are inherited from #205 and unchanged.
